### PR TITLE
Fix vpImageTools::binarise() function + test files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
   - cd ${TRAVIS_BUILD_DIR} && { curl -O http://www.irisa.fr/lagadic/visp/download/sequence/ViSP-images-2.10.0.zip ; cd -; }
   - unzip ${TRAVIS_BUILD_DIR}/ViSP-images-2.10.0.zip -d ${TRAVIS_BUILD_DIR}
   # Get libs for OSX
-  #   There is a bug in a formula resulting in update failing if run once, but not the second time
-  #   See https://github.com/Homebrew/homebrew/issues/45616
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update; fi"
   #- "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap homebrew/science; fi"
   #- "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install opencv3; fi"

--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -1532,6 +1532,22 @@ void vpImage<Type>::sub(const vpImage<Type> &A, const vpImage<Type> &B,
 }
 
 /*!
+
+  \warning This generic method is not implemented. You should rather use the
+  instantiated methods for unsigned char and vpRGBa images.
+
+  \sa vpImage<unsigned char>::performLut(const unsigned char (&)[256])
+  \sa vpImage<vpRGBa char>::performLut(const vpRGBa (&)[256])
+
+*/
+template<class Type>
+void vpImage<Type>::performLut(const Type (&)[256])
+{
+//  vpTRACE("Not implemented");
+  std::cerr << "Not implemented !" << std::endl;
+}
+
+/*!
   Modify the intensities of a grayscale image using the look-up table passed in parameter.
 
   \param lut : Look-up table (unsigned char array of size=256) which maps each intensity to his new value.

--- a/modules/core/test/image/testImageBinarise.cpp
+++ b/modules/core/test/image/testImageBinarise.cpp
@@ -1,0 +1,179 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test for vpImageTools::binarise() function.
+ *
+ * Authors:
+ * Souriya Trinh
+ *
+ *****************************************************************************/
+/*!
+  \example testImageBinarise.cpp
+
+  \brief Test vpImageTools::binarise() function.
+
+*/
+
+#include <visp3/core/vpImageTools.h>
+
+
+int main()
+{
+  std::cout << "Test vpImageTools::binarise() with different data types." << std::endl;
+
+  unsigned int width = 5, height = 4;
+  unsigned char *uchar_array = new unsigned char[width*height];
+  double *double_array = new double[width*height];
+  vpRGBa *rgba_array = new vpRGBa[width*height];
+  for(unsigned char i = 0; i < width*height; i++) {
+    uchar_array[i] = i;
+    double_array[i] = i;
+    rgba_array[i] = vpRGBa(i, i, i, i);
+  }
+
+  vpImage<unsigned char> I(uchar_array, height, width);
+  vpImage<double> I_double(double_array, height, width);
+  vpImage<vpRGBa> I_rgba(rgba_array, height, width);
+
+  std::cout << "I:" << std::endl;
+  for(unsigned int i = 0; i < I.getHeight(); i++) {
+    for(unsigned int j = 0; j < I.getWidth(); j++) {
+      std::cout << static_cast<unsigned>(I[i][j]) << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  std::cout << "\nI_double:" << std::endl;
+  for(unsigned int i = 0; i < I_double.getHeight(); i++) {
+    for(unsigned int j = 0; j < I_double.getWidth(); j++) {
+      std::cout << I_double[i][j] << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  std::cout << "\nI_rgba:" << std::endl;
+  for(unsigned int i = 0; i < I_rgba.getHeight(); i++) {
+    for(unsigned int j = 0; j < I_rgba.getWidth(); j++) {
+      std::cout << static_cast<unsigned>(I_rgba[i][j].R) << " ; " << static_cast<unsigned>(I_rgba[i][j].G) << " ; "
+          << static_cast<unsigned>(I_rgba[i][j].B) << " ; " << static_cast<unsigned int>(I_rgba[i][j].A) << std::endl;
+    }
+    std::cout << std::endl;
+  }
+
+  vpImageTools::binarise(I, (unsigned char) 5, (unsigned char) 12, (unsigned char) 0, (unsigned char) 127, (unsigned char) 255);
+  vpImageTools::binarise(I_double, 5.0, 12.0, 0.0, 127.0, 255.0);
+  vpImageTools::binarise(I_rgba, vpRGBa(5), vpRGBa(12), vpRGBa(0), vpRGBa(127), vpRGBa(255));
+
+  std::cout << "\nI binarise:" << std::endl;
+  for(unsigned int i = 0; i < I.getHeight(); i++) {
+    for(unsigned int j = 0; j < I.getWidth(); j++) {
+      std::cout << static_cast<unsigned>(I[i][j]) << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  std::cout << "\nI_double binarise:" << std::endl;
+  for(unsigned int i = 0; i < I_double.getHeight(); i++) {
+    for(unsigned int j = 0; j < I_double.getWidth(); j++) {
+      std::cout << I_double[i][j] << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  std::cout << "\nI_rgba binarise:" << std::endl;
+  for(unsigned int i = 0; i < I_rgba.getHeight(); i++) {
+    for(unsigned int j = 0; j < I_rgba.getWidth(); j++) {
+      std::cout << static_cast<unsigned>(I_rgba[i][j].R) << " ; " << static_cast<unsigned>(I_rgba[i][j].G) << " ; "
+          << static_cast<unsigned>(I_rgba[i][j].B) << " ; " << static_cast<unsigned>(I_rgba[i][j].A) << std::endl;
+    }
+    std::cout << std::endl;
+  }
+
+
+  //Check if results are the same between iterate and LUT methods
+  width = 32;
+  height = 8;
+  unsigned char *uchar_array1 = new unsigned char[width*height];
+  unsigned char *uchar_array2 = new unsigned char[width*height];
+  for(unsigned int i = 0; i < 256; i++) {
+    uchar_array1[i] = (unsigned char) i;
+    uchar_array2[i] = (unsigned char) i;
+  }
+
+  vpImage<unsigned char> I_uchar1(uchar_array1, height, width);
+  vpImage<unsigned char> I_uchar2(uchar_array2, height, width);
+
+  unsigned char threshold1 = 50, threshold2 = 200;
+  unsigned char value1 = 4, value2 = 127, value3 = 250;
+  vpImageTools::binarise(I_uchar1, threshold1, threshold2, value1, value2, value3, false);
+  vpImageTools::binarise(I_uchar2, threshold1, threshold2, value1, value2, value3, true);
+
+  for(unsigned int i = 0; i < height; i++) {
+    for(unsigned int j = 0; j < width; j++) {
+      if(I_uchar1[i][j] != I_uchar2[i][j]) {
+        std::cerr << "Results are different between iterate and LUT methods !" << std::endl;
+        return -1;
+      }
+    }
+  }
+
+
+  //Test performance between iterate and LUT methods
+  width = 640;
+  height = 480;
+  unsigned char *uchar_array_perf_lut = new unsigned char[width*height];
+  unsigned char *uchar_array_perf_iterate = new unsigned char[width*height];
+  for(unsigned int i = 0; i < width*height; i++) {
+    uchar_array_perf_lut[i] = (unsigned char) i;
+    uchar_array_perf_iterate[i] = (unsigned char) i;
+  }
+
+  vpImage<unsigned char> I_perf_lut(uchar_array_perf_lut, height, width);
+  vpImage<unsigned char> I_perf_iterate(uchar_array_perf_iterate, height, width);
+
+  unsigned int nbIterations = 100;
+  double t1 = vpTime::measureTimeMs();
+  for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
+    vpImageTools::binarise(I_perf_iterate, threshold1, threshold2, value1, value2, value3, false);
+  }
+  t1 = vpTime::measureTimeMs() - t1;
+  std::cout << "Iterate: " << t1 << " ms for " << nbIterations << " iterations." << std::endl;
+
+  double t2 = vpTime::measureTimeMs();
+  for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
+    vpImageTools::binarise(I_perf_lut, threshold1, threshold2, value1, value2, value3, true);
+  }
+  t2 = vpTime::measureTimeMs() - t2;
+  std::cout << "LUT: " << t2 << " ms for " << nbIterations << " iterations." << std::endl;
+
+
+  std::cout << "\ntestImageBinarise ok !" << std::endl;
+  return 0;
+}

--- a/modules/core/test/image/testPerformanceLUT.cpp
+++ b/modules/core/test/image/testPerformanceLUT.cpp
@@ -1,0 +1,351 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test performance between iteration and LUT.
+ *
+ * Authors:
+ * Souriya Trinh
+ *
+ *****************************************************************************/
+
+#include <visp3/core/vpImage.h>
+#include <visp3/core/vpImageIo.h>
+#include <visp3/core/vpParseArgv.h>
+#include <visp3/core/vpIoTools.h>
+#include <visp3/core/vpMath.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/*!
+  \example testPerformanceLUT.cpp
+
+  \brief Test performance between iteration and LUT.
+
+*/
+
+// List of allowed command line options
+#define GETOPTARGS  "cdi:o:h"
+
+void usage(const char *name, const char *badparam, std::string ipath, std::string opath, std::string user);
+bool getOptions(int argc, const char **argv, std::string &ipath, std::string &opath, std::string user);
+
+/*
+
+  Print the program options.
+
+  \param name : Program name.
+  \param badparam : Bad parameter name.
+  \param ipath: Input image path.
+  \param opath : Output image path.
+  \param user : Username.
+
+ */
+void usage(const char *name, const char *badparam, std::string ipath, std::string opath, std::string user)
+{
+  fprintf(stdout, "\n\
+Test performance between methods to iterate over pixel image.\n\
+\n\
+SYNOPSIS\n\
+  %s [-i <input image path>] [-o <output image path>]\n\
+     [-h]\n                 \
+", name);
+
+  fprintf(stdout, "\n\
+OPTIONS:                                               Default\n\
+  -i <input image path>                                %s\n\
+     Set image input path.\n\
+     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     image.\n\
+     Setting the VISP_INPUT_IMAGE_PATH environment\n\
+     variable produces the same behaviour than using\n\
+     this option.\n\
+\n\
+  -o <output image path>                               %s\n\
+     Set image output path.\n\
+     From this directory, creates the \"%s\"\n\
+     subdirectory depending on the username, where \n\
+     Klimt_grey.pgm output image is written.\n\
+\n\
+  -h\n\
+     Print the help.\n\n",
+    ipath.c_str(), opath.c_str(), user.c_str());
+
+  if (badparam)
+    fprintf(stdout, "\nERROR: Bad parameter [%s]\n", badparam);
+}
+
+/*!
+
+  Set the program options.
+
+  \param argc : Command line number of parameters.
+  \param argv : Array of command line parameters.
+  \param ipath: Input image path.
+  \param opath : Output image path.
+  \param user : Username.
+  \return false if the program has to be stopped, true otherwise.
+
+*/
+bool getOptions(int argc, const char **argv, std::string &ipath, std::string &opath, std::string user)
+{
+  const char *optarg_;
+  int c;
+  while ((c = vpParseArgv::parse(argc, argv, GETOPTARGS, &optarg_)) > 1) {
+
+    switch (c) {
+    case 'i': ipath = optarg_; break;
+    case 'o': opath = optarg_; break;
+    case 'h': usage(argv[0], NULL, ipath, opath, user); return false; break;
+
+    case 'c':
+    case 'd':
+      break;
+
+    default:
+      usage(argv[0], optarg_, ipath, opath, user); return false; break;
+    }
+  }
+
+  if ((c == 1) || (c == -1)) {
+    // standalone param or error
+    usage(argv[0], NULL, ipath, opath, user);
+    std::cerr << "ERROR: " << std::endl;
+    std::cerr << "  Bad argument " << optarg_ << std::endl << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+/*!
+  Iterate over pixels using raw pointer and adjust the pixel intensities with the formula:
+  new_intensity = old_intensitie * alpha + beta.
+
+  \param I : Input color image.
+  \param alpha : Gain.
+  \param beta: Offset.
+*/
+void iterate_method1(vpImage<vpRGBa> &I, const double alpha, const double beta) {
+  unsigned int size = I.getWidth() * I.getHeight();
+  unsigned char *ptrStart = (unsigned char*) I.bitmap;
+  unsigned char *ptrEnd = ptrStart + size*4;
+  unsigned char *ptrCurrent = ptrStart;
+
+  while(ptrCurrent != ptrEnd) {
+    *ptrCurrent = vpMath::saturate<unsigned char>((*ptrCurrent) * alpha + beta);
+    ++ptrCurrent;
+  }
+}
+
+/*!
+  Iterate over pixels using a double for loop and adjust the pixel intensities with the formula:
+  new_intensity = old_intensitie * alpha + beta.
+
+  \param I : Input color image.
+  \param alpha : Gain.
+  \param beta: Offset.
+*/
+void iterate_method2(vpImage<vpRGBa> &I, const double alpha, const double beta) {
+  for(unsigned int i = 0; i < I.getHeight(); i++) {
+    for(unsigned int j = 0; j < I.getWidth(); j++) {
+      I[i][j].R = vpMath::saturate<unsigned char>(I[i][j].R * alpha + beta);
+      I[i][j].G = vpMath::saturate<unsigned char>(I[i][j].G * alpha + beta);
+      I[i][j].B = vpMath::saturate<unsigned char>(I[i][j].B * alpha + beta);
+      I[i][j].A = vpMath::saturate<unsigned char>(I[i][j].A * alpha + beta);
+    }
+  }
+}
+
+/*!
+  Using a look-up table, adjust the pixel intensities.
+
+  \param I : Input color image.
+  \param lut : Look-up table mapping for each intensity the new corresponding value.
+*/
+void lut_method(vpImage<vpRGBa> &I, const vpRGBa (&lut)[256]) {
+  I.performLut(lut);
+}
+
+int
+main(int argc, const char ** argv)
+{
+  try {
+    std::string env_ipath;
+    std::string opt_ipath;
+    std::string opt_opath;
+    std::string ipath;
+    std::string opath;
+    std::string filename;
+    std::string username;
+
+    // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
+    env_ipath = vpIoTools::getViSPImagesDataPath();
+
+    // Set the default input path
+    if (! env_ipath.empty())
+      ipath = env_ipath;
+
+    // Set the default output path
+#if defined(_WIN32)
+    opt_opath = "C:/temp";
+#else
+    opt_opath = "/tmp";
+#endif
+
+    // Get the user login name
+    vpIoTools::getUserName(username);
+
+    // Read the command line options
+    if (getOptions(argc, argv, opt_ipath, opt_opath, username) == false) {
+      exit (-1);
+    }
+
+    // Get the option values
+    if (!opt_ipath.empty())
+      ipath = opt_ipath;
+    if (!opt_opath.empty())
+      opath = opt_opath;
+
+    // Append to the output path string, the login name of the user
+    opath = vpIoTools::createFilePath(opath, username);
+
+    // Test if the output path exist. If no try to create it
+    if (vpIoTools::checkDirectory(opath) == false) {
+      try {
+        // Create the dirname
+        vpIoTools::makeDirectory(opath);
+      }
+      catch (...) {
+        usage(argv[0], NULL, ipath, opt_opath, username);
+        std::cerr << std::endl
+                  << "ERROR:" << std::endl;
+        std::cerr << "  Cannot create " << opath << std::endl;
+        std::cerr << "  Check your -o " << opt_opath << " option " << std::endl;
+        exit(-1);
+      }
+    }
+
+    // Compare ipath and env_ipath. If they differ, we take into account
+    // the input path comming from the command line option
+    if (!opt_ipath.empty() && !env_ipath.empty()) {
+      if (ipath != env_ipath) {
+        std::cout << std::endl
+                  << "WARNING: " << std::endl;
+        std::cout << "  Since -i <visp image path=" << ipath << "> "
+                  << "  is different from VISP_IMAGE_PATH=" << env_ipath << std::endl
+                  << "  we skip the environment variable." << std::endl;
+      }
+    }
+
+    // Test if an input path is set
+    if (opt_ipath.empty() && env_ipath.empty()){
+      usage(argv[0], NULL, ipath, opt_opath, username);
+      std::cerr << std::endl
+                << "ERROR:" << std::endl;
+      std::cerr << "  Use -i <visp image path> option or set VISP_INPUT_IMAGE_PATH "
+                << std::endl
+                << "  environment variable to specify the location of the " << std::endl
+                << "  image path where test images are located." << std::endl << std::endl;
+      exit(-1);
+    }
+
+
+    //
+    // Here starts really the test
+    //
+
+    // Create a grey level image
+    vpImage<vpRGBa> I_iterate1, I_iterate2, I_lut;
+
+    // Load a grey image from the disk
+    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    std::cout << "Read image: " << filename << std::endl;
+    vpImageIo::read(I_iterate1, filename);
+    vpImageIo::read(I_iterate2, filename);
+    vpImageIo::read(I_lut, filename);
+
+    std::cout << "I=" << I_iterate1.getWidth() << "x" << I_iterate1.getHeight() << std::endl;
+
+    double alpha = 1.5, beta = -30.0;
+    unsigned int nbIterations = 10;
+
+    //Iterate method 1
+    double t_iterate1 = vpTime::measureTimeMs();
+    for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
+      iterate_method1(I_iterate1, alpha, beta);
+    }
+    t_iterate1 = vpTime::measureTimeMs() - t_iterate1;
+    std::cout << "t_iterate1=" << t_iterate1 << " ms ; t_iterate1/" << nbIterations << "="
+        << (t_iterate1/nbIterations) << " ms" << std::endl;
+
+    filename = vpIoTools::createFilePath(opath, "Klimt_performance_iterate1.ppm");
+    vpImageIo::write(I_iterate1, filename);
+
+
+    //Iterate method 2
+    double t_iterate2 = vpTime::measureTimeMs();
+    for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
+      iterate_method2(I_iterate2, alpha, beta);
+    }
+    t_iterate2 = vpTime::measureTimeMs() - t_iterate2;
+    std::cout << "t_iterate2=" << t_iterate2 << " ms ; t_iterate2/" << nbIterations << "="
+        << (t_iterate2/nbIterations) << " ms" << std::endl;
+
+    filename = vpIoTools::createFilePath(opath, "Klimt_performance_iterate2.ppm");
+    vpImageIo::write(I_iterate2, filename);
+
+
+    //LUT method
+    double t_lut = vpTime::measureTimeMs();
+    for(unsigned int cpt = 0; cpt < nbIterations; cpt++) {
+      //Construct the LUT
+      vpRGBa lut[256];
+      for(unsigned int i = 0; i < 256; i++) {
+        lut[i].R = vpMath::saturate<unsigned char>(alpha * i + beta);
+        lut[i].G = vpMath::saturate<unsigned char>(alpha * i + beta);
+        lut[i].B = vpMath::saturate<unsigned char>(alpha * i + beta);
+        lut[i].A = vpMath::saturate<unsigned char>(alpha * i + beta);
+      }
+
+      lut_method(I_lut, lut);
+    }
+    t_lut = vpTime::measureTimeMs() - t_lut;
+    std::cout << "t_lut=" << t_lut << " ms ; t_lut/" << nbIterations << "="
+        << (t_lut/nbIterations) << " ms" << std::endl;
+
+    filename = vpIoTools::createFilePath(opath, "Klimt_performance_lut.ppm");
+    vpImageIo::write(I_lut, filename);
+    return 0;
+  }
+  catch(vpException &e) {
+    std::cerr << "Catch an exception: " << e.what() << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
Fix vpImageTools::binarise() function to be able to work with other types than unsigned char.
Add test file for vpImageTools::binarise() and performance file for LUT vs iterate methods.
Add default warning function when trying to call vpImage<>.performLut() on image data types different than unsigned char or vpRGBa.