### PR TITLE
Add possibility to construct a vpImage from array + conversion methods RGB <==> HSV

### DIFF
--- a/modules/core/include/visp3/core/vpImageConvert.h
+++ b/modules/core/include/visp3/core/vpImageConvert.h
@@ -177,7 +177,13 @@ public:
                     vpImage<unsigned char>* pR,
                     vpImage<unsigned char>* pG,
                     vpImage<unsigned char>* pB,
-                    vpImage<unsigned char>* pa = NULL) ;
+                    vpImage<unsigned char>* pa = NULL);
+
+  static void merge(const vpImage<unsigned char> *R,
+                    const vpImage<unsigned char> *G,
+                    const vpImage<unsigned char> *B,
+                    const vpImage<unsigned char> *a,
+                    vpImage<vpRGBa> &RGBa);
 
   /*!
     Converts a yuv pixel value in rgb format.
@@ -300,8 +306,31 @@ public:
   static void MONO16ToRGBa(unsigned char *grey16, unsigned char *rgba,
         unsigned int size);
   
+  static void HSVToRGBa(const double *hue, const double *saturation, const double *value, unsigned char *rgba,
+        const unsigned int size);
+  static void HSVToRGBa(const unsigned char *hue, const unsigned char *saturation, const unsigned char *value,
+        unsigned char *rgba, const unsigned int size);
+  static void RGBaToHSV(const unsigned char *rgba, double *hue, double *saturation, double *value,
+        const unsigned int size);
+  static void RGBaToHSV(const unsigned char *rgba, unsigned char *hue, unsigned char *saturation, unsigned char *value,
+        const unsigned int size);
+
+  static void HSVToRGB(const double *hue, const double *saturation, const double *value, unsigned char *rgb,
+        const unsigned int size);
+  static void HSVToRGB(const unsigned char *hue, const unsigned char *saturation, const unsigned char *value,
+        unsigned char *rgb, const unsigned int size);
+  static void RGBToHSV(const unsigned char *rgb, double *hue, double *saturation, double *value,
+        const unsigned int size);
+  static void RGBToHSV(const unsigned char *rgb, unsigned char *hue, unsigned char *saturation, unsigned char *value,
+        const unsigned int size);
+
 private:
   static void computeYCbCrLUT();
+
+  static void HSV2RGB(const double *hue, const double *saturation, const double *value, unsigned char *rgba,
+        const unsigned int size, const unsigned int step);
+  static void RGB2HSV(const unsigned char *rgb, double *hue, double *saturation, double *value,
+        const unsigned int size, const unsigned int step);
 
 private:
   static bool YCbCrLUTcomputed;

--- a/modules/core/include/visp3/core/vpImageFilter.h
+++ b/modules/core/include/visp3/core/vpImageFilter.h
@@ -397,6 +397,7 @@ public:
   }
 
   static void gaussianBlur(const vpImage<unsigned char> &I, vpImage<double>& GI, unsigned int size=7, double sigma=0., bool normalize=true);
+  static void gaussianBlur(const vpImage<double> &I, vpImage<double>& GI, unsigned int size=7, double sigma=0., bool normalize=true);
   /*!
    Apply a 5x5 Gaussian filter to an image pixel.
 

--- a/modules/core/src/image/vpImageConvert.cpp
+++ b/modules/core/src/image/vpImageConvert.cpp
@@ -48,6 +48,7 @@
 
 
 #include <sstream>
+#include <map>
 
 // image
 #include <visp3/core/vpImageConvert.h>

--- a/modules/core/src/image/vpImageFilter.cpp
+++ b/modules/core/src/image/vpImageFilter.cpp
@@ -339,6 +339,26 @@ void vpImageFilter::gaussianBlur(const vpImage<unsigned char> &I, vpImage<double
 }
 
 /*!
+  Apply a Gaussian blur to a double image.
+  \param I : Input double image.
+  \param GI : Filtered image.
+  \param size : Filter size. This value should be odd.
+  \param sigma : Gaussian standard deviation. If it is equal to zero or negative, it is computed from filter size as sigma = (size-1)/6.
+  \param normalize : Flag indicating whether to normalize the filter coefficients or not.
+
+ */
+void vpImageFilter::gaussianBlur(const vpImage<double> &I, vpImage<double>& GI, unsigned int size, double sigma, bool normalize)
+{
+  double *fg=new double[(size+1)/2] ;
+  vpImageFilter::getGaussianKernel(fg, size, sigma, normalize) ;
+  vpImage<double> GIx ;
+  vpImageFilter::filterX(I, GIx,fg,size);
+  vpImageFilter::filterY(GIx, GI,fg,size);
+  GIx.destroy();
+  delete[] fg;
+}
+
+/*!
   Return the coefficients of a Gaussian filter.
 
   \param filter : Pointer to the filter kernel that should refer to a (size+1)/2 array.

--- a/modules/core/test/image/testConversion.cpp
+++ b/modules/core/test/image/testConversion.cpp
@@ -646,6 +646,7 @@ main(int argc, const char ** argv)
     // Test construction of vpImage from an array with copyData==true
     ////////////////////////////////////
     unsigned char *rgba2 = new unsigned char[size*4];
+    memset(rgba2, 127, size*4);
     vpImage<vpRGBa> I_copyData((vpRGBa *) rgba2, h, w, true);
 
     //Delete the array
@@ -654,7 +655,7 @@ main(int argc, const char ** argv)
       rgba2 = NULL;
     }
 
-    filename =  vpIoTools::createFilePath(opath, "Klimt_copyData.ppm");
+    filename =  vpIoTools::createFilePath(opath, "I_copyData.ppm");
     /* Save the the current image */
     vpImageIo::write(I_copyData, filename);
 

--- a/modules/core/test/image/testConversion.cpp
+++ b/modules/core/test/image/testConversion.cpp
@@ -559,9 +559,94 @@ main(int argc, const char ** argv)
     vpCTRACE << "Write " << filename << std::endl;
     vpImageIo::write(B, filename) ;
     vpCTRACE<< "Convert result in "<<std::endl<< filename << std::endl;
+
+    ////////////////////////////////////
+    // Merge 4 vpImage<unsigned char> (RGBa) to vpImage<vpRGBa>
+    ////////////////////////////////////
+    vpImageConvert::split(Ic, &R, &G, &B, &a);
+    begintime  = vpTime::measureTimeMs();
+    vpImage<vpRGBa> I_merge;
+    for(int i=0; i<1000; i++){
+      vpImageConvert::merge(&R, &G, &B, &a, I_merge);
+    }
+    endtime = vpTime::measureTimeMs();
+
+    std::cout<<"Time for 1000 merge (ms): "<< endtime - begintime <<std::endl;
+
+    filename =  vpIoTools::createFilePath(opath, "Klimt_merge.ppm");
+    /* Save the the current image */
+    vpImageIo::write(I_merge, filename) ;
+
+    ////////////////////////////////////
+    // Convert a vpImage<vpRGBa> in RGB color space to a vpImage<vpRGBa> in HSV color
+    ////////////////////////////////////
+    unsigned int size = Ic.getWidth()*Ic.getHeight();
+    unsigned int w = Ic.getWidth(), h = Ic.getHeight();
+    unsigned char *hue = new unsigned char[size];
+    unsigned char *saturation = new unsigned char[size];
+    unsigned char *value = new unsigned char[size];
+
+    vpImageConvert::RGBaToHSV((unsigned char *) Ic.bitmap, hue, saturation, value, size);
+    vpImage<unsigned char> I_hue(hue, h, w);
+    vpImage<unsigned char> I_saturation(saturation, h, w);
+    vpImage<unsigned char> I_value(value, h, w);
+    vpImage<vpRGBa> I_HSV;
+    vpImageConvert::merge(&I_hue, &I_saturation, &I_value, NULL, I_HSV);
+
+    filename =  vpIoTools::createFilePath(opath, "Klimt_HSV.ppm");
+    /* Save the the current image */
+    vpImageIo::write(I_HSV, filename);
+
+    //Check the conversion RGBa <==> HSV
+    double *hue2 = new double[size];
+    double *saturation2 = new double[size];
+    double *value2 = new double[size];
+    vpImageConvert::RGBaToHSV((unsigned char *) Ic.bitmap, hue2, saturation2, value2, size);
+
+    unsigned char *rgba = new unsigned char[size*4];
+    vpImageConvert::HSVToRGBa(hue2, saturation2, value2, rgba, size);
+
+    if(hue2 != NULL) {
+      delete[] hue2;
+      hue2 = NULL;
+    }
+
+    if(saturation2 != NULL) {
+      delete[] saturation2;
+      saturation2 = NULL;
+    }
+
+    if(value2 != NULL) {
+      delete[] value2;
+      value2 = NULL;
+    }
+
+    vpRGBa *rgba2 = (vpRGBa *) rgba;
+
+    vpImage<vpRGBa> I_HSV2RGBa(rgba2, h, w);
+    filename =  vpIoTools::createFilePath(opath, "Klimt_HSV2RGBa.ppm");
+    /* Save the the current image */
+    vpImageIo::write(I_HSV2RGBa, filename);
+
+    for(unsigned int i = 0; i < Ic.getHeight(); i++) {
+      for(unsigned int j = 0; j < Ic.getWidth(); j++) {
+        if(Ic[i][j].R != I_HSV2RGBa[i][j].R ||
+           Ic[i][j].G != I_HSV2RGBa[i][j].G ||
+           Ic[i][j].B != I_HSV2RGBa[i][j].B) {
+          std::cerr << "Ic[i][j].R=" << static_cast<unsigned>(Ic[i][j].R)
+              << " ; I_HSV2RGBa[i][j].R=" << static_cast<unsigned>(I_HSV2RGBa[i][j].R) << std::endl;
+          std::cerr << "Ic[i][j].G=" << static_cast<unsigned>(Ic[i][j].G)
+              << " ; I_HSV2RGBa[i][j].G=" << static_cast<unsigned>(I_HSV2RGBa[i][j].G) << std::endl;
+          std::cerr << "Ic[i][j].B=" << static_cast<unsigned>(Ic[i][j].B)
+              << " ; I_HSV2RGBa[i][j].B=" << static_cast<unsigned>(I_HSV2RGBa[i][j].B) << std::endl;
+          throw vpException(vpException::fatalError, "Problem with conversion between RGB <==> HSV");
+        }
+      }
+    }
+
     return 0;
   }
-  catch(vpException e) {
+  catch(vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
     return 1;
   }

--- a/modules/core/test/image/testConversion.cpp
+++ b/modules/core/test/image/testConversion.cpp
@@ -621,9 +621,7 @@ main(int argc, const char ** argv)
       value2 = NULL;
     }
 
-    vpRGBa *rgba2 = (vpRGBa *) rgba;
-
-    vpImage<vpRGBa> I_HSV2RGBa(rgba2, h, w);
+    vpImage<vpRGBa> I_HSV2RGBa((vpRGBa *) rgba, h, w);
     filename =  vpIoTools::createFilePath(opath, "Klimt_HSV2RGBa.ppm");
     /* Save the the current image */
     vpImageIo::write(I_HSV2RGBa, filename);
@@ -642,6 +640,26 @@ main(int argc, const char ** argv)
           throw vpException(vpException::fatalError, "Problem with conversion between RGB <==> HSV");
         }
       }
+    }
+
+    ////////////////////////////////////
+    // Test construction of vpImage from an array with copyData==true
+    ////////////////////////////////////
+    unsigned char *rgba2 = new unsigned char[size*4];
+    vpImage<vpRGBa> I_copyData((vpRGBa *) rgba2, h, w, true);
+
+    //Delete the array
+    if(rgba2 != NULL) {
+      delete[] rgba2;
+      rgba2 = NULL;
+    }
+
+    filename =  vpIoTools::createFilePath(opath, "Klimt_copyData.ppm");
+    /* Save the the current image */
+    vpImageIo::write(I_copyData, filename);
+
+    if(I_copyData.getSize() > 0) {
+      I_copyData[0][0].R = 10;
     }
 
     return 0;


### PR DESCRIPTION
I would like to add some modifications in vpImage class as I didn't find a way to construct a vpImage from an array. It could be useful in cases where the image grabbing is done for example by the network or with an external library. The constructor assumes that the image data is stored in a continuous array in memory with the proper order RGBa:
```
unsigned char *rgba = new unsigned char[width*height*4];
vpImage<vpRGBa> I((vpRGBa *) rgba, height, width);
```


I also thought that functions to convert between RGB and HSV colorspace could be useful if ViSP is built without OpenCV.
Image in RGB:
![klimt_merge](https://cloud.githubusercontent.com/assets/8035162/10634937/5bc315e0-77f5-11e5-8b30-fd88d5ec65a6.png)

Image in HSV:
![klimt_hsv](https://cloud.githubusercontent.com/assets/8035162/10634905/08333248-77f5-11e5-94cf-968916aa691f.png)


Finally, I added the function vpImageConvert::merge() in the same way as there is vpImageConvert::split().