### PR TITLE
Modify the != operator to return true when at least one channel is different.

### DIFF
--- a/modules/core/src/image/vpRGBa.cpp
+++ b/modules/core/src/image/vpRGBa.cpp
@@ -129,16 +129,7 @@ bool vpRGBa::operator==(const vpRGBa &v)
 */
 bool vpRGBa::operator!=(const vpRGBa &v)
 {
-  if (R == v.R)
-    return false;
-  if (G == v.G)
-    return false;
-  if (B == v.B)
-    return false;
-  if (A == v.A)
-    return false;
-
-  return true ;
+  return (R != v.R || G != v.G || B != v.B || A != v.A);
 }
 
 /*!


### PR DESCRIPTION
Pull request for issue #3.
Modify the != operator to return true when at least one channel is different when comparing two vpRGBa. Before, the != operator returned false when at least one channel is equal.
