### PR TITLE
Add LUT in vpImage.h and saturate function in vpMath.h.

### DIFF
--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -312,6 +312,9 @@ public:
   void sub(const vpImage<Type> &B, vpImage<Type> &C);
   void sub(const vpImage<Type> &A, const vpImage<Type> &B, vpImage<Type> &C);
 
+  // Perform a look-up table transformation
+  void performLut(const Type (&lut)[256]);
+
 private:
   unsigned int npixels ; //<! number of pixel in the image
   unsigned int width ;   //<! number of columns
@@ -1436,6 +1439,51 @@ void vpImage<Type>::sub(const vpImage<Type> &A, const vpImage<Type> &B,
   for (unsigned int i=0;i<A.getWidth()*A.getHeight();i++)
   {
     *(C.bitmap + i) = *(A.bitmap + i) - *(B.bitmap + i) ;
+  }
+}
+
+/*!
+  Modify the intensities of a grayscale image using the look-up table passed in parameter.
+
+  \param lut : Look-up table (unsigned char array of size=256) which maps each intensity to his new value.
+*/
+template<>
+inline void vpImage<unsigned char>::performLut(const unsigned char (&lut)[256]) {
+  unsigned int size = getWidth()*getHeight();
+  unsigned char *ptrStart = (unsigned char*) bitmap;
+  unsigned char *ptrEnd = ptrStart + size;
+  unsigned char *ptrCurrent = ptrStart;
+
+  while(ptrCurrent != ptrEnd) {
+    *ptrCurrent = lut[*ptrCurrent];
+    ++ptrCurrent;
+  }
+}
+
+/*!
+  Modify the intensities of a color image using the look-up table passed in parameter.
+
+  \param lut : Look-up table (vpRGBa array of size=256) which maps each intensity to his new value.
+*/
+template<>
+inline void vpImage<vpRGBa>::performLut(const vpRGBa (&lut)[256]) {
+  unsigned int size = getWidth()*getHeight();
+  unsigned char *ptrStart = (unsigned char*) bitmap;
+  unsigned char *ptrEnd = ptrStart + size*4;
+  unsigned char *ptrCurrent = ptrStart;
+
+  while(ptrCurrent != ptrEnd) {
+    *ptrCurrent = lut[*ptrCurrent].R;
+    ++ptrCurrent;
+
+    *ptrCurrent = lut[*ptrCurrent].G;
+    ++ptrCurrent;
+
+    *ptrCurrent = lut[*ptrCurrent].B;
+    ++ptrCurrent;
+
+    *ptrCurrent = lut[*ptrCurrent].A;
+    ++ptrCurrent;
   }
 }
 

--- a/modules/core/include/visp3/core/vpMath.h
+++ b/modules/core/include/visp3/core/vpMath.h
@@ -54,6 +54,8 @@
 
 #include <math.h>
 #include <limits>
+#include <climits>
+#include <algorithm>
 
 #if defined(VISP_HAVE_FUNC_ISNAN) || defined(VISP_HAVE_FUNC_STD_ISNAN) || defined(VISP_HAVE_FUNC_ISINF) || defined(VISP_HAVE_FUNC_STD_ISINF) || defined(VISP_HAVE_FUNC_STD_ROUND)
 #  include <cmath>
@@ -191,6 +193,15 @@ class VISP_EXPORT vpMath
   static bool isNaN(const double value);
   static bool isInf(const double value);
 
+  template<typename _Tp> static inline _Tp saturate(unsigned char v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(char v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(unsigned short v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(short v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(unsigned v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(int v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(float v) { return _Tp(v); }
+  template<typename _Tp> static inline _Tp saturate(double v) { return _Tp(v); }
+
  private:
   static const double ang_min_sinc;
   static const double ang_min_mc;
@@ -241,7 +252,7 @@ int vpMath::round(const double x)
 #elif defined(VISP_HAVE_FUNC_STD_ROUND)
   return (int)std::round(x)
 #else
-  return (x > 0.0) ? floor(x + 0.5) : ceil(x - 0.5);
+  return (x > 0.0) ? ((int) floor(x + 0.5)) : ((int) ceil(x - 0.5));
 #endif
 }
 
@@ -319,6 +330,137 @@ double vpMath::sigmoid(double x, double x0,double x1, double n)
 	double l1 = 1./(1.+exp(-0.5*n));
 	return (1./(1.+exp(-n*((x-x0)/(x1-x0)-0.5)))-l0)/(l1-l0);
 }
+
+//unsigned char
+template<> inline unsigned char vpMath::saturate<unsigned char>(char v) {
+  return (unsigned char) std::max((int) v, 0);
+}
+
+template<> inline unsigned char vpMath::saturate<unsigned char>(unsigned short v) {
+  return (unsigned char) std::min((unsigned) v, (unsigned) UCHAR_MAX);
+}
+
+template<> inline unsigned char vpMath::saturate<unsigned char>(int v) {
+  return (unsigned char) ((unsigned) v <= UCHAR_MAX ? v : v > 0 ? UCHAR_MAX : 0);
+}
+
+template<> inline unsigned char vpMath::saturate<unsigned char>(short v) {
+  return saturate<unsigned char> ((int) v);
+}
+
+template<> inline unsigned char vpMath::saturate<unsigned char>(unsigned v) {
+  return (unsigned char) std::min(v, (unsigned) UCHAR_MAX);
+}
+
+template<> inline unsigned char vpMath::saturate<unsigned char>(float v) {
+  int iv = vpMath::round(v);
+  return saturate<unsigned char> (iv);
+}
+
+template<> inline unsigned char vpMath::saturate<unsigned char>(double v) {
+  int iv = vpMath::round(v);
+  return saturate<unsigned char> (iv);
+}
+
+//char
+template<> inline char vpMath::saturate<char>(unsigned char v) {
+  return (char) std::min((int) v, SCHAR_MAX);
+}
+
+template<> inline char vpMath::saturate<char>(unsigned short v) {
+  return (char) std::min((unsigned) v, (unsigned) SCHAR_MAX);
+}
+
+template<> inline char vpMath::saturate<char>(int v) {
+  return (char) ((unsigned) (v - SCHAR_MIN) <= (unsigned) UCHAR_MAX ? v :
+                 v > 0 ? SCHAR_MAX : SCHAR_MIN);
+}
+
+template<> inline char vpMath::saturate<char>(short v) {
+  return saturate<char>((int) v);
+}
+
+template<> inline char vpMath::saturate<char>(unsigned v) {
+  return (char) std::min(v, (unsigned) SCHAR_MAX);
+}
+
+template<> inline char vpMath::saturate<char>(float v) {
+  int iv = vpMath::round(v);
+  return saturate<char>(iv);
+}
+
+template<> inline char vpMath::saturate<char>(double v) {
+  int iv = vpMath::round(v);
+  return saturate<char>(iv);
+}
+
+//unsigned short
+template<> inline unsigned short vpMath::saturate<unsigned short>(char v) {
+  return (unsigned short) std::max((int) v, 0);
+}
+
+template<> inline unsigned short vpMath::saturate<unsigned short>(short v) {
+  return (unsigned short) std::max((int) v, 0);
+}
+
+template<> inline unsigned short vpMath::saturate<unsigned short>(int v) {
+  return (unsigned short) ((unsigned) v <= (unsigned) USHRT_MAX ? v :
+                           v > 0 ? USHRT_MAX : 0);
+}
+
+template<> inline unsigned short vpMath::saturate<unsigned short>(unsigned v) {
+  return (unsigned short) std::min(v, (unsigned) USHRT_MAX);
+}
+
+template<> inline unsigned short vpMath::saturate<unsigned short>(float v) {
+  int iv = vpMath::round(v);
+  return vpMath::saturate<unsigned short>(iv);
+}
+
+template<> inline unsigned short vpMath::saturate<unsigned short>(double v) {
+  int iv = vpMath::round(v);
+  return vpMath::saturate<unsigned short>(iv);
+}
+
+//short
+template<> inline short vpMath::saturate<short>(unsigned short v) {
+  return (short) std::min((int) v, SHRT_MAX);
+}
+template<> inline short vpMath::saturate<short>(int v) {
+  return (short) ((unsigned) (v - SHRT_MIN) <= (unsigned) USHRT_MAX ? v :
+                  v > 0 ? SHRT_MAX : SHRT_MIN);
+}
+template<> inline short vpMath::saturate<short>(unsigned v) {
+  return (short) std::min(v, (unsigned) SHRT_MAX);
+}
+template<> inline short vpMath::saturate<short>(float v) {
+  int iv = vpMath::round(v);
+  return vpMath::saturate<short>(iv);
+}
+template<> inline short vpMath::saturate<short>(double v) {
+  int iv = vpMath::round(v);
+  return vpMath::saturate<short>(iv);
+}
+
+//int
+template<> inline int vpMath::saturate<int>(float v) {
+  return vpMath::round(v);
+}
+
+template<> inline int vpMath::saturate<int>(double v) {
+  return vpMath::round(v);
+}
+
+//unsigned int
+// (Comment from OpenCV) we intentionally do not clip negative numbers, to make -1 become 0xffffffff etc.
+template<> inline unsigned vpMath::saturate<unsigned>(float v) {
+  return (unsigned) vpMath::round(v);
+}
+
+template<> inline unsigned vpMath::saturate<unsigned>(double v) {
+  return (unsigned) vpMath::round(v);
+}
+
 
 #endif
 

--- a/modules/core/include/visp3/core/vpMath.h
+++ b/modules/core/include/visp3/core/vpMath.h
@@ -337,19 +337,19 @@ template<> inline unsigned char vpMath::saturate<unsigned char>(char v) {
 }
 
 template<> inline unsigned char vpMath::saturate<unsigned char>(unsigned short v) {
-  return (unsigned char) std::min((unsigned) v, (unsigned) UCHAR_MAX);
+  return (unsigned char) std::min((unsigned int) v, (unsigned int) UCHAR_MAX);
 }
 
 template<> inline unsigned char vpMath::saturate<unsigned char>(int v) {
-  return (unsigned char) ((unsigned) v <= UCHAR_MAX ? v : v > 0 ? UCHAR_MAX : 0);
+  return (unsigned char) ((unsigned int) v <= UCHAR_MAX ? v : v > 0 ? UCHAR_MAX : 0);
 }
 
 template<> inline unsigned char vpMath::saturate<unsigned char>(short v) {
   return saturate<unsigned char> ((int) v);
 }
 
-template<> inline unsigned char vpMath::saturate<unsigned char>(unsigned v) {
-  return (unsigned char) std::min(v, (unsigned) UCHAR_MAX);
+template<> inline unsigned char vpMath::saturate<unsigned char>(unsigned int v) {
+  return (unsigned char) std::min(v, (unsigned int) UCHAR_MAX);
 }
 
 template<> inline unsigned char vpMath::saturate<unsigned char>(float v) {
@@ -368,11 +368,11 @@ template<> inline char vpMath::saturate<char>(unsigned char v) {
 }
 
 template<> inline char vpMath::saturate<char>(unsigned short v) {
-  return (char) std::min((unsigned) v, (unsigned) SCHAR_MAX);
+  return (char) std::min((unsigned int) v, (unsigned int) SCHAR_MAX);
 }
 
 template<> inline char vpMath::saturate<char>(int v) {
-  return (char) ((unsigned) (v - SCHAR_MIN) <= (unsigned) UCHAR_MAX ? v :
+  return (char) ((unsigned int) (v - SCHAR_MIN) <= (unsigned int) UCHAR_MAX ? v :
                  v > 0 ? SCHAR_MAX : SCHAR_MIN);
 }
 
@@ -380,8 +380,8 @@ template<> inline char vpMath::saturate<char>(short v) {
   return saturate<char>((int) v);
 }
 
-template<> inline char vpMath::saturate<char>(unsigned v) {
-  return (char) std::min(v, (unsigned) SCHAR_MAX);
+template<> inline char vpMath::saturate<char>(unsigned int v) {
+  return (char) std::min(v, (unsigned int) SCHAR_MAX);
 }
 
 template<> inline char vpMath::saturate<char>(float v) {
@@ -404,12 +404,12 @@ template<> inline unsigned short vpMath::saturate<unsigned short>(short v) {
 }
 
 template<> inline unsigned short vpMath::saturate<unsigned short>(int v) {
-  return (unsigned short) ((unsigned) v <= (unsigned) USHRT_MAX ? v :
+  return (unsigned short) ((unsigned int) v <= (unsigned int) USHRT_MAX ? v :
                            v > 0 ? USHRT_MAX : 0);
 }
 
-template<> inline unsigned short vpMath::saturate<unsigned short>(unsigned v) {
-  return (unsigned short) std::min(v, (unsigned) USHRT_MAX);
+template<> inline unsigned short vpMath::saturate<unsigned short>(unsigned int v) {
+  return (unsigned short) std::min(v, (unsigned int) USHRT_MAX);
 }
 
 template<> inline unsigned short vpMath::saturate<unsigned short>(float v) {
@@ -427,11 +427,11 @@ template<> inline short vpMath::saturate<short>(unsigned short v) {
   return (short) std::min((int) v, SHRT_MAX);
 }
 template<> inline short vpMath::saturate<short>(int v) {
-  return (short) ((unsigned) (v - SHRT_MIN) <= (unsigned) USHRT_MAX ? v :
+  return (short) ((unsigned int) (v - SHRT_MIN) <= (unsigned int) USHRT_MAX ? v :
                   v > 0 ? SHRT_MAX : SHRT_MIN);
 }
-template<> inline short vpMath::saturate<short>(unsigned v) {
-  return (short) std::min(v, (unsigned) SHRT_MAX);
+template<> inline short vpMath::saturate<short>(unsigned int v) {
+  return (short) std::min(v, (unsigned int) SHRT_MAX);
 }
 template<> inline short vpMath::saturate<short>(float v) {
   int iv = vpMath::round(v);
@@ -453,12 +453,12 @@ template<> inline int vpMath::saturate<int>(double v) {
 
 //unsigned int
 // (Comment from OpenCV) we intentionally do not clip negative numbers, to make -1 become 0xffffffff etc.
-template<> inline unsigned vpMath::saturate<unsigned>(float v) {
-  return (unsigned) vpMath::round(v);
+template<> inline unsigned int vpMath::saturate<unsigned int>(float v) {
+  return (unsigned int) vpMath::round(v);
 }
 
-template<> inline unsigned vpMath::saturate<unsigned>(double v) {
-  return (unsigned) vpMath::round(v);
+template<> inline unsigned int vpMath::saturate<unsigned int>(double v) {
+  return (unsigned int) vpMath::round(v);
 }
 
 

--- a/modules/core/test/math/testMath.cpp
+++ b/modules/core/test/math/testMath.cpp
@@ -184,7 +184,293 @@ int main() {
   }
   std::cout << "vpMath::round is Ok !" << std::endl;
 
-  std::cout << "OK !" << std::endl;
 
+  //Test saturate functions
+  //unsigned char
+  char char_value = -127;
+  unsigned char uchar_value = vpMath::saturate<unsigned char>(char_value);
+  if(uchar_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(-127)=" << uchar_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  unsigned short ushort_value = 60000;
+  uchar_value = vpMath::saturate<unsigned char>(ushort_value);
+  if(uchar_value != UCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(60000)=" << uchar_value << " / should be " << UCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  int int_value = 70000;
+  uchar_value = vpMath::saturate<unsigned char>(int_value);
+  if(uchar_value != UCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(70000)=" << uchar_value << " / should be " << UCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  int_value = -70000;
+  uchar_value = vpMath::saturate<unsigned char>(int_value);
+  if(uchar_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(-70000)=" << uchar_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  short short_value = 30000;
+  uchar_value = vpMath::saturate<unsigned char>(short_value);
+  if(uchar_value != UCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(30000)=" << uchar_value << " / should be " << UCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  short_value = -30000;
+  uchar_value = vpMath::saturate<unsigned char>(short_value);
+  if(uchar_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(-30000)=" << uchar_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  unsigned int uint_value = 10000;
+  uchar_value = vpMath::saturate<unsigned char>(uint_value);
+  if(uchar_value != UCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(10000)=" << uchar_value << " / should be " << UCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  float float_value = 10000.1f;
+  uchar_value = vpMath::saturate<unsigned char>(float_value);
+  if(uchar_value != UCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(10000.1f)=" << uchar_value << " / should be " << UCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = -10000.1f;
+  uchar_value = vpMath::saturate<unsigned char>(float_value);
+  if(uchar_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(-10000.1f)=" << uchar_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  double double_value = 10000.1;
+  uchar_value = vpMath::saturate<unsigned char>(double_value);
+  if(uchar_value != UCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(10000.0)=" << uchar_value << " / should be " << UCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  double_value = -10000.1;
+  uchar_value = vpMath::saturate<unsigned char>(double_value);
+  if(uchar_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned char>(-10000.0)=" << uchar_value << " / should be 0" << std::endl;
+    return -1;
+  }
+  std::cout << "vpMath::saturate<unsigned char>() is Ok !" << std::endl;
+
+
+  //char
+  uchar_value = 255;
+  char_value = vpMath::saturate<char>(uchar_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(255)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  ushort_value = 60000;
+  char_value = vpMath::saturate<char>(ushort_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(60000)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  int_value = 70000;
+  char_value = vpMath::saturate<char>(int_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(70000)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  int_value = -70000;
+  char_value = vpMath::saturate<char>(int_value);
+  if(char_value != SCHAR_MIN) {
+    std::cerr << "Fail: vpMath::saturate<char>(-70000)=" << char_value << " / should be " << SCHAR_MIN << std::endl;
+    return -1;
+  }
+
+  short_value = 30000;
+  char_value = vpMath::saturate<char>(short_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(30000)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  short_value = -30000;
+  char_value = vpMath::saturate<char>(short_value);
+  if(char_value != SCHAR_MIN) {
+    std::cerr << "Fail: vpMath::saturate<char>(-30000)=" << char_value << " / should be " << SCHAR_MIN << std::endl;
+    return -1;
+  }
+
+  uint_value = 10000;
+  char_value = vpMath::saturate<char>(uint_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(10000)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = 10000.1f;
+  char_value = vpMath::saturate<char>(float_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(10000.1f)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = -10000.1f;
+  char_value = vpMath::saturate<char>(float_value);
+  if(char_value != SCHAR_MIN) {
+    std::cerr << "Fail: vpMath::saturate<char>(-10000.1f)=" << char_value << " / should be " << SCHAR_MIN << std::endl;
+    return -1;
+  }
+
+  double_value = 10000.1;
+  char_value = vpMath::saturate<char>(double_value);
+  if(char_value != SCHAR_MAX) {
+    std::cerr << "Fail: vpMath::saturate<char>(10000.1)=" << char_value << " / should be " << SCHAR_MAX << std::endl;
+    return -1;
+  }
+
+  double_value = -10000.1;
+  char_value = vpMath::saturate<char>(double_value);
+  if(char_value != SCHAR_MIN) {
+    std::cerr << "Fail: vpMath::saturate<char>(-10000.1)=" << char_value << " / should be " << SCHAR_MIN << std::endl;
+    return -1;
+  }
+  std::cout << "vpMath::saturate<char>() is Ok !" << std::endl;
+
+
+  //unsigned short
+  char_value = -127;
+  ushort_value = vpMath::saturate<unsigned short>(char_value);
+  if(ushort_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(127)=" << ushort_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  short_value = -30000;
+  ushort_value = vpMath::saturate<unsigned short>(short_value);
+  if(ushort_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(-30000)=" << ushort_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  int_value = 70000;
+  ushort_value = vpMath::saturate<unsigned short>(int_value);
+  if(ushort_value != USHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(70000)=" << ushort_value << " / should be " << USHRT_MAX << std::endl;
+    return -1;
+  }
+
+  int_value = -70000;
+  ushort_value = vpMath::saturate<unsigned short>(int_value);
+  if(ushort_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(-70000)=" << ushort_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  uint_value = 70000;
+  ushort_value = vpMath::saturate<unsigned short>(uint_value);
+  if(ushort_value != USHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(70000)=" << ushort_value << " / should be " << USHRT_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = 70000.1f;
+  ushort_value = vpMath::saturate<unsigned short>(float_value);
+  if(ushort_value != USHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(70000.1f)=" << ushort_value << " / should be " << USHRT_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = -10000.1f;
+  ushort_value = vpMath::saturate<unsigned short>(float_value);
+  if(ushort_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(-10000.1f)=" << ushort_value << " / should be 0" << std::endl;
+    return -1;
+  }
+
+  double_value = 70000.1;
+  ushort_value = vpMath::saturate<unsigned short>(double_value);
+  if(ushort_value != USHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(70000.1)=" << ushort_value << " / should be " << USHRT_MAX << std::endl;
+    return -1;
+  }
+
+  double_value = -10000.1;
+  ushort_value = vpMath::saturate<unsigned short>(double_value);
+  if(ushort_value != 0) {
+    std::cerr << "Fail: vpMath::saturate<unsigned short>(-10000.1)=" << ushort_value << " / should be 0" << std::endl;
+    return -1;
+  }
+  std::cout << "vpMath::saturate<unsigned short>() is Ok !" << std::endl;
+
+
+  //short
+  ushort_value = 60000;
+  short_value = vpMath::saturate<short>(ushort_value);
+  if(short_value != SHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<short>(60000)=" << short_value << " / should be " << SHRT_MAX << std::endl;
+    return -1;
+  }
+
+  int_value = 70000;
+  short_value = vpMath::saturate<short>(int_value);
+  if(short_value != SHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<short>(70000)=" << short_value << " / should be " << SHRT_MAX << std::endl;
+    return -1;
+  }
+
+  int_value = -70000;
+  short_value = vpMath::saturate<short>(int_value);
+  if(short_value != SHRT_MIN) {
+    std::cerr << "Fail: vpMath::saturate<short>(-70000)=" << short_value << " / should be " << SHRT_MIN << std::endl;
+    return -1;
+  }
+
+  uint_value = 70000;
+  short_value = vpMath::saturate<short>(uint_value);
+  if(short_value != SHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<short>(70000)=" << short_value << " / should be " << SHRT_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = 70000.1f;
+  short_value = vpMath::saturate<short>(float_value);
+  if(short_value != SHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<short>(70000.1f)=" << short_value << " / should be " << SHRT_MAX << std::endl;
+    return -1;
+  }
+
+  float_value = -70000.1f;
+  short_value = vpMath::saturate<short>(float_value);
+  if(short_value != SHRT_MIN) {
+    std::cerr << "Fail: vpMath::saturate<short>(-70000.1f)=" << short_value << " / should be " << SHRT_MIN << std::endl;
+    return -1;
+  }
+
+  double_value = 70000.1;
+  short_value = vpMath::saturate<short>(double_value);
+  if(short_value != SHRT_MAX) {
+    std::cerr << "Fail: vpMath::saturate<short>(70000.1)=" << short_value << " / should be " << SHRT_MAX << std::endl;
+    return -1;
+  }
+
+  double_value = -70000.1;
+  short_value = vpMath::saturate<short>(double_value);
+  if(short_value != SHRT_MIN) {
+    std::cerr << "Fail: vpMath::saturate<short>(70000.1)=" << short_value << " / should be " << SHRT_MIN << std::endl;
+    return -1;
+  }
+  std::cout << "vpMath::saturate<short>() is Ok !" << std::endl;
+
+
+  std::cout << "OK !" << std::endl;
   return 0;
 }


### PR DESCRIPTION
I would like to add the possibility to modify the pixel values using a look-up table and a saturate function to avoid unwanted numerical overflow with unsigned char operations.

Benchmark iterate vs LUT:
```
I=8192x1856
t_iterate1=37153.7 ms ; t_iterate1/100=371.537 ms
t_iterate2=43461.3 ms ; t_iterate2/100=434.613 ms
t_lut=2308.87 ms ; t_lut/100=23.0887 ms
```
The following code try to benchmark the LUT approach against the iterate approach:
```
#include <visp3/core/vpImage.h>
#include <visp3/core/vpImageIo.h>
#include <visp3/core/vpMath.h>


void iterate_method1(vpImage<vpRGBa> &I, const double alpha, const double beta) {
  unsigned int size = I.getWidth() * I.getHeight();
  unsigned char *ptrStart = (unsigned char*) I.bitmap;
  unsigned char *ptrEnd = ptrStart + size*4;
  unsigned char *ptrCurrent = ptrStart;

  while(ptrCurrent != ptrEnd) {
    *ptrCurrent = vpMath::saturate<unsigned char>((*ptrCurrent) * alpha + beta);
    ++ptrCurrent;
  }
}

void iterate_method2(vpImage<vpRGBa> &I, const double alpha, const double beta) {
  for(unsigned int i = 0; i < I.getHeight(); i++) {
    for(unsigned int j = 0; j < I.getWidth(); j++) {
      I[i][j].R = vpMath::saturate<unsigned char>(I[i][j].R * alpha + beta);
      I[i][j].G = vpMath::saturate<unsigned char>(I[i][j].G * alpha + beta);
      I[i][j].B = vpMath::saturate<unsigned char>(I[i][j].B * alpha + beta);
      I[i][j].A = vpMath::saturate<unsigned char>(I[i][j].A * alpha + beta);
    }
  }
}

void lut_method(vpImage<vpRGBa> &I, const vpRGBa (&lut)[256]) {
  I.performLut(lut);
}


int main() {
  vpImage<vpRGBa> I_iterate1, I_iterate2, I_LUT;
  std::string input_image_filename = "img.jpg";
  vpImageIo::read(I_iterate1, input_image_filename);
  I_iterate2 = I_iterate1;
  I_LUT = I_iterate1;

  //I=1856x8192
  std::cout << "I=" << I_iterate1.getWidth() << "x" << I_iterate1.getHeight() << std::endl;

  double alpha = 1.5, beta = -30.0;
  unsigned int nbIterations = 100;

  //Iterate method 1
  double t_iterate1 = vpTime::measureTimeMs();
  for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
    iterate_method1(I_iterate1, alpha, beta);
  }
  t_iterate1 = vpTime::measureTimeMs() - t_iterate1;
  std::cout << "t_iterate1=" << t_iterate1 << " ms ; t_iterate1/" << nbIterations << "="
      << (t_iterate1/nbIterations) << " ms" << std::endl;

  vpImageIo::write(I_iterate1, "img_iterate1.png");


  //Iterate method 2
  double t_iterate2 = vpTime::measureTimeMs();
  for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
    iterate_method2(I_iterate2, alpha, beta);
  }
  t_iterate2 = vpTime::measureTimeMs() - t_iterate2;
  std::cout << "t_iterate2=" << t_iterate2 << " ms ; t_iterate2/" << nbIterations << "="
      << (t_iterate2/nbIterations) << " ms" << std::endl;

  vpImageIo::write(I_iterate2, "img_iterate2.png");


  //LUT method
  double t_lut = vpTime::measureTimeMs();
  for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
    //Construct the LUT
    vpRGBa lut[256];
    for(unsigned int i = 0; i < 256; i++) {
      lut[i].R = vpMath::saturate<unsigned char>(alpha * i + beta);
      lut[i].G = vpMath::saturate<unsigned char>(alpha * i + beta);
      lut[i].B = vpMath::saturate<unsigned char>(alpha * i + beta);
      lut[i].A = vpMath::saturate<unsigned char>(alpha * i + beta);
    }

    lut_method(I_LUT, lut);
  }
  t_lut = vpTime::measureTimeMs() - t_lut;
  std::cout << "t_lut=" << t_lut << " ms ; t_lut/" << nbIterations << "="
      << (t_lut/nbIterations) << " ms" << std::endl;

  vpImageIo::write(I_LUT, "img_LUT.png");
}
```