### PR TITLE
Fix cdash error, fix memory leak.

### DIFF
--- a/modules/core/src/math/transformation/vpRotationVector.cpp
+++ b/modules/core/src/math/transformation/vpRotationVector.cpp
@@ -111,6 +111,10 @@ VISP_EXPORT std::ostream &operator <<(std::ostream &s,const vpRotationVector &m)
 
 
 void vpRotationVector::init(const unsigned int vector_size){
+  if(r != NULL) {
+    delete[] r;
+  }
+
   this->_size = vector_size;
 	r = new double[this->_size];
 	std::fill(r,r+this->_size,0.);
@@ -118,4 +122,5 @@ void vpRotationVector::init(const unsigned int vector_size){
 
 vpRotationVector::~vpRotationVector(){
 	delete[] r;
+	r = NULL;
 }

--- a/modules/core/test/math/testQuaternion.cpp
+++ b/modules/core/test/math/testQuaternion.cpp
@@ -130,6 +130,21 @@ int main()
     }
 
 
+    //Test copy constructor
+    vpQuaternionVector q_copy1 = vpQuaternionVector(0, 0, 1, 1);
+    std::cout << "q_copy1=" << q_copy1 << std::endl;
+    vpQuaternionVector q_copy2 = q_copy1;
+    q_copy1.set(1, 0, 1, 10);
+    std::cout << "q_copy1 after set=" << q_copy1 << std::endl;
+    std::cout << "q_copy2=" << q_copy2 << std::endl;
+
+
+    //Test assignment operator
+    vpQuaternionVector q_copy3(10, 10, 10, 10);
+    q_copy3 = q_copy1;
+    std::cout << "q_copy3=" << q_copy3 << std::endl;
+
+
     std::cout << "vpQuaternion operations are ok !" << std::endl;
     return 0;
   }

--- a/modules/vision/test/key-point/testKeyPoint-6.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-6.cpp
@@ -235,8 +235,8 @@ int main(int argc, const char ** argv) {
 #if (VISP_HAVE_OPENCV_VERSION >= 0x020403)
     descriptorNames.push_back("BRISK");
 #endif
-    descriptorNames.push_back("BRIEF");
 #if defined(VISP_HAVE_OPENCV_XFEATURES2D) || (VISP_HAVE_OPENCV_VERSION < 0x030000)
+    descriptorNames.push_back("BRIEF");
     descriptorNames.push_back("FREAK");
 #endif
 #if defined(VISP_HAVE_OPENCV_XFEATURES2D)


### PR DESCRIPTION
Add protection to use BRIEF only if OpenCV contrib is present with OpenCV 3.0. Fix memory leak in vpRotationVector class.