### PR TITLE
Fix errors in testKeyPoint-5/6/7.cpp with OpenCV 2.3.1.

### DIFF
--- a/modules/vision/test/key-point/testKeyPoint-5.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-5.cpp
@@ -202,8 +202,8 @@ int main(int argc, const char ** argv) {
 #endif
     detectorNames.push_back("PyramidORB");
     detectorNames.push_back("ORB");
-    detectorNames.push_back("PyramidBRISK");
 #if (VISP_HAVE_OPENCV_VERSION >= 0x020403)
+    detectorNames.push_back("PyramidBRISK");
     detectorNames.push_back("BRISK");
 #endif
 #if (VISP_HAVE_OPENCV_VERSION >= 0x030000)

--- a/modules/vision/test/key-point/testKeyPoint-6.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-6.cpp
@@ -237,7 +237,9 @@ int main(int argc, const char ** argv) {
 #endif
 #if defined(VISP_HAVE_OPENCV_XFEATURES2D) || (VISP_HAVE_OPENCV_VERSION < 0x030000)
     descriptorNames.push_back("BRIEF");
+#if (VISP_HAVE_OPENCV_VERSION >= 0x020402)
     descriptorNames.push_back("FREAK");
+#endif
 #endif
 #if defined(VISP_HAVE_OPENCV_XFEATURES2D)
     descriptorNames.push_back("DAISY");

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -632,7 +632,7 @@ int main(int argc, const char ** argv) {
       //Test vpKeyPoint::reset()
       vpKeyPoint keypoint_reset;
 
-      keypointName = "BRISK";
+      keypointName = "ORB";
       keypoint_reset.setDetector(keypointName);
       keypoint_reset.setExtractor(keypointName);
 


### PR DESCRIPTION
Fix errors in testKeyPoint-5.cpp testKeyPoint-6.cpp testKeyPoint-7.cpp with OpenCV 2.3.1 (features not available in OpenCV 2.3.1).