### PR TITLE
Fix problem in test files for PR #22.

### DIFF
--- a/modules/vision/test/key-point/testKeyPoint-5.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-5.cpp
@@ -203,7 +203,9 @@ int main(int argc, const char ** argv) {
     detectorNames.push_back("PyramidORB");
     detectorNames.push_back("ORB");
     detectorNames.push_back("PyramidBRISK");
+#if (VISP_HAVE_OPENCV_VERSION >= 0x020403)
     detectorNames.push_back("BRISK");
+#endif
 #if (VISP_HAVE_OPENCV_VERSION >= 0x030000)
     detectorNames.push_back("PyramidKAZE");
     detectorNames.push_back("KAZE");

--- a/modules/vision/test/key-point/testKeyPoint-6.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-6.cpp
@@ -232,7 +232,9 @@ int main(int argc, const char ** argv) {
     descriptorNames.push_back("SURF");
 #endif
     descriptorNames.push_back("ORB");
+#if (VISP_HAVE_OPENCV_VERSION >= 0x020403)
     descriptorNames.push_back("BRISK");
+#endif
     descriptorNames.push_back("BRIEF");
 #if defined(VISP_HAVE_OPENCV_XFEATURES2D) || (VISP_HAVE_OPENCV_VERSION < 0x030000)
     descriptorNames.push_back("FREAK");

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -343,7 +343,7 @@ int main(int argc, const char ** argv) {
 
     //Test with binary descriptor
     {
-      std::string keypointName = "BRISK";
+      std::string keypointName = "ORB";
       keyPoints.setDetector(keypointName);
       keyPoints.setExtractor(keypointName);
 


### PR DESCRIPTION
Add protections to use BRISK features only from OpenCV 2.4.3 in test files:
- testKeyPoint-5.cpp
- testKeyPoint-6.cpp
- testKeyPoint-7.cpp