### PR TITLE
Improve vpKeyPoint, vpKalmanFilter and vpQuaternionVector  classes.

### DIFF
--- a/modules/core/include/visp3/core/vpKalmanFilter.h
+++ b/modules/core/include/visp3/core/vpKalmanFilter.h
@@ -140,7 +140,7 @@ public:
   // int init() { return init_done ; }
   void init(unsigned int size_state, unsigned int size_measure, unsigned int n_signal) ;
   void prediction() ;
-  void filtering(vpColVector &z) ;
+  void filtering(const vpColVector &z) ;
   /*!
     Return the size of the state vector \f${\bf x}_{(k)}\f$ for one signal.
   */
@@ -190,8 +190,6 @@ public:
       iterations. Only used in some specific state models implemented
       in vpLinearKalmanFilterInstantiation.*/
   double dt ;
-
-protected:
   /*!
     The state prediction covariance \f${\bf P}_{k \mid k-1} \f$ where 
     \f$ {\bf P}_{k \mid k-1} = {\bf F}_{k-1}  {\bf P}_{k-1 \mid k-1} {\bf F}^T_{k-1} 
@@ -205,6 +203,8 @@ protected:
     \right) {\bf P}_{k \mid k-1}\f$. 
   */
   vpMatrix Pest ;
+
+protected:
 
   /*!  
     Filter gain \f${\bf W}_k\f$ where \f$ {\bf W}_k = {\bf P}_{k

--- a/modules/core/include/visp3/core/vpQuaternionVector.h
+++ b/modules/core/include/visp3/core/vpQuaternionVector.h
@@ -100,11 +100,17 @@ public:
   //! Returns w-component of the quaternion.
   inline double w() const {return r[3];}
 
-  vpQuaternionVector operator+( vpQuaternionVector &q)  ;
-  vpQuaternionVector operator-( vpQuaternionVector &q)  ;
-  vpQuaternionVector operator-()  ;
-  vpQuaternionVector operator*(const double l) ;
-  vpQuaternionVector operator*( vpQuaternionVector &rq) ;
+  vpQuaternionVector operator+(const vpQuaternionVector &q);
+  vpQuaternionVector operator-(const vpQuaternionVector &q);
+  vpQuaternionVector operator-();
+  vpQuaternionVector operator*(const double l) const;
+  vpQuaternionVector operator*(const vpQuaternionVector &rq) const;
+  vpQuaternionVector operator/(const double l) const;
+
+  vpQuaternionVector conjugate() const;
+  vpQuaternionVector inverse() const;
+  double magnitude() const;
+  void normalize();
 } ;
 
 #endif

--- a/modules/core/src/math/kalman/vpKalmanFilter.cpp
+++ b/modules/core/src/math/kalman/vpKalmanFilter.cpp
@@ -209,7 +209,7 @@ vpKalmanFilter::prediction()
 
 */
 void
-vpKalmanFilter::filtering(vpColVector &z)
+vpKalmanFilter::filtering(const vpColVector &z)
 {
   if (verbose_mode)
     std::cout << "z " << std::endl << z << std::endl ;

--- a/modules/core/src/math/transformation/vpQuaternionVector.cpp
+++ b/modules/core/src/math/transformation/vpQuaternionVector.cpp
@@ -94,7 +94,7 @@ void vpQuaternionVector::set(const double x_, const double y_,
 
   \param q : quaternion to add.
 */
-vpQuaternionVector vpQuaternionVector::operator+( vpQuaternionVector &q)  
+vpQuaternionVector vpQuaternionVector::operator+(const vpQuaternionVector &q)
 {	
   return vpQuaternionVector(x()+q.x(), y()+q.y(), z()+q.z(), w()+q.w());
 }
@@ -105,7 +105,7 @@ vpQuaternionVector vpQuaternionVector::operator+( vpQuaternionVector &q)
 
   \param q : quaternion to substract.
 */
-vpQuaternionVector vpQuaternionVector::operator-( vpQuaternionVector &q)  
+vpQuaternionVector vpQuaternionVector::operator-(const vpQuaternionVector &q)
 {
   return vpQuaternionVector(x()-q.x(), y()-q.y(), z()-q.z(), w()-q.w());
 }
@@ -117,17 +117,27 @@ vpQuaternionVector vpQuaternionVector::operator-()
 }
 
 //! Multiplication by scalar. Returns a quaternion defined by (lx,ly,lz,lw).
-vpQuaternionVector vpQuaternionVector::operator*( double l) 
+vpQuaternionVector vpQuaternionVector::operator*(const double l) const
 {
   return vpQuaternionVector(l*x(),l*y(),l*z(),l*w());
 }
 
 //! Multiply two quaternions.
-vpQuaternionVector vpQuaternionVector::operator* ( vpQuaternionVector &rq) {	
+vpQuaternionVector vpQuaternionVector::operator* (const vpQuaternionVector &rq) const {
   return vpQuaternionVector(w() * rq.x() + x() * rq.w() + y() * rq.z() - z() * rq.y(),
 			    w() * rq.y() + y() * rq.w() + z() * rq.x() - x() * rq.z(),
 			    w() * rq.z() + z() * rq.w() + x() * rq.y() - y() * rq.x(),
 			    w() * rq.w() - x() * rq.x() - y() * rq.y() - z() * rq.z());
+}
+
+//! Division by scalar. Returns a quaternion defined by (x/l,y/l,z/l,w/l).
+vpQuaternionVector vpQuaternionVector::operator/(const double l) const
+{
+  if(vpMath::nul(l, std::numeric_limits<double>::epsilon())) {
+    throw vpException(vpException::fatalError, "Division by scalar l==0 !");
+  }
+
+  return vpQuaternionVector(x()/l,y()/l,z()/l,w()/l);
 }
 
 /*! 
@@ -146,4 +156,50 @@ void vpQuaternionVector::buildFrom(const vpRotationMatrix &R)
 
   double sinTheta_2 = sin(theta);
   set( u[0] * sinTheta_2, u[1] * sinTheta_2, u[2] * sinTheta_2, cos(theta) );
+}
+
+/*!
+  Quaternion conjugate.
+
+  \return The conjugate quaternion.
+*/
+vpQuaternionVector vpQuaternionVector::conjugate() const {
+  return vpQuaternionVector( -x(), -y(), -z(), w() );
+}
+
+/*!
+  Quaternion inverse.
+
+  \return The inverse quaternion.
+*/
+vpQuaternionVector vpQuaternionVector::inverse() const {
+  vpQuaternionVector q_inv;
+
+  double mag_square = w()*w() + x()*x() + y()*y() + z()*z();
+  if(!vpMath::nul(mag_square, std::numeric_limits<double>::epsilon())) {
+    q_inv = this->conjugate() / mag_square;
+  } else {
+    std::cerr << "The current quaternion is null ! The inverse cannot be computed !" << std::endl;
+  }
+
+  return q_inv;
+}
+
+/*!
+  Quaternion magnitude or norm.
+
+  \return The magnitude or norm of the quaternion.
+*/
+double vpQuaternionVector::magnitude() const {
+  return sqrt( w()*w() + x()*x() + y()*y() + z()*z() );
+}
+
+/*!
+  Normalize the quaternion.
+*/
+void vpQuaternionVector::normalize() {
+  double mag = magnitude();
+  if(!vpMath::nul(mag, std::numeric_limits<double>::epsilon())) {
+    set( x()/mag, y()/mag, z()/mag, w()/mag );
+  }
 }

--- a/modules/core/test/math/testQuaternion.cpp
+++ b/modules/core/test/math/testQuaternion.cpp
@@ -1,0 +1,140 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Tests quaternion operations.
+ *
+ * Author:
+ * Souriya Trinh
+ *
+ *****************************************************************************/
+
+
+/*!
+  \file testQuaternion.cpp
+  \brief Tests quaternion operations.
+*/
+
+
+#include <limits>
+#include <visp3/core/vpMath.h>
+#include <visp3/core/vpQuaternionVector.h>
+#include <visp3/core/vpException.h>
+
+
+int main()
+{
+  try {
+    //Test addition of two quaternions
+    vpQuaternionVector q1(2.1, -1, -3.7, 1.5);
+    vpQuaternionVector q2(0.5, 1.4, 0.7, 2.5);
+    vpQuaternionVector q3 = q1 + q2;
+    std::cout << "q3=" << q3 << std::endl;
+    if(!vpMath::equal(q3.x(), 2.6, std::numeric_limits<double>::epsilon()) ||
+       !vpMath::equal(q3.y(), 0.4, std::numeric_limits<double>::epsilon()) ||
+       !vpMath::equal(q3.z(), -3.0, std::numeric_limits<double>::epsilon()) ||
+       !vpMath::equal(q3.w(), 4.0, std::numeric_limits<double>::epsilon())) {
+      throw vpException(vpException::fatalError, "Problem with addition of two quaternions !");
+    }
+
+
+    //Test subtraction of two quaternions
+    vpQuaternionVector q4 = q3-q1;
+    std::cout << "q4=" << q4 << std::endl;
+    if(!vpMath::equal(q4.x(), q2.x(), std::numeric_limits<double>::epsilon()*1e4) ||
+       !vpMath::equal(q4.y(), q2.y(), std::numeric_limits<double>::epsilon()*1e4) ||
+       !vpMath::equal(q4.z(), q2.z(), std::numeric_limits<double>::epsilon()*1e4) ||
+       !vpMath::equal(q4.w(), q2.w(), std::numeric_limits<double>::epsilon()*1e4)) {
+      throw vpException(vpException::fatalError, "Problem with subtraction of two quaternions !");
+    }
+
+
+    //Test multiplication of two quaternions
+    //https://www.wolframalpha.com/input/?i=quaternion+-Sin%5BPi%5D%2B3i%2B4j%2B3k+multiplied+by+-1j%2B3.9i%2B4-3k&lk=3
+    vpQuaternionVector q5(3.0, 4.0, 3.0, -sin(M_PI));
+    vpQuaternionVector q6(3.9, -1.0, -3.0, 4.0);
+    vpQuaternionVector q7 = q5 * q6;
+    std::cout << "q7=" << q7 << std::endl;
+    if(!vpMath::equal(q7.x(), 3.0, std::numeric_limits<double>::epsilon()*1e4) ||
+        !vpMath::equal(q7.y(), 36.7, std::numeric_limits<double>::epsilon()*1e4) ||
+        !vpMath::equal(q7.z(), -6.6, std::numeric_limits<double>::epsilon()*1e4) ||
+        !vpMath::equal(q7.w(), 1.3, std::numeric_limits<double>::epsilon()*1e4)) {
+      throw vpException(vpException::fatalError, "Problem with multiplication of two quaternions !");
+    }
+
+
+    //Test quaternion conjugate
+    vpQuaternionVector q7_conj = q7.conjugate();
+    std::cout << "q7_conj=" << q7_conj << std::endl;
+    if(!vpMath::equal(q7_conj.x(), -3.0, std::numeric_limits<double>::epsilon()*1e4) ||
+        !vpMath::equal(q7_conj.y(), -36.7, std::numeric_limits<double>::epsilon()*1e4) ||
+        !vpMath::equal(q7_conj.z(), 6.6, std::numeric_limits<double>::epsilon()*1e4) ||
+        !vpMath::equal(q7_conj.w(), 1.3, std::numeric_limits<double>::epsilon()*1e4)) {
+      throw vpException(vpException::fatalError, "Problem with quaternion conjugate !");
+    }
+
+
+    //Test quaternion inverse
+    vpQuaternionVector q7_inv = q7.inverse();
+    std::cout << "q7_inv=" << q7_inv << std::endl;
+    if(!vpMath::equal(q7_inv.x(), -0.00214111, 0.000001) ||
+        !vpMath::equal(q7_inv.y(), -0.026193, 0.000001) ||
+        !vpMath::equal(q7_inv.z(), 0.00471045, 0.000001) ||
+        !vpMath::equal(q7_inv.w(), 0.000927816, 0.000001)) {
+      throw vpException(vpException::fatalError, "Problem with quaternion inverse !");
+    }
+
+
+    //Test quaternion norm
+    double q7_norm = q7.magnitude();
+    std::cout << "q7_norm=" << q7_norm << std::endl;
+    if(!vpMath::equal(q7_norm, 37.4318, 0.0001)) {
+      throw vpException(vpException::fatalError, "Problem with quaternion magnitude !");
+    }
+
+
+    //Test quaternion normalization
+    q7.normalize();
+    std::cout << "q7_unit=" << q7 << std::endl;
+    if(!vpMath::equal(q7.x(), 0.0801457, 0.00001) ||
+       !vpMath::equal(q7.y(), 0.98045, 0.00001) ||
+       !vpMath::equal(q7.z(), -0.176321, 0.00001) ||
+       !vpMath::equal(q7.w(), 0.0347298, 0.00001)) {
+      throw vpException(vpException::fatalError, "Problem with quaternion normalization !");
+    }
+
+
+    std::cout << "vpQuaternion operations are ok !" << std::endl;
+    return 0;
+  }
+  catch(vpException &e) {
+    std::cerr << "Catch an exception: " << e << std::endl;
+    return 1;
+  }
+}

--- a/modules/vision/test/key-point/testKeyPoint-3.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-3.cpp
@@ -55,7 +55,7 @@
 #include <visp3/io/vpParseArgv.h>
 
 // List of allowed command line options
-#define GETOPTARGS	"cdi:h"
+#define GETOPTARGS	"cdh"
 
 void usage(const char *name, const char *badparam);
 bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display);
@@ -66,13 +66,11 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display)
 
   \param name : Program name.
   \param badparam : Bad parameter name.
-  \param ipath: Input image path.
-
 */
 void usage(const char *name, const char *badparam)
 {
   fprintf(stdout, "\n\
-Test key points matching.\n\
+Test keypoints matching.\n\
 \n\
 SYNOPSIS\n\
   %s [-c] [-d] [-h]\n", name);
@@ -81,8 +79,8 @@ SYNOPSIS\n\
 OPTIONS:                                               \n\
 \n\
   -c\n\
-     Disable the mouse click. Useful to automaze the \n\
-     execution of this program without humain intervention.\n\
+     Disable the mouse click. Useful to automate the \n\
+     execution of this program without human intervention.\n\
 \n\
   -d \n\
      Turn off the display.\n\
@@ -154,8 +152,7 @@ int main(int argc, const char ** argv) {
     env_ipath = vpIoTools::getViSPImagesDataPath();
 
     if(env_ipath.empty()) {
-      std::cerr << "Please get the visp-images-data package path or set the VISP_INPUT_IMAGE_PATH "
-          "environment variable value." << std::endl;
+      std::cerr << "Please set the VISP_INPUT_IMAGE_PATH environment variable value." << std::endl;
       return -1;
     }
 
@@ -277,6 +274,7 @@ int main(int argc, const char ** argv) {
     return -1;
   }
 
+  std::cout << "testKeyPoint-3 is ok !" << std::endl;
   return 0;
 }
 #else

--- a/modules/vision/test/key-point/testKeyPoint-4.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-4.cpp
@@ -58,7 +58,7 @@
 #include <visp3/vision/vpKeyPoint.h>
 
 // List of allowed command line options
-#define GETOPTARGS	"cdi:h"
+#define GETOPTARGS	"cdh"
 
 void usage(const char *name, const char *badparam);
 bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display);
@@ -69,13 +69,12 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display)
 
   \param name : Program name.
   \param badparam : Bad parameter name.
-  \param ipath: Input image path.
 
 */
 void usage(const char *name, const char *badparam)
 {
   fprintf(stdout, "\n\
-Test key points matching.\n\
+Test keypoints matching.\n\
 \n\
 SYNOPSIS\n\
   %s [-c] [-d] [-h]\n", name);
@@ -84,8 +83,8 @@ SYNOPSIS\n\
 OPTIONS:                                               \n\
 \n\
   -c\n\
-     Disable the mouse click. Useful to automaze the \n\
-     execution of this program without humain intervention.\n\
+     Disable the mouse click. Useful to automate the \n\
+     execution of this program without human intervention.\n\
 \n\
   -d \n\
      Turn off the display.\n\
@@ -157,8 +156,7 @@ int main(int argc, const char ** argv) {
     env_ipath = vpIoTools::getViSPImagesDataPath();
 
     if(env_ipath.empty()) {
-      std::cerr << "Please get the visp-images-data package path or set the VISP_INPUT_IMAGE_PATH "
-          "environment variable value." << std::endl;
+      std::cerr << "Please set the VISP_INPUT_IMAGE_PATH environment variable value." << std::endl;
       return -1;
     }
 
@@ -395,6 +393,7 @@ int main(int argc, const char ** argv) {
     return -1;
   }
 
+  std::cout << "testKeyPoint-4 is ok !" << std::endl;
   return 0;
 }
 #else

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -1,0 +1,684 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test saving / loading learning files for vpKeyPoint class.
+ *
+ * Authors:
+ * Souriya Trinh
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <iomanip>
+
+#include <visp3/core/vpConfig.h>
+
+#if defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020301)
+
+#include <visp3/core/vpImage.h>
+#include <visp3/io/vpImageIo.h>
+#include <visp3/core/vpIoTools.h>
+#include <visp3/io/vpParseArgv.h>
+#include <visp3/vision/vpKeyPoint.h>
+#include <visp3/core/vpException.h>
+
+// List of allowed command line options
+#define GETOPTARGS	"cdo:h"
+
+void usage(const char *name, const char *badparam, std::string opath, std::string user);
+bool getOptions(int argc, const char **argv, std::string &opath, std::string user);
+
+/*!
+
+  Print the program options.
+
+  \param name : Program name.
+  \param badparam : Bad parameter name.
+
+*/
+void usage(const char *name, const char *badparam, std::string opath, std::string user)
+{
+  fprintf(stdout, "\n\
+Test save / load learning files for vpKeyPoint class.\n\
+\n\
+SYNOPSIS\n\
+  %s [-c] [-d] [-h]\n", name);
+
+  fprintf(stdout, "\n\
+OPTIONS:                                               \n\
+\n\
+  -o <output image path>                               %s\n\
+     Set image output path.\n\
+     From this directory, creates the \"%s\"\n\
+     subdirectory depending on the username, where \n\
+     learning files will be written.\n\
+\n\
+  -h\n\
+     Print the help.\n",
+     opath.c_str(), user.c_str());
+
+  if (badparam)
+    fprintf(stdout, "\nERROR: Bad parameter [%s]\n", badparam);
+}
+
+/*!
+
+  Set the program options.
+
+  \param argc : Command line number of parameters.
+  \param argv : Array of command line parameters.
+  \param opath : Output image path.
+  \param user : Username.
+  \return false if the program has to be stopped, true otherwise.
+
+*/
+bool getOptions(int argc, const char **argv, std::string &opath, std::string user)
+{
+  const char *optarg_;
+  int	c;
+  while ((c = vpParseArgv::parse(argc, argv, GETOPTARGS, &optarg_)) > 1) {
+
+    switch (c) {
+    case 'c': break; //not used, to avoid error with default arguments ctest
+    case 'd': break; //not used, to avoid error with default arguments ctest
+    case 'o': opath = optarg_; break;
+    case 'h': usage(argv[0], NULL, opath, user); return false; break;
+
+    default:
+      usage(argv[0], optarg_, opath, user); return false; break;
+      return false; break;
+    }
+  }
+
+  if ((c == 1) || (c == -1)) {
+    // standalone param or error
+    usage(argv[0], NULL, opath, user);
+    std::cerr << "ERROR: " << std::endl;
+    std::cerr << "  Bad argument " << optarg_ << std::endl << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+/*!
+  Compare two vectors of cv::KeyPoint.
+
+  \param keypoints1 : First vectors of cv::KeyPoint.
+  \param keypoints2 : Second vectors of cv::KeyPoint.
+
+  \return True if the two vectors are identical, false otherwise.
+*/
+bool compareKeyPoints(const std::vector<cv::KeyPoint> &keypoints1, const std::vector<cv::KeyPoint> &keypoints2) {
+  if(keypoints1.size() != keypoints2.size()) {
+    return false;
+  }
+
+  for(size_t cpt = 0; cpt < keypoints1.size(); cpt++) {
+    if(!vpMath::equal(keypoints1[cpt].angle, keypoints2[cpt].angle, std::numeric_limits<float>::epsilon())) {
+      std::cerr << std::fixed << std::setprecision(9) << "keypoints1[cpt].angle=" << keypoints1[cpt].angle <<
+          " ; keypoints2[cpt].angle=" << keypoints2[cpt].angle << std::endl;
+      return false;
+    }
+
+    if(keypoints1[cpt].class_id != keypoints2[cpt].class_id) {
+      std::cerr << "keypoints1[cpt].class_id=" << keypoints1[cpt].class_id << " ; keypoints2[cpt].class_id=" <<
+          keypoints2[cpt].class_id << std::endl;
+      return false;
+    }
+
+    if(keypoints1[cpt].octave != keypoints2[cpt].octave) {
+      std::cerr << "keypoints1[cpt].octave=" << keypoints1[cpt].octave << " ; keypoints2[cpt].octave=" <<
+          keypoints2[cpt].octave << std::endl;
+      return false;
+    }
+
+    if(!vpMath::equal(keypoints1[cpt].pt.x, keypoints2[cpt].pt.x, std::numeric_limits<float>::epsilon())) {
+      std::cerr << std::fixed << std::setprecision(9) << "keypoints1[cpt].pt.x=" << keypoints1[cpt].pt.x <<
+          " ; keypoints2[cpt].pt.x=" << keypoints2[cpt].pt.x << std::endl;
+      return false;
+    }
+
+    if(!vpMath::equal(keypoints1[cpt].pt.y, keypoints2[cpt].pt.y, std::numeric_limits<float>::epsilon())) {
+      std::cerr << std::fixed << std::setprecision(9) << "keypoints1[cpt].pt.y=" << keypoints1[cpt].pt.y <<
+          " ; keypoints2[cpt].pt.y=" << keypoints2[cpt].pt.y << std::endl;
+      return false;
+    }
+
+    if(!vpMath::equal(keypoints1[cpt].response, keypoints2[cpt].response, std::numeric_limits<float>::epsilon())) {
+      std::cerr << std::fixed << std::setprecision(9) << "keypoints1[cpt].response=" << keypoints1[cpt].response <<
+          " ; keypoints2[cpt].response=" << keypoints2[cpt].response << std::endl;
+      return false;
+    }
+
+    if(!vpMath::equal(keypoints1[cpt].size, keypoints2[cpt].size, std::numeric_limits<float>::epsilon())) {
+      std::cerr << std::fixed << std::setprecision(9) << "keypoints1[cpt].size=" << keypoints1[cpt].size <<
+          " ; keypoints2[cpt].size=" << keypoints2[cpt].size << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/*!
+  Compare two descriptors.
+
+  \param descriptors1 : First descriptor.
+  \param descriptors2 : Second descriptor.
+
+  \return True if the two vectors are identical, false otherwise.
+*/
+bool compareDescriptors(const cv::Mat &descriptors1, const cv::Mat &descriptors2) {
+  if(descriptors1.rows != descriptors2.rows || descriptors1.cols != descriptors2.cols ||
+      descriptors1.type() != descriptors2.type()) {
+    return false;
+  }
+
+  for(int i = 0; i < descriptors1.rows; i++) {
+    for(int j = 0; j < descriptors1.cols; j++) {
+      switch(descriptors1.type()) {
+      case CV_8U:
+        if(descriptors1.at<unsigned char>(i,j) != descriptors2.at<unsigned char>(i,j)) {
+          std::cerr << "descriptors1.at<unsigned char>(i,j)=" << descriptors1.at<unsigned char>(i,j) <<
+              " ; descriptors2.at<unsigned char>(i,j)=" << descriptors2.at<unsigned char>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      case CV_8S:
+        if(descriptors1.at<char>(i,j) != descriptors2.at<char>(i,j)) {
+          std::cerr << "descriptors1.at<char>(i,j)=" << descriptors1.at<char>(i,j) <<
+              " ; descriptors2.at<char>(i,j)=" << descriptors2.at<char>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      case CV_16U:
+        if(descriptors1.at<unsigned short>(i,j) != descriptors2.at<unsigned short>(i,j)) {
+          std::cerr << "descriptors1.at<unsigned short>(i,j)=" << descriptors1.at<unsigned short>(i,j) <<
+              " ; descriptors2.at<unsigned short>(i,j)=" << descriptors2.at<unsigned short>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      case CV_16S:
+        if(descriptors1.at<short>(i,j) != descriptors2.at<short>(i,j)) {
+          std::cerr << "descriptors1.at<short>(i,j)=" << descriptors1.at<short>(i,j) <<
+              " ; descriptors2.at<short>(i,j)=" << descriptors2.at<short>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      case CV_32S:
+        if(descriptors1.at<int>(i,j) != descriptors2.at<int>(i,j)) {
+          std::cerr << "descriptors1.at<int>(i,j)=" << descriptors1.at<int>(i,j) <<
+              " ; descriptors2.at<int>(i,j)=" << descriptors2.at<int>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      case CV_32F:
+        if(!vpMath::equal(descriptors1.at<float>(i,j), descriptors2.at<float>(i,j), std::numeric_limits<float>::epsilon())) {
+          std::cerr << std::fixed << std::setprecision(9) << "descriptors1.at<float>(i,j)=" << descriptors1.at<float>(i,j)
+              << " ; descriptors2.at<float>(i,j)=" << descriptors2.at<float>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      case CV_64F:
+        if(!vpMath::equal(descriptors1.at<double>(i,j), descriptors2.at<double>(i,j), std::numeric_limits<double>::epsilon())) {
+          std::cerr << std::fixed << std::setprecision(17) << "descriptors1.at<double>(i,j)=" << descriptors1.at<double>(i,j)
+              << " ; descriptors2.at<double>(i,j)=" << descriptors2.at<double>(i,j) << std::endl;
+          return false;
+        }
+        break;
+
+      default:
+        return false;
+        break;
+      }
+    }
+  }
+
+  return true;
+}
+
+/*!
+  \example testKeyPoint-7.cpp
+
+  \brief   Test saving / loading learning file.
+*/
+int main(int argc, const char ** argv) {
+  try {
+    std::string env_ipath;
+    std::string opt_opath;
+    std::string username;
+    std::string opath;
+    std::string filename;
+
+    //Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
+    env_ipath = vpIoTools::getViSPImagesDataPath();
+
+    if(env_ipath.empty()) {
+      throw vpException(vpException::ioError, "Please set the VISP_INPUT_IMAGE_PATH environment variable value.");
+    }
+
+    // Set the default output path
+#if defined(_WIN32)
+    opt_opath = "C:/temp";
+#else
+    opt_opath = "/tmp";
+#endif
+
+    // Get the user login name
+    vpIoTools::getUserName(username);
+
+    // Read the command line options
+    if (getOptions(argc, argv, opt_opath, username) == false) {
+      throw vpException(vpException::fatalError, "getOptions(argc, argv, opt_opath, username) == false");
+    }
+
+    // Get the option values
+    if (!opt_opath.empty()) {
+      opath = opt_opath;
+    }
+
+    // Append to the output path string, the login name of the user
+    opath = vpIoTools::createFilePath(opath, username);
+
+    // Test if the output path exist. If no try to create it
+    if (vpIoTools::checkDirectory(opath) == false) {
+      try {
+        // Create the dirname
+        vpIoTools::makeDirectory(opath);
+      }
+      catch (...) {
+        usage(argv[0], NULL, opt_opath, username);
+        std::stringstream ss;
+        ss << std::endl << "ERROR:" << std::endl;
+        ss << "  Cannot create " << opath << std::endl;
+        ss << "  Check your -o " << opt_opath << " option " << std::endl;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+    }
+
+    vpImage<unsigned char> I;
+
+    //Set the path location of the image sequence
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/Klimt");
+
+    //Build the name of the image files
+    std::string img_filename = vpIoTools::createFilePath(dirname, "/Klimt.ppm");
+    vpImageIo::read(I, img_filename);
+
+    vpKeyPoint keyPoints;
+
+    //Test with binary descriptor
+    {
+      std::string keypointName = "BRISK";
+      keyPoints.setDetector(keypointName);
+      keyPoints.setExtractor(keypointName);
+
+      keyPoints.buildReference(I);
+
+      std::vector<cv::KeyPoint> trainKeyPoints;
+      keyPoints.getTrainKeyPoints(trainKeyPoints);
+      cv::Mat trainDescriptors = keyPoints.getTrainDescriptors();
+      if(trainKeyPoints.empty() || trainDescriptors.empty() || (int) trainKeyPoints.size() != trainDescriptors.rows) {
+        throw vpException(vpException::fatalError, "Problem when detecting keypoints or when computing descriptors !");
+      }
+
+      //Save in binary with training images
+      filename = vpIoTools::createFilePath(opath, "bin_with_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_bin_with_img.bin");
+      keyPoints.saveLearningData(filename, true, true);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint1;
+      read_keypoint1.loadLearningData(filename, true);
+      std::vector<cv::KeyPoint> trainKeyPoints_read;
+      read_keypoint1.getTrainKeyPoints(trainKeyPoints_read);
+      cv::Mat trainDescriptors_read = read_keypoint1.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved "
+            "in binary with train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "binary with train images saved !");
+      }
+
+
+      //Save in binary with no training images
+      filename = vpIoTools::createFilePath(opath, "bin_without_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_bin_without_img.bin");
+      keyPoints.saveLearningData(filename, true, false);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint2;
+      read_keypoint2.loadLearningData(filename, true);
+      trainKeyPoints_read.clear();
+      read_keypoint2.getTrainKeyPoints(trainKeyPoints_read);
+      trainDescriptors_read = read_keypoint2.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "binary without train images !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "binary without train images !");
+      }
+
+
+#if defined(VISP_HAVE_XML2)
+      //Save in xml with training images
+      filename = vpIoTools::createFilePath(opath, "xml_with_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_xml_with_img.xml");
+      keyPoints.saveLearningData(filename, false, true);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint3;
+      read_keypoint3.loadLearningData(filename, false);
+      trainKeyPoints_read.clear();
+      read_keypoint3.getTrainKeyPoints(trainKeyPoints_read);
+      trainDescriptors_read = read_keypoint3.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "xml with train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "xml with train images saved !");
+      }
+
+
+      //Save in xml without training images
+      filename = vpIoTools::createFilePath(opath, "xml_without_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_xml_without_img.xml");
+      keyPoints.saveLearningData(filename, false, false);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint4;
+      read_keypoint4.loadLearningData(filename, false);
+      trainKeyPoints_read.clear();
+      read_keypoint4.getTrainKeyPoints(trainKeyPoints_read);
+      trainDescriptors_read = read_keypoint4.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "xml without train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "xml without train images saved !");
+      }
+#endif
+
+      std::cout << "Saving / loading learning files with binary descriptor are ok !" << std::endl;
+    }
+
+
+    //Test with floating point descriptor
+#if defined(VISP_HAVE_OPENCV_NONFREE) || ( (VISP_HAVE_OPENCV_VERSION >= 0x030000) && defined(VISP_HAVE_OPENCV_XFEATURES2D) )
+    {
+      std::string keypointName = "SIFT";
+      keyPoints.setDetector(keypointName);
+      keyPoints.setExtractor(keypointName);
+
+      keyPoints.buildReference(I);
+
+      std::vector<cv::KeyPoint> trainKeyPoints;
+      keyPoints.getTrainKeyPoints(trainKeyPoints);
+      cv::Mat trainDescriptors = keyPoints.getTrainDescriptors();
+      if(trainKeyPoints.empty() || trainDescriptors.empty() || (int) trainKeyPoints.size() != trainDescriptors.rows) {
+        throw vpException(vpException::fatalError, "Problem when detecting keypoints or when computing descriptors (SIFT) !");
+      }
+
+      //Save in binary with training images
+      filename = vpIoTools::createFilePath(opath, "bin_with_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_bin_with_img.bin");
+      keyPoints.saveLearningData(filename, true, true);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint1;
+      read_keypoint1.loadLearningData(filename, true);
+      std::vector<cv::KeyPoint> trainKeyPoints_read;
+      read_keypoint1.getTrainKeyPoints(trainKeyPoints_read);
+      cv::Mat trainDescriptors_read = read_keypoint1.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "binary with train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "binary with train images saved !");
+      }
+
+
+      //Save in binary with no training images
+      filename = vpIoTools::createFilePath(opath, "bin_without_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_bin_without_img.bin");
+      keyPoints.saveLearningData(filename, true, false);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint2;
+      read_keypoint2.loadLearningData(filename, true);
+      trainKeyPoints_read.clear();
+      read_keypoint2.getTrainKeyPoints(trainKeyPoints_read);
+      trainDescriptors_read = read_keypoint2.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "binary without train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "binary without train images saved !");
+      }
+
+
+#if defined(VISP_HAVE_XML2)
+      //Save in xml with training images
+      filename = vpIoTools::createFilePath(opath, "xml_with_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_xml_with_img.xml");
+      keyPoints.saveLearningData(filename, false, true);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint3;
+      read_keypoint3.loadLearningData(filename, false);
+      trainKeyPoints_read.clear();
+      read_keypoint3.getTrainKeyPoints(trainKeyPoints_read);
+      trainDescriptors_read = read_keypoint3.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "xml with train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "xml with train images saved !");
+      }
+
+
+      //Save in xml without training images
+      filename = vpIoTools::createFilePath(opath, "xml_without_img");
+      vpIoTools::makeDirectory(filename);
+      filename = vpIoTools::createFilePath(filename, "test_save_in_xml_without_img.xml");
+      keyPoints.saveLearningData(filename, false, false);
+
+      //Test if save is ok
+      if(!vpIoTools::checkFilename(filename)) {
+        std::stringstream ss;
+        ss << "Problem when saving file=" << filename;
+        throw vpException(vpException::ioError, ss.str().c_str());
+      }
+
+      //Test if read is ok
+      vpKeyPoint read_keypoint4;
+      read_keypoint4.loadLearningData(filename, false);
+      trainKeyPoints_read.clear();
+      read_keypoint4.getTrainKeyPoints(trainKeyPoints_read);
+      trainDescriptors_read = read_keypoint4.getTrainDescriptors();
+
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainKeyPoints when reading learning file saved in "
+            "xml without train images saved !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_read)) {
+        throw vpException(vpException::fatalError, "Problem with trainDescriptors when reading learning file saved in "
+            "xml without train images saved !");
+      }
+#endif
+
+      std::cout << "Saving / loading learning files with floating point descriptor are ok !" << std::endl;
+
+
+      //Test vpKeyPoint::reset()
+      vpKeyPoint keypoint_reset;
+
+      keypointName = "BRISK";
+      keypoint_reset.setDetector(keypointName);
+      keypoint_reset.setExtractor(keypointName);
+
+      keypoint_reset.buildReference(I);
+
+      //reset
+      keypoint_reset.reset();
+
+      keypointName = "SIFT";
+      keypoint_reset.setDetector(keypointName);
+      keypoint_reset.setExtractor(keypointName);
+
+      keypoint_reset.buildReference(I);
+
+      std::vector<cv::KeyPoint> trainKeyPoints_reset;
+      keypoint_reset.getTrainKeyPoints(trainKeyPoints_reset);
+      cv::Mat trainDescriptors_reset = keypoint_reset.getTrainDescriptors();
+
+      //If reset is ok, we should get the same keypoints and the same descriptors
+      if(!compareKeyPoints(trainKeyPoints, trainKeyPoints_reset)) {
+        throw vpException(vpException::fatalError, "Problem with vpKeyPoint::reset() and trainKeyPoints !");
+      }
+
+      if(!compareDescriptors(trainDescriptors, trainDescriptors_reset)) {
+        throw vpException(vpException::fatalError, "Problem with vpKeyPoint::reset() and trainDescriptors !");
+      }
+
+      std::cout << "vpKeyPoint::reset() is ok with trainKeyPoints and trainDescriptors !" << std::endl;
+    }
+#endif
+
+
+  } catch(vpException &e) {
+    std::cerr << e.what() << std::endl;
+    return -1;
+  }
+
+  std::cout << "Saving / loading learning files are ok !" << std::endl;
+  std::cout << "testKeyPoint-7 is ok !" << std::endl;
+  return 0;
+}
+#else
+int main() {
+  std::cerr << "You need OpenCV library." << std::endl;
+
+  return 0;
+}
+
+#endif

--- a/modules/vision/test/key-point/testKeyPoint.cpp
+++ b/modules/vision/test/key-point/testKeyPoint.cpp
@@ -53,7 +53,7 @@
 #include <visp3/io/vpParseArgv.h>
 
 // List of allowed command line options
-#define GETOPTARGS	"cdi:h"
+#define GETOPTARGS	"cdh"
 
 void usage(const char *name, const char *badparam);
 bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display);
@@ -64,13 +64,12 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display)
 
   \param name : Program name.
   \param badparam : Bad parameter name.
-  \param ipath: Input image path.
 
 */
 void usage(const char *name, const char *badparam)
 {
   fprintf(stdout, "\n\
-Test key points matching.\n\
+Test keypoints matching.\n\
 \n\
 SYNOPSIS\n\
   %s [-c] [-d] [-h]\n", name);
@@ -79,8 +78,8 @@ SYNOPSIS\n\
 OPTIONS:                                               \n\
 \n\
   -c\n\
-     Disable the mouse click. Useful to automaze the \n\
-     execution of this program without humain intervention.\n\
+     Disable the mouse click. Useful to automate the \n\
+     execution of this program without human intervention.\n\
 \n\
   -d \n\
      Turn off the display.\n\
@@ -150,12 +149,8 @@ int main(int argc, const char ** argv) {
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
     env_ipath = vpIoTools::getViSPImagesDataPath();
 
-    //Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
-    env_ipath = vpIoTools::getViSPImagesDataPath();
-
     if(env_ipath.empty()) {
-      std::cerr << "Please get the visp-images-data package path or set the VISP_INPUT_IMAGE_PATH "
-          "environment variable value." << std::endl;
+      std::cerr << "Please set the VISP_INPUT_IMAGE_PATH environment variable value." << std::endl;
       return -1;
     }
 
@@ -240,6 +235,7 @@ int main(int argc, const char ** argv) {
     return -1;
   }
 
+  std::cout << "testKeyPoint is ok !" << std::endl;
   return 0;
 }
 #else


### PR DESCRIPTION
Improve vpKeyPoint class:
- add AGAST detector (OpenCV 3.0)
- add KAZE, AKAZE, DAISY, LATCH desciptor extractors (OpenCV 3.0 contrib)
- add possibility to set keypoint parameters with OpenCV 3.0
- improve saveLearningData when visp_io is not available, improve XML saving, should be possible to save learning data in binary mode also on big-endian platform (need to be tested)
- add corresponding test files

Improve vpKalmanFilter:
- change visibility to be able to get error covariance variable

Improve vpQuaternionVector:
- add some quaternion operations