### PR TITLE
Compute histogram on nbins + display function.

### DIFF
--- a/modules/core/include/visp3/core/vpHistogram.h
+++ b/modules/core/include/visp3/core/vpHistogram.h
@@ -1,7 +1,5 @@
 /****************************************************************************
  *
- * $Id$
- *
  * This file is part of the ViSP software.
  * Copyright (C) 2005 - 2014 by INRIA. All rights reserved.
  * 
@@ -51,9 +49,12 @@
 #ifndef vpHistogram_h
 #define vpHistogram_h
 
+#include <sstream>
+
 #include <visp3/core/vpImage.h>
 #include <visp3/core/vpHistogramPeak.h>
 #include <visp3/core/vpHistogramValey.h>
+#include <visp3/core/vpColor.h>
 
 #ifdef VISP_BUILD_DEPRECATED_FUNCTIONS
 #  include <visp3/core/vpList.h>
@@ -143,10 +144,15 @@ public:
 
   */
   inline unsigned operator[](const unsigned char level) const
-    {
+  {
+    if (level < size) {
       return histogram[level];
+    }
 
-    };
+    std::stringstream ss;
+    ss << "Level is > to size (" << size << ") !";
+    throw vpException(vpException::dimensionError, ss.str().c_str());
+  };
   /*!
 
     Return the number of pixels having the gray \e level.
@@ -168,9 +174,15 @@ public:
 
   */
   inline unsigned operator()(const unsigned char level) const
-    {
+  {
+    if(level < size) {
       return histogram[level];
-    };
+    }
+
+    std::stringstream ss;
+    ss << "Level is > to size (" << size << ") !";
+    throw vpException(vpException::dimensionError, ss.str().c_str());
+  };
   /*!
 
     Return the number of pixels having the gray \e level.
@@ -192,9 +204,15 @@ public:
 
   */
   inline unsigned get(const unsigned char level) const
-    {
+  {
+    if(level < size) {
       return histogram[level];
-    };
+    }
+
+    std::stringstream ss;
+    ss << "Level is > to size (" << size << ") !";
+    throw vpException(vpException::dimensionError, ss.str().c_str());
+  };
 
   /*!
 
@@ -214,11 +232,21 @@ public:
 
   */
   inline void set(const unsigned char level, unsigned int value)
-    {
+  {
+    if(level < size) {
       histogram[level] = value;
-    };
+    } else {
+      std::stringstream ss;
+      ss << "Level is > to size (" << size << ") !";
+      throw vpException(vpException::dimensionError, ss.str().c_str());
+    }
+  };
 
-  void     calculate(const vpImage<unsigned char> &I);
+  void     calculate(const vpImage<unsigned char> &I, const unsigned int nbins=256);
+
+  void     display(const vpImage<unsigned char> &I, const vpColor &color=vpColor::white, const unsigned int thickness=2,
+                   const unsigned int maxValue_=0);
+
   void     smooth(const unsigned int fsize = 3);
   unsigned getPeaks(std::list<vpHistogramPeak> & peaks);
   unsigned getPeaks(unsigned char dist, 
@@ -249,7 +277,7 @@ public:
 
     \sa getValues()
   */
-  inline unsigned getSize()
+  inline unsigned getSize() const
     { 
       return size; 
     };

--- a/modules/core/src/tools/histogram/vpHistogram.cpp
+++ b/modules/core/src/tools/histogram/vpHistogram.cpp
@@ -1,7 +1,5 @@
 /****************************************************************************
  *
- * $Id$
- *
  * This file is part of the ViSP software.
  * Copyright (C) 2005 - 2014 by INRIA. All rights reserved.
  * 
@@ -48,8 +46,11 @@
 
 */
 
-#include <visp3/core/vpHistogram.h>
 #include <stdlib.h>
+#include <visp3/core/vpHistogram.h>
+#include <visp3/core/vpImageConvert.h>
+#include <visp3/core/vpDisplayX.h>
+
 
 bool compare_vpHistogramPeak (vpHistogramPeak first, vpHistogramPeak second);
 
@@ -156,16 +157,80 @@ vpHistogram::init(unsigned size_)
   Calculate the histogram from a gray level image.
 
   \param I : Gray level image.
-
+  \param nbins : Number of bins to compute the histogram.
 */
-void vpHistogram::calculate(const vpImage<unsigned char> &I)
+void vpHistogram::calculate(const vpImage<unsigned char> &I, const unsigned int nbins)
 {
+  if(size != nbins) {
+    if (histogram != NULL) {
+      delete [] histogram;
+      histogram = NULL;
+    }
+
+    size = nbins > 256 ? 256 : nbins;
+    if(nbins > 256) {
+      std::cerr << "nbins=" << nbins << " > 256 ; use by default nbins=256" << std::endl;
+    }
+    histogram = new unsigned int[size];
+  }
+
   memset(histogram, 0, size * sizeof(unsigned));
 
-  for (unsigned i=0; i < I.getHeight(); i ++) {
-    for (unsigned j=0; j < I.getWidth(); j ++) {
-      histogram[ I[i][j] ] ++;
+  unsigned int lut[256];
+  for(unsigned int i = 0; i < 256; i++) {
+    lut[i] = (unsigned int) (i * size / 256.0);
+  }
+
+  unsigned int size = I.getWidth()*I.getHeight();
+  unsigned char *ptrStart = (unsigned char*) I.bitmap;
+  unsigned char *ptrEnd = ptrStart + size;
+  unsigned char *ptrCurrent = ptrStart;
+
+  while(ptrCurrent != ptrEnd) {
+    histogram[ lut[ *ptrCurrent ] ] ++;
+    ++ptrCurrent;
+  }
+}
+
+/*!
+  Display the histogram distribution in an image, the minimal image size is 36x36 px.
+
+  \param I : Image with the histogram distribution displayed.
+  \param color : Color used for the display.
+  \param thickness : Thickness of the line.
+  \param maxValue_ : Maximum value in the histogram, if 0 it will be computed from the current histogram.
+  Useful to plot a 3 channels histogram for a RGB image for example to keep a coherent vertical scale between the channels.
+*/
+void vpHistogram::display(const vpImage<unsigned char> &I, const vpColor &color, const unsigned int thickness,
+    const unsigned int maxValue_) {
+  unsigned int width = I.getWidth(), height = I.getHeight();
+  //Minimal width and height are 36 px
+  if(width < 36 || height < 36) {
+    std::cerr << "Image I must have at least width >= 36 && height >= 36 !" << std::endl;
+    return;
+  }
+
+  unsigned int maxValue = maxValue_;
+  if(maxValue == 0) {
+    for(unsigned int i = 0; i < size; i++) {
+      if(histogram[i] > maxValue) {
+        maxValue = histogram[i];
+      }
     }
+  }
+
+  //Keep 12 free pixels at the top
+  unsigned int max_height = height-12;
+  double ratio_height = max_height / (double) maxValue;
+  double ratio_width = (width-1) / (double) (size-1.0);
+
+  for(unsigned int i = 1; i < size; i++) {
+    unsigned int value1 = histogram[i-1];
+    unsigned int value2 = histogram[i];
+
+    vpImagePoint startPt((height-1)-(value1*ratio_height), (i-1)*ratio_width);
+    vpImagePoint endPt((height-1)-(value2*ratio_height), (i*ratio_width));
+    vpDisplay::displayLine(I, startPt, endPt, color, thickness);
   }
 }
 

--- a/modules/core/src/tools/histogram/vpHistogram.cpp
+++ b/modules/core/src/tools/histogram/vpHistogram.cpp
@@ -167,9 +167,9 @@ void vpHistogram::calculate(const vpImage<unsigned char> &I, const unsigned int 
       histogram = NULL;
     }
 
-    size = nbins > 256 ? 256 : nbins;
-    if(nbins > 256) {
-      std::cerr << "nbins=" << nbins << " > 256 ; use by default nbins=256" << std::endl;
+    size = nbins > 256 ? 256 : (nbins > 0 ? nbins : 256);
+    if(nbins > 256 || nbins == 0) {
+      std::cerr << "nbins=" << nbins << " , nbins should be between ]0 ; 256] ; use by default nbins=256" << std::endl;
     }
     histogram = new unsigned int[size];
   }


### PR DESCRIPTION
I would like to improve the vpHistogram class by:
* adding the possibility to compute the histogram on nbins (nbins between ]0 ; 256])
* adding a display function to show the histogram.

Note:
The histogram is computed on grayscale image but it is possible to display a 3 (RGB) channels histogram. You have to compute the histogram on each channel and call the display for each channel. Also, the parameter ```maxValue_``` (in vpHistogram::display) should be used with the maximum value on the 3 histograms to have a coherent vertical scale. 