### PR TITLE
Fix warning for PR #22. Fix testQuaternion on Windows and MSVC.

### DIFF
--- a/modules/core/include/visp3/core/vpMath.h
+++ b/modules/core/include/visp3/core/vpMath.h
@@ -61,15 +61,15 @@
 #if defined(_WIN32)	// Not defined in Microsoft math.h
 
 # ifndef M_PI
-#   define M_PI            3.14159265358979323846f
+#   define M_PI            3.14159265358979323846
 # endif
 
 # ifndef M_PI_2
-#   define M_PI_2          (M_PI/2.f)
+#   define M_PI_2          (M_PI/2.0)
 # endif
 
 # ifndef M_PI_4
-#   define M_PI_4          (M_PI/4.f)
+#   define M_PI_4          (M_PI/4.0)
 # endif
 
 #endif

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -816,11 +816,11 @@ bool vpIoTools::readConfigVar(const std::string &var, float &value)
       if(configVars[k] == var)
         {
           if(configValues[k].compare("PI") == 0)
-              value = M_PI;
+              value = (float) M_PI;
           else if(configValues[k].compare("PI/2") == 0)
-              value = M_PI/2;
+              value = (float) (M_PI/2.0);
           else if(configValues[k].compare("-PI/2") == 0)
-              value = -M_PI/2;
+              value = (float) (-M_PI/2.0);
           else
               value = (float) atof(configValues[k].c_str());
           found = true;

--- a/modules/vision/src/key-point/vpKeyPoint.cpp
+++ b/modules/vision/src/key-point/vpKeyPoint.cpp
@@ -4350,9 +4350,9 @@ struct KeyPoint_LessThan {
   KeyPoint_LessThan(const std::vector<cv::KeyPoint>& _kp) :
       kp(&_kp) {
   }
-  bool operator()(int i, int j) const {
-    const cv::KeyPoint& kp1 = (*kp)[(size_t) i];
-    const cv::KeyPoint& kp2 = (*kp)[(size_t) j];
+  bool operator()(/*int i, int j*/ size_t i, size_t j) const {
+    const cv::KeyPoint& kp1 = (*kp)[/*(size_t)*/ i];
+    const cv::KeyPoint& kp2 = (*kp)[/*(size_t)*/ j];
     if (!vpMath::equal(kp1.pt.x, kp2.pt.x, std::numeric_limits<float>::epsilon())) { //if (kp1.pt.x != kp2.pt.x) {
       return kp1.pt.x < kp2.pt.x;
     }


### PR DESCRIPTION
Fix warning conversion from size_t to int. Fix the double precision of the M_PI constant with Windows platform and MSVC.