### PR TITLE
Restrict operations that could be done with matrices and vectors to what that should do

### DIFF
--- a/example/moments/image/servoMomentImage.cpp
+++ b/example/moments/image/servoMomentImage.cpp
@@ -350,19 +350,19 @@ void execute(unsigned int nbIter){
     //robot.setPosition(vpRobot::CAMERA_FRAME,0.01*v);
 
     err_features = task.error;
-	std::cout<<" || s - s* || = "<<task.error.sumSquare()<<std::endl;
+    std::cout<<" || s - s* || = "<<task.error.sumSquare()<<std::endl;
 
     robot.setVelocity(vpRobot::CAMERA_FRAME, v) ;
     vpTime::wait(t, sampling_time * 1000); // Wait 10 ms
 
     ViSP_plot.plot(0,iter, v);
-	ViSP_plot.plot(1,iter,currentpose);			// Plot the velocities
-	ViSP_plot.plot(2, iter,err_features);		//cMo as translations and theta_u
+    ViSP_plot.plot(1,iter,currentpose);			// Plot the velocities
+    ViSP_plot.plot(2, iter,err_features);		//cMo as translations and theta_u
 
-	_error = ( task.getError() ).sumSquare();
+    _error = ( task.getError() ).sumSquare();
 
-	#if defined(PRINT_CONDITION_NUMBER)
-		/*
+#if defined(PRINT_CONDITION_NUMBER)
+    /*
 		 * Condition number of interaction matrix
 		 */
 		vpMatrix Linteraction = task.L;

--- a/example/robot-simulator/camera/servoSimu3D_cMcd_CamVelocityWithoutVpServo.cpp
+++ b/example/robot-simulator/camera/servoSimu3D_cMcd_CamVelocityWithoutVpServo.cpp
@@ -265,7 +265,7 @@ main(int argc, const char ** argv)
 
       // Create the identity matrix
       vpMatrix I(3,3);
-      I.setIdentity();
+      I.eye();
 
       // Compute the camera translational velocity
       vpColVector v(3);

--- a/example/servo-afma4/servoAfma4Point2DArtVelocity.cpp
+++ b/example/servo-afma4/servoAfma4Point2DArtVelocity.cpp
@@ -89,7 +89,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot.h>

--- a/example/servo-afma4/servoAfma4Point2DCamVelocity.cpp
+++ b/example/servo-afma4/servoAfma4Point2DCamVelocity.cpp
@@ -86,7 +86,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot.h>

--- a/example/servo-afma4/servoAfma4Point2DCamVelocityKalman.cpp
+++ b/example/servo-afma4/servoAfma4Point2DCamVelocityKalman.cpp
@@ -77,7 +77,6 @@
 #include <visp3/robot/vpRobotAfma4.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-afma6/servoAfma62DhalfCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma62DhalfCamVelocity.cpp
@@ -77,7 +77,7 @@
 #include <visp3/visual_features/vpFeatureLine.h>
 #include <visp3/visual_features/vpFeaturePoint.h>
 #include <visp3/visual_features/vpFeatureDepth.h>
-#include <visp3/core/vpGenericFeature.h>
+#include <visp3/visual_features/vpGenericFeature.h>
 #include <visp3/core/vpLine.h>
 #include <visp3/vs/vpServo.h>
 #include <visp3/visual_features/vpFeatureBuilder.h>
@@ -87,7 +87,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-afma6/servoAfma6Cylinder2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6Cylinder2DCamVelocity.cpp
@@ -79,7 +79,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 int

--- a/example/servo-afma6/servoAfma6Cylinder2DCamVelocitySecondaryTask.cpp
+++ b/example/servo-afma6/servoAfma6Cylinder2DCamVelocitySecondaryTask.cpp
@@ -83,7 +83,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 

--- a/example/servo-afma6/servoAfma6Ellipse2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6Ellipse2DCamVelocity.cpp
@@ -82,7 +82,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot.h>

--- a/example/servo-afma6/servoAfma6FourPoints2DArtVelocity.cpp
+++ b/example/servo-afma6/servoAfma6FourPoints2DArtVelocity.cpp
@@ -87,7 +87,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot.h>

--- a/example/servo-afma6/servoAfma6FourPoints2DCamVelocityInteractionCurrent.cpp
+++ b/example/servo-afma6/servoAfma6FourPoints2DCamVelocityInteractionCurrent.cpp
@@ -93,7 +93,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 
 #define L 0.05 // to deal with a 10cm by 10cm square
 

--- a/example/servo-afma6/servoAfma6FourPoints2DCamVelocityInteractionDesired.cpp
+++ b/example/servo-afma6/servoAfma6FourPoints2DCamVelocityInteractionDesired.cpp
@@ -92,7 +92,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 
 #define L 0.05 // to deal with a 10cm by 10cm square
 

--- a/example/servo-afma6/servoAfma6Line2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6Line2DCamVelocity.cpp
@@ -79,7 +79,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 int

--- a/example/servo-afma6/servoAfma6Point2DArtVelocity.cpp
+++ b/example/servo-afma6/servoAfma6Point2DArtVelocity.cpp
@@ -88,7 +88,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot.h>

--- a/example/servo-afma6/servoAfma6Point2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6Point2DCamVelocity.cpp
@@ -78,7 +78,6 @@
 #include <visp3/robot/vpRobotAfma6.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/blob/vpDot.h>
 #include <visp3/core/vpDisplay.h>

--- a/example/servo-afma6/servoAfma6Points2DCamVelocityEyeToHand.cpp
+++ b/example/servo-afma6/servoAfma6Points2DCamVelocityEyeToHand.cpp
@@ -78,7 +78,6 @@
 #include <visp3/visual_features/vpFeatureBuilder.h>
 #include <visp3/robot/vpRobotAfma6.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/blob/vpDot.h>
 #include <visp3/vision/vpPose.h>

--- a/example/servo-afma6/servoAfma6Segment2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6Segment2DCamVelocity.cpp
@@ -65,7 +65,6 @@
 #include <visp3/robot/vpRobotAfma6.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/blob/vpDot.h>
 #include <visp3/core/vpDisplay.h>

--- a/example/servo-afma6/servoAfma6SquareLines2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6SquareLines2DCamVelocity.cpp
@@ -83,7 +83,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot.h>

--- a/example/servo-afma6/servoAfma6TwoLines2DCamVelocity.cpp
+++ b/example/servo-afma6/servoAfma6TwoLines2DCamVelocity.cpp
@@ -87,7 +87,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 int

--- a/example/servo-biclops/servoBiclopsPoint2DArtVelocity.cpp
+++ b/example/servo-biclops/servoBiclopsPoint2DArtVelocity.cpp
@@ -93,8 +93,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
-
 
 #ifdef VISP_HAVE_PTHREAD
 pthread_mutex_t mutexEndLoop = PTHREAD_MUTEX_INITIALIZER;

--- a/example/servo-pioneer/servoPioneerPoint2DDepthWithoutVpServo.cpp
+++ b/example/servo-pioneer/servoPioneerPoint2DDepthWithoutVpServo.cpp
@@ -222,8 +222,8 @@ int main(int argc, char **argv)
     robot.get_eJe(eJe);
 
     vpMatrix L; // Interaction matrix
-    L.stackMatrices(L_x); // constant since build with the desired feature
-    L.stackMatrices(L_Z); // not constant since it corresponds to log(Z/Z*) that evolves at each iteration
+    L.stack(L_x); // constant since build with the desired feature
+    L.stack(L_Z); // not constant since it corresponds to log(Z/Z*) that evolves at each iteration
 
     vpColVector v; // vz, wx
 
@@ -255,8 +255,8 @@ int main(int argc, char **argv)
 
       // Update the global interaction matrix
       vpMatrix L;
-      L.stackMatrices(L_x); // constant since build with the desired feature
-      L.stackMatrices(L_Z); // not constant since it corresponds to log(Z/Z*) that evolves at each iteration
+      L.stack(L_x); // constant since build with the desired feature
+      L.stack(L_Z); // not constant since it corresponds to log(Z/Z*) that evolves at each iteration
 
       // Update the global error s-s*
       vpColVector error;

--- a/example/servo-ptu46/servoPtu46Point2DArtVelocity.cpp
+++ b/example/servo-ptu46/servoPtu46Point2DArtVelocity.cpp
@@ -100,6 +100,7 @@ pthread_mutex_t mutexEndLoop = PTHREAD_MUTEX_INITIALIZER;
 
 void signalCtrC( int signumber )
 {
+  (void)(signumber);
 #ifdef VISP_HAVE_PTHREAD
   pthread_mutex_unlock( &mutexEndLoop );
 #endif
@@ -162,17 +163,15 @@ main()
       return(-1) ;
     }
 
-
     vpServo task ;
 
     vpDot2 dot ;
 
     try{
       vpERROR_TRACE("start dot.initTracking(I) ") ;
-      int x,y;
-      vpDisplay::getClick( I,y,x );
-      dot.set_u( x ) ;
-      dot.set_v( y ) ;
+      vpImagePoint germ;
+      vpDisplay::getClick( I, germ );
+      dot.setCog(germ);
       vpDEBUG_TRACE(25,"Click!");
       //dot.initTracking(I) ;
       dot.track(I);

--- a/example/servo-ptu46/servoPtu46Point2DArtVelocity.cpp
+++ b/example/servo-ptu46/servoPtu46Point2DArtVelocity.cpp
@@ -88,7 +88,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-viper650/servoViper650Point2DCamVelocity.cpp
+++ b/example/servo-viper650/servoViper650Point2DCamVelocity.cpp
@@ -71,7 +71,6 @@
 #include <visp3/robot/vpRobotViper650.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/io/vpImageIo.h>
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-viper850/servoViper850FourPointsKinect.cpp
+++ b/example/servo-viper850/servoViper850FourPointsKinect.cpp
@@ -79,7 +79,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-viper850/servoViper850Point2DArtVelocity-jointAvoidance-basic.cpp
+++ b/example/servo-viper850/servoViper850Point2DArtVelocity-jointAvoidance-basic.cpp
@@ -75,7 +75,6 @@
 #include <visp3/robot/vpRobotViper850.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/blob/vpDot2.h>
 #include <visp3/gui/vpPlot.h>

--- a/example/servo-viper850/servoViper850Point2DArtVelocity-jointAvoidance-gpa.cpp
+++ b/example/servo-viper850/servoViper850Point2DArtVelocity-jointAvoidance-gpa.cpp
@@ -72,7 +72,6 @@
 #include <visp3/robot/vpRobotViper850.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/blob/vpDot2.h>
 #include <visp3/gui/vpPlot.h>

--- a/example/servo-viper850/servoViper850Point2DArtVelocity-jointAvoidance-large.cpp
+++ b/example/servo-viper850/servoViper850Point2DArtVelocity-jointAvoidance-large.cpp
@@ -72,7 +72,6 @@
 #include <visp3/robot/vpRobotViper850.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/blob/vpDot2.h>
 #include <visp3/gui/vpPlot.h>

--- a/example/servo-viper850/servoViper850Point2DArtVelocity.cpp
+++ b/example/servo-viper850/servoViper850Point2DArtVelocity.cpp
@@ -75,7 +75,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-viper850/servoViper850Point2DCamVelocity.cpp
+++ b/example/servo-viper850/servoViper850Point2DCamVelocity.cpp
@@ -71,7 +71,6 @@
 #include <visp3/robot/vpRobotViper850.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/io/vpImageIo.h>
 #include <visp3/blob/vpDot2.h>

--- a/example/servo-viper850/servoViper850Point2DCamVelocityKalman.cpp
+++ b/example/servo-viper850/servoViper850Point2DCamVelocityKalman.cpp
@@ -72,7 +72,6 @@
 #include <visp3/robot/vpRobotViper850.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/vs/vpServoDisplay.h>
 #include <visp3/io/vpImageIo.h>
 #include <visp3/blob/vpDot2.h>

--- a/example/tracking/CMakeLists.txt
+++ b/example/tracking/CMakeLists.txt
@@ -50,7 +50,7 @@ set(example_cpp
   trackMeCircle.cpp
   trackMeEllipse.cpp
   trackMeLine.cpp
-  trackMeNurbs.cpp
+#  trackMeNurbs.cpp
   trackDot.cpp
   trackDot2.cpp
   trackKltOpencv.cpp
@@ -79,7 +79,7 @@ add_test(trackDot2WithAutoDetection trackDot2WithAutoDetection -c ${OPTION_TO_DE
 add_test(trackMeCircle    trackMeCircle -c ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(trackMeEllipse   trackMeEllipse -c ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(trackMeLine      trackMeLine -c ${OPTION_TO_DESACTIVE_DISPLAY})
-add_test(trackMeNurbs     trackMeNurbs -c ${OPTION_TO_DESACTIVE_DISPLAY})
+#add_test(trackMeNurbs     trackMeNurbs -c ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(trackDot         trackDot -c ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(trackDot2        trackDot2 -c ${OPTION_TO_DESACTIVE_DISPLAY})
 

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -1,0 +1,302 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * This class implements an 2D array as a template class.
+ *
+ * Authors:
+ * Fabien Spindler
+ *
+ *****************************************************************************/
+#ifndef __vpArray2D_h_
+#define __vpArray2D_h_
+
+#include <iostream>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <visp3/core/vpConfig.h>
+#include <visp3/core/vpException.h>
+
+/*!
+  \class vpArray2D
+  \ingroup group_core_matrices
+
+  This class implements a 2D array as a template class and all the basic functionalities common to matrices and vectors,
+  but also specific containers such as twist, homogeneous or rotation matrices.
+*/
+template<class Type>
+class vpArray2D
+{
+protected:
+  //! Number of rows in the array
+  unsigned int rowNum;
+  //! Number of columns in the array
+  unsigned int colNum;
+  //! Address of the first element of each rows
+  Type **rowPtrs;
+  //! Current array size (rowNum * colNum)
+  unsigned int dsize;
+
+public:
+  //! Address of the first element of the data array
+  Type *data;
+
+public:
+  /*!
+  Basic constructor of a 2D array.
+  Number of columns and rows are set to zero.
+  */
+  vpArray2D<Type>()
+    : rowNum(0), colNum(0), rowPtrs(NULL), dsize(0), data(NULL)
+  {}
+  /*!
+  Copy constructor of a 2D array.
+  */
+  vpArray2D<Type>(const vpArray2D<Type> & A)
+    : rowNum(0), colNum(0), rowPtrs(NULL), dsize(0), data(NULL)
+  {
+    resize(A.rowNum, A.colNum);
+    memcpy(data, A.data, rowNum*colNum*sizeof(Type));
+  }
+  /*!
+  Constructor that initializes a 2D array with 0.
+
+  \param r : Array number of rows.
+  \param c : Array number of columns.
+  */
+  vpArray2D<Type>(unsigned int r, unsigned int c)
+    : rowNum(0), colNum(0), rowPtrs(NULL), dsize(0), data(NULL)
+  {
+    resize(r, c);
+  }
+  /*!
+  Constructor that initialize a 2D array with \e val.
+
+  \param r : Array number of rows.
+  \param c : Array number of columns.
+  \param val : Each element of the array is set to \e val.
+  */
+  vpArray2D<Type>(unsigned int r, unsigned int c, Type val)
+    : rowNum(0), colNum(0), rowPtrs(NULL), dsize(0), data(NULL)
+  {
+    resize(r, c);
+    *this = val;
+  }
+  /*!
+  Destructor that desallocate memory.
+  */
+  virtual ~vpArray2D<Type>()
+  {
+    if (data != NULL ) {
+      free(data);
+      data=NULL;
+    }
+
+    if (rowPtrs!=NULL) {
+      free(rowPtrs);
+      rowPtrs=NULL ;
+    }
+    rowNum = colNum = dsize = 0;
+  }
+
+  /** @name Common inherited functionalities  */
+  //@{
+
+  Type getMinValue() const;
+
+  Type getMaxValue() const;
+
+  //! Return the number of rows of the 2D array
+  inline unsigned int getRows() const { return rowNum ;}
+  //! Return the number of columns of the 2D array
+  inline unsigned int getCols() const { return colNum; }
+  //! Return the number of elements of the 2D array.
+  inline unsigned int size() const { return colNum*rowNum; }
+  /*!
+  Set the size of the array and initialize all the values to zero.
+
+  \param nrows : number of rows.
+  \param ncols : number of column.
+  \param flagNullify : if true, then the array is re-initialized to 0
+  after resize. If false, the initial values from the common part of the
+  array (common part between old and new version of the array) are kept.
+  Default value is true.
+  */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    if ((nrows == rowNum) && (ncols == colNum)) {
+      if (flagNullify && this->data != NULL) {
+        memset(this->data, 0, this->dsize*sizeof(Type));
+      }
+    }
+    else {
+      const bool recopyNeeded = (ncols != this ->colNum);
+      Type * copyTmp = NULL;
+      unsigned int rowTmp = 0, colTmp=0;
+
+      // Recopy case per case is required if number of cols has changed;
+      // structure of Type array is not the same in this case.
+      if (recopyNeeded && this->data != NULL) {
+        copyTmp = new Type[this->dsize];
+        memcpy (copyTmp, this ->data, sizeof(Type)*this->dsize);
+        rowTmp=this->rowNum; colTmp=this->colNum;
+      }
+
+      // Reallocation of this->data array
+      this->dsize = nrows*ncols;
+      this->data = (Type*)realloc(this->data, this->dsize*sizeof(Type));
+      if ((NULL == this->data) && (0 != this->dsize)) {
+        if (copyTmp != NULL) delete [] copyTmp;
+        throw(vpException(vpException::memoryAllocationError,
+          "Memory allocation error when allocating 2D array data")) ;
+      }
+
+      this->rowPtrs = (Type**)realloc (this->rowPtrs, nrows*sizeof(Type*));
+      if ((NULL == this->rowPtrs) && (0 != this->dsize)) {
+        if (copyTmp != NULL) delete [] copyTmp;
+        throw(vpException(vpException::memoryAllocationError,
+          "Memory allocation error when allocating 2D array rowPtrs")) ;
+      }
+
+      // Update rowPtrs
+      {
+        Type **t_= rowPtrs;
+        for (unsigned int i=0; i<dsize; i+=ncols)  {
+          *t_++ = this->data + i;
+        }
+      }
+
+      this->rowNum = nrows; this->colNum = ncols;
+
+      // Recopy of this->data array values or nullify
+      if (flagNullify) {
+        memset(this->data,0,this->dsize*sizeof(Type));
+      }
+      else if (recopyNeeded && this->rowPtrs != NULL) {
+        // Recopy...
+        const unsigned int minRow = (this->rowNum<rowTmp)?this->rowNum:rowTmp;
+        const unsigned int minCol = (this->colNum<colTmp)?this->colNum:colTmp;
+        for (unsigned int i=0; i<this->rowNum; ++i) {
+          for (unsigned int j=0; j<this->colNum; ++j) {
+            if ((minRow > i) && (minCol > j)) {
+              (*this)[i][j] = copyTmp [i*colTmp+j];
+            }
+            else {
+              (*this)[i][j] = 0;
+            }
+          }
+        }
+      }
+
+      if (copyTmp != NULL)
+        delete [] copyTmp;
+    }
+  }
+  //! Set all the elements of the array to \e x.
+  vpArray2D<Type> & operator=(Type x)
+  {
+    for (unsigned int i=0;i<rowNum;i++)
+      for(unsigned int j=0;j<colNum;j++)
+        rowPtrs[i][j] = x;
+
+    return *this;
+  }
+
+  //! Set element \f$A_{ij} = x\f$ using A[i][j] = x
+  inline Type *operator[](unsigned int i) { return rowPtrs[i]; }
+  //! Get element \f$x = A_{ij}\f$ using x = A[i][j]
+  inline Type *operator[](unsigned int i) const {return rowPtrs[i];}
+
+  /*!
+    \relates vpArray2D
+    Writes the given array to the output stream and returns a reference to the output stream.
+    */
+  friend VISP_EXPORT std::ostream &operator<<(std::ostream &s, const vpArray2D<Type> &A)
+  {
+    if (A.data == NULL)
+      return s;
+    std::ios_base::fmtflags original_flags = s.flags();
+
+    s.precision(10) ;
+    for (unsigned int i=0;i<A.getRows();i++) {
+      for (unsigned int j=0;j<A.getCols();j++){
+        s <<  A[i][j] << "  ";
+      }
+      // We don't add a \n char on the end of the last array line
+      if (i < A.getRows()-1)
+        s << std::endl;
+    }
+
+    s.flags(original_flags); // restore s to standard state
+
+    return s;
+  }
+  //@}
+};
+
+/*!
+ Return the array min value.
+ */
+template<class Type>
+Type
+vpArray2D<Type>::getMinValue() const
+{
+  Type *dataptr = data;
+  Type min = *dataptr;
+  dataptr++;
+  for (unsigned int i = 0; i < dsize-1; i++)
+  {
+    if (*dataptr < min) min = *dataptr;
+    dataptr++;
+  }
+  return min;
+}
+
+/*!
+ Return the array max value.
+ */
+template<class Type>
+Type
+vpArray2D<Type>::getMaxValue() const
+{
+  Type *dataptr = data;
+  Type max = *dataptr;
+  dataptr++;
+  for (unsigned int i = 0; i < dsize-1; i++)
+  {
+    if (*dataptr > max) max = *dataptr;
+    dataptr++;
+  }
+  return max;
+}
+
+#endif

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -326,8 +326,8 @@ public:
         file >> rows;
         file >> cols;
 
-        if (rows > std::numeric_limits<unsigned int>::max()
-            || cols > std::numeric_limits<unsigned int>::max())
+        if (rows > (std::numeric_limits<unsigned int>::max)()
+            || cols > (std::numeric_limits<unsigned int>::max)())
           throw vpException(vpException::badValue, "Array exceed the max size.");
 
         A.resize(rows,cols);

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -602,7 +602,6 @@ public:
     return true;
   }
   //@}
-
 };
 
 /*!

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -40,12 +40,14 @@
 #ifndef vpColVector_H
 #define vpColVector_H
 
-#include <visp3/core/vpMatrix.h>
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpRowVector.h>
 #include <visp3/core/vpMath.h>
 
 class vpMatrix;
 class vpRotationVector;
+class vpRowVector;
+class vpTranslationVector;
 
 /*!
   \file vpColVector.h
@@ -56,162 +58,238 @@ class vpRotationVector;
 /*!
   \class vpColVector
   \ingroup group_core_matrices
-  \brief Class that provides a data structure for the column vectors
-  as well as a set of operations on these vectors.
+  This class provides a data structure for a column vector that contains values of double.
+  It contains also some functions to achieve a set of operations on these vectors.
 
-  the vpColVector is derived from vpMatrix.
-
-  \author Eric Marchand   (Eric.Marchand@irisa.fr) Irisa / Inria Rennes
-
-  \warning Note the vector in the class (*this) will be noted A in the comment
+  The vpColVector is derived from vpArray2D.
 */
-class VISP_EXPORT vpColVector : public vpMatrix
+class VISP_EXPORT vpColVector : public vpArray2D<double>
 {
    friend class vpMatrix;
-protected:
-  vpColVector (const vpMatrix &m, unsigned int j);
-  vpColVector (const vpColVector &m, unsigned int r, unsigned int nrows) ;
-
 public:
 
-  //! Basic constructor.
-  vpColVector() : vpMatrix() {};
-  //! Constructor of vector of size n. Each element is set to 0.
-  vpColVector(unsigned int n) : vpMatrix(n,1){};
-  //! Constructor of vector of size n. Each element is set to \e val.
-  vpColVector(unsigned int n, double val) : vpMatrix(n, 1, val){};
-  //! Copy constructor.
-  vpColVector (const vpColVector &v);
-  //! Constructor that initialize a vpColVector from a vpRotationVector.
-  vpColVector (const vpRotationVector &v);
-
-  void insert(unsigned int i, const vpColVector &v);
-
-  /*! Set the size of the column vector.
-    \param i : Column vector size.
-    \param flagNullify : If true, set the data to zero.
-   */
-  void resize(const unsigned int i, const bool flagNullify = true)
-  {
-    vpMatrix::resize(i, 1, flagNullify);
-  }
-
-  //! Access  V[i] = x
-  inline double &operator [](unsigned int n) {  return *(data + n);  }
-  //! Access x = V[i]
-  inline const double &operator [](unsigned int n) const { return *(data+n);  }
-  //! Copy operator.   Allow operation such as A = v
-  vpColVector &operator=(const vpColVector &v);
-  // Copy from a matrix.
-  vpColVector &operator=(const vpMatrix &m);
-  //! Initialize each element of the vector to x
-  vpColVector &operator=(double x);
-  // Copy operator.   Allow operation such as A << v
-  vpColVector &operator<<(const vpColVector &v);
-  // Assigment operator.   Allow operation such as A = *v
-  vpColVector &operator<<(double *);
-
-  //! Addition of two vectors V = A+v
-  vpColVector operator+(const vpColVector &v) const;
-  //! Substraction of two vectors V = A-v
-  vpColVector operator-(const vpColVector &v) const;
-  //! Operator A = -A
-  vpColVector operator-() const;
-  //! Dot product
-  double  operator*(const vpColVector &x) const;
-  //! Dot product
-  vpMatrix  operator*(const vpRowVector &x) const;
-  //! Multiplication by a scalar V =  A * x
-  vpColVector operator*(const double x) const;
-
-  vpColVector rows(unsigned int first_row, unsigned int last_row) const
-  { 
-    return vpColVector(*this, first_row-1, last_row-first_row+1);
-  }
-
-  //! Reshape methods
-  void reshape(vpMatrix & m,
-	       const unsigned int &nrows, const unsigned int &ncols);
-  vpMatrix reshape(const unsigned int &nrows, const unsigned int &ncols);
-
-  void stack(const double &b);
-  void stack(const vpColVector &B);
-  static vpColVector stack(const vpColVector &A, const vpColVector &B);
-  static void stack(const vpColVector &A, const vpColVector &B, vpColVector &C);
-
-  //! Transpose of a vector
-  vpRowVector t() const;
-
-  //! Normalise the vector
-  vpColVector &normalize() ;
-  // normalise the vector
-  //  vpColVector &normalize(vpColVector &x) const ;
-
-  //! Compute the cross product of two vectors C = a x b
-  static vpColVector crossProd(const vpColVector &a, const vpColVector &b)  ;
-  
-  // Compute the cross product of two vectors C = a x b
-  inline static vpColVector cross(const vpColVector &a, const vpColVector &b){
-                                  return crossProd(a,b);}
-  
-  // Compute the skew matrix [v]x
-  static vpMatrix skew(const vpColVector &v);
-  //! Dot Product
-  
-  static double dotProd(const vpColVector &a, const vpColVector &b)  ;
- 
-  //! sort the elements of vector v
-  static vpColVector  sort(const vpColVector &v)  ;
-  //! reverse sorting of the elements of vector v
-  static vpColVector invSort(const vpColVector &v)  ;
-  //! compute the median
-  static double median(const vpColVector &v) ;
-  //! compute the mean
-  static double mean(const vpColVector &v)  ;
-  //! compute the standard deviation
-  static double stdev(const vpColVector &v, const bool useBesselCorrection=false);
+   //! Basic constructor that creates an empty 0-size column vector.
+  vpColVector() : vpArray2D<double>() {};
+  //! Construct a column vector of size n. All the elements are initialized to zero.
+  vpColVector(unsigned int n) : vpArray2D<double>(n,1){};
+  //! Construct a column vector of size n. Each element is set to \e val.
+  vpColVector(unsigned int n, double val) : vpArray2D<double>(n, 1, val){};
+  //! Copy constructor that allows to construct a column vector from an other one.
+  vpColVector(const vpColVector &v) : vpArray2D<double>(v) {};
+  vpColVector(const vpColVector &v, unsigned int r, unsigned int nrows) ;
+  //! Constructor that initialize a column vector from a 3-dim rotation vector.
+  vpColVector(const vpRotationVector &v);
+  //! Constructor that initialize a column vector from a 3-dim translation vector.
+  vpColVector(const vpTranslationVector &t);
+  vpColVector(const vpMatrix &M);
+  vpColVector(const vpMatrix &M, unsigned int j);
+  vpColVector(const std::vector<double> &v);
+  vpColVector(const std::vector<float> &v);
 
   /*!
-
-    Convert a column vector containing angles in radians into
-    degrees.
-
+    Removes all elements from the vector (which are destroyed),
+    leaving the container with a size of 0.
   */
-  inline void rad2deg() {
-    double r2d = 180.0/M_PI;
+  void clear()
+  {
+    if (data != NULL ) {
+      free(data);
+      data=NULL;
+    }
 
-    for (unsigned int i=0; i < rowNum; i++)
-      (*this)[i] *= r2d;
+    if (rowPtrs!=NULL) {
+      free(rowPtrs);
+      rowPtrs=NULL ;
+    }
+    rowNum = colNum = dsize = 0;
   }
+
   /*!
     Convert a column vector containing angles in degrees into radians.
-
+    \sa rad2deg()
   */
   inline void deg2rad() {
     double d2r = M_PI/180.0;
 
-    for (unsigned int i=0; i < rowNum; i++)
-      (*this)[i] *= d2r;
+    (*this) *= d2r;
   }
+
+  double euclideanNorm() const;
+  /*!
+     Extract a sub-column vector from a column vector.
+     \param r : Index of the row corresponding to the first element of the vector to extract.
+     \param size : Size of the vector to extract.
+     \exception vpException::fatalError If the vector to extract is not contained in the original one.
+
+     \code
+     vpColVector v1;
+     for (unsigned int i=0; i<4; i++)
+       v1.stack(i);
+     // v1 is equal to [0 1 2 3]^T
+     vpColVector v2 = v1.extract(1, 3);
+     // v2 is equal to [1 2 3]^T
+     \endcode
+   */
+  vpColVector extract(unsigned int r, unsigned int size) const
+  {
+    if (r >= rowNum || r+size > rowNum) {
+      throw(vpException(vpException::fatalError,
+                        "Cannot extract a (%dx1) column vector from a (%dx1) column vector starting at index %d",
+                        size, rowNum, r));
+    }
+
+    return vpColVector(*this, r, size);
+  }
+
+  double infinityNorm() const;
+  void init(const vpColVector &v, unsigned int r, unsigned int nrows);
+  void insert(unsigned int i, const vpColVector &v);
+
+  vpColVector &normalize() ;
+  vpColVector &normalize(vpColVector &x) const ;
+
+  //! Operator that allows to set a value of an element \f$v_i\f$: v[i] = x
+  inline double &operator[](unsigned int n) {  return *(data + n);  }
+  //! Operator that allows to get the value of an element \f$v_i\f$: x = v[i]
+  inline const double &operator[](unsigned int n) const { return *(data+n);  }
+  //! Copy operator.   Allow operation such as A = v
+  vpColVector &operator=(const vpColVector &v);
+  vpColVector &operator=(const vpTranslationVector &t);
+  vpColVector &operator=(const vpMatrix &M);
+  vpColVector &operator=(const std::vector<double> &v);
+  vpColVector &operator=(const std::vector<float> &v);
+  vpColVector &operator=(double x);
+
+  double operator*(const vpColVector &x) const;
+  vpMatrix  operator*(const vpRowVector &v) const;
+  vpColVector operator*(const double x) const;
+  vpColVector &operator*=(double x);
+
+  vpColVector operator/(const double x) const;
+  vpColVector &operator/=(double x);
+
+  vpColVector operator+(const vpColVector &v) const;
+  vpColVector &operator+=(vpColVector v);
+
+  vpColVector operator-(const vpColVector &v) const;
+  vpColVector &operator-=(vpColVector v);
+  vpColVector operator-() const;
+
+  vpColVector &operator<<(const vpColVector &v);
+  vpColVector &operator<<(double *);
+
+  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
 
   /*!
-
-    Return the size of the vector in term of number of rows.
-
+    Convert a column vector containing angles in radians into degrees.
+    \sa deg2rad()
   */
-  inline unsigned int size() const
-  {
-    return getRows();
+  inline void rad2deg() {
+    double r2d = 180.0/M_PI;
+
+    (*this) *= r2d;
   }
 
+  void reshape(vpMatrix & M, const unsigned int &nrows, const unsigned int &ncols);
+  vpMatrix reshape(const unsigned int &nrows, const unsigned int &ncols);
+
+  /*! Modify the size of the column vector.
+    \param i : Size of the vector. This value corresponds to the vector number
+    of rows.
+    \param flagNullify : If true, set the data to zero.
+   */
+  void resize(const unsigned int i, const bool flagNullify = true)
+  {
+    vpArray2D<double>::resize(i, 1, flagNullify);
+  }
+  /*!
+    Resize the column vector to a \e nrows-dimension vector.
+    This function can only be used with \e ncols = 1.
+    \param nrows : Vector number of rows. This value corresponds
+    to the size of the vector.
+    \param ncols : Vector number of columns. This value should be set to 1.
+    \param flagNullify : If true, set the data to zero.
+    \exception vpException::fatalError When \e ncols is not equal to 1.
+
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    if (ncols != 1)
+      throw(vpException(vpException::fatalError,
+                        "Cannot resize a column vector to a (%dx%d) dimension vector that has more than one column",
+                        nrows, ncols));
+    vpArray2D::resize(nrows, ncols, flagNullify);
+  };
+
+  void stack(const double &d);
+  void stack(const vpColVector &v);
+
+  double sumSquare() const;
+  vpRowVector t() const;
+
+  /*!
+     Compute and return the cross product of two 3-dimension vectors: \f$a \times b\f$.
+     \param a : 3-dimension column vector.
+     \param b : 3-dimension column vector.
+     \return The cross product \f$a \times b\f$.
+
+     \exception vpException::dimensionError If the vectors dimension is not equal to 3.
+
+   */
+  inline static vpColVector cross(const vpColVector &a, const vpColVector &b)
+  {
+    return crossProd(a,b);
+  }
+  static vpColVector crossProd(const vpColVector &a, const vpColVector &b)  ;
+
+  static double dotProd(const vpColVector &a, const vpColVector &b)  ;
+  static vpColVector invSort(const vpColVector &v)  ;
+  static double median(const vpColVector &v) ;
+  static double mean(const vpColVector &v)  ;
+  // Compute the skew matrix [v]x
+  static vpMatrix skew(const vpColVector &v);
+
+  static vpColVector sort(const vpColVector &v)  ;
+
+  static vpColVector stack(const vpColVector &A, const vpColVector &B);
+  static void stack(const vpColVector &A, const vpColVector &B, vpColVector &C);
+
+  static double stdev(const vpColVector &v, const bool useBesselCorrection=false);
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use extract().
+   */
+  vp_deprecated vpColVector rows(unsigned int first_row, unsigned int last_row) const
+  {
+     return vpColVector(*this, first_row-1, last_row-first_row+1);
+  }
+  /*!
+     \deprecated You should rather use eye()
+   */
+  vp_deprecated void setIdentity(const double & val=1.0) ;
+  /*!
+     \deprecated You should rather use stack(const vpColVector &)
+   */
+  vp_deprecated void stackMatrices(const vpColVector &r) { stack(r); };
+  /*!
+     \deprecated You should rather use stack(const vpColVector &A, const vpColVector &B)
+   */
+  vp_deprecated static vpColVector stackMatrices(const vpColVector &A, const vpColVector &B) { return stack(A, B); };
+  /*!
+     \deprecated You should rather use stack(const vpColVector &A, const vpColVector &B, vpColVector &C)
+   */
+  vp_deprecated static void stackMatrices(const vpColVector &A, const vpColVector &B, vpColVector &C) { stack(A, B, C); };
+
+  //@}
+#endif
 };
 
+VISP_EXPORT vpColVector operator*(const double &x, const vpColVector &v) ;
 
 #endif
-
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -255,13 +255,18 @@ public:
   static vpColVector stack(const vpColVector &A, const vpColVector &B);
   static void stack(const vpColVector &A, const vpColVector &B, vpColVector &C);
 
-  static double stdev(const vpColVector &v, const bool useBesselCorrection=false);
+  static double stdev(const vpColVector &v, const bool useBesselCorrection=false);  
 
 #if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
   /*!
     @name Deprecated functions
   */
   //@{
+  /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
   /*!
      \deprecated You should rather use extract().
    */

--- a/modules/core/include/visp3/core/vpForceTwistMatrix.h
+++ b/modules/core/include/visp3/core/vpForceTwistMatrix.h
@@ -39,7 +39,7 @@
 #ifndef vpForceTwistMatrix_h
 #define vpForceTwistMatrix_h
 
-#include <visp3/core/vpMatrix.h>
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
 #include <visp3/core/vpRotationMatrix.h>
@@ -50,11 +50,11 @@
 
   \ingroup group_core_transformations
 
-  \brief Class that consider the particular case of twist
+  Class that consider the particular case of twist
   transformation matrix that allows to transform a force/troque vector
   from one frame to an other.
 
-  The vpForceTwistMatrix is derived from vpMatrix.
+  The vpForceTwistMatrix is derived from vpArray2D.
 
   The twist transformation matrix that allows to transform the
   force/torque vector expressed at frame \f${\cal F}_b\f$ into the
@@ -97,13 +97,13 @@ int main()
 }
   \endcode
 */
-class VISP_EXPORT vpForceTwistMatrix : public vpMatrix
+class VISP_EXPORT vpForceTwistMatrix : public vpArray2D<double>
 {
-  friend class vpMatrix;
+  friend class vpArray2D;
 
  public:
   // basic constructor
-  vpForceTwistMatrix()   ;
+  vpForceTwistMatrix();
   // copy constructor
   vpForceTwistMatrix(const vpForceTwistMatrix &F) ;
   // constructor from an homogeneous transformation
@@ -113,20 +113,17 @@ class VISP_EXPORT vpForceTwistMatrix : public vpMatrix
   vpForceTwistMatrix(const vpTranslationVector &t, const vpThetaUVector &thetau) ;
   // Construction from Translation and rotation (matrix parameterization)
   vpForceTwistMatrix(const vpTranslationVector &t, const vpRotationMatrix &R) ;
-  vpForceTwistMatrix(const double tx,   const double ty,   const double tz,
-		     const double tux,  const double tuy,  const double tuz) ;
-
-  // Basic initialisation (identity)
-  void init() ;
+  vpForceTwistMatrix(const double tx,  const double ty,  const double tz,
+                     const double tux, const double tuy, const double tuz) ;
 
   vpForceTwistMatrix buildFrom(const vpTranslationVector &t,
-			       const vpRotationMatrix &R);
+                               const vpRotationMatrix &R);
   vpForceTwistMatrix buildFrom(const vpTranslationVector &t,
-			       const vpThetaUVector &thetau);
+                               const vpThetaUVector &thetau);
   vpForceTwistMatrix buildFrom(const vpHomogeneousMatrix &M) ;
 
   // Basic initialisation (identity)
-  void setIdentity() ;
+  void eye() ;
 
   vpForceTwistMatrix operator*(const vpForceTwistMatrix &F) const ;
   vpMatrix operator*(const vpMatrix &M) const ;
@@ -135,12 +132,34 @@ class VISP_EXPORT vpForceTwistMatrix : public vpMatrix
 
   // copy operator from vpMatrix (handle with care)
   vpForceTwistMatrix &operator=(const vpForceTwistMatrix &H);
+
+  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
+
+  /*!
+    This function is not applicable to a velocity twist matrix that is always a
+    6-by-6 matrix.
+    \exception vpException::fatalError When this function is called.
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    (void)nrows;
+    (void)ncols;
+    (void)flagNullify;
+    throw(vpException(vpException::fatalError, "Cannot resize a velocity twist matrix"));
+  };
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use eye().
+   */
+  vp_deprecated void setIdentity();
+  //@}
+#endif
 } ;
 
 #endif
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */

--- a/modules/core/include/visp3/core/vpForceTwistMatrix.h
+++ b/modules/core/include/visp3/core/vpForceTwistMatrix.h
@@ -153,6 +153,11 @@ class VISP_EXPORT vpForceTwistMatrix : public vpArray2D<double>
   */
   //@{
   /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
+  /*!
      \deprecated You should rather use eye().
    */
   vp_deprecated void setIdentity();

--- a/modules/core/include/visp3/core/vpForceTwistMatrix.h
+++ b/modules/core/include/visp3/core/vpForceTwistMatrix.h
@@ -99,8 +99,6 @@ int main()
 */
 class VISP_EXPORT vpForceTwistMatrix : public vpArray2D<double>
 {
-  friend class vpArray2D;
-
  public:
   // basic constructor
   vpForceTwistMatrix();

--- a/modules/core/include/visp3/core/vpGEMM.h
+++ b/modules/core/include/visp3/core/vpGEMM.h
@@ -39,12 +39,10 @@
 #ifndef __VP_GEMM__
 #define __VP_GEMM__
 
-#include <visp3/core/vpMatrix.h>
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
-#include <visp3/core/vpDebug.h>
 
-const vpMatrix null(0,0);
+const vpArray2D<double> vpArrayNull(0,0);
 
 /*!
   \brief Enumeration of the operations applied on matrices in vpGEMM function.
@@ -54,7 +52,7 @@ const vpMatrix null(0,0);
   - VP_GEMM_B_T to use the transpose matrix of B instead of the matrix B
   - VP_GEMM_C_T to use the transpose matrix of C instead of the matrix C
   
-  \relates vpMatrix
+  \relates vpArray2D
   */
 typedef enum {
   VP_GEMM_A_T=1, //! Use A^T instead of A
@@ -65,56 +63,56 @@ typedef enum {
 
 
 
-template<unsigned int> inline void GEMMsize(const vpMatrix & /*A*/,const vpMatrix & /*B*/, unsigned int &/*Arows*/,  unsigned int &/*Acols*/, unsigned int &/*Brows*/,  unsigned int &/*Bcols*/){}
+template<unsigned int> inline void GEMMsize(const vpArray2D<double> & /*A*/,const vpArray2D<double> & /*B*/, unsigned int &/*Arows*/,  unsigned int &/*Acols*/, unsigned int &/*Brows*/,  unsigned int &/*Bcols*/){}
 
- template<> void inline GEMMsize<0>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> void inline GEMMsize<0>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getRows();
   Acols= A.getCols();
   Brows= B.getRows();
   Bcols= B.getCols();
 }
 
- template<> inline void GEMMsize<1>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<1>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getCols();
   Acols= A.getRows();
   Brows= B.getRows();
   Bcols= B.getCols();
 }
- template<> inline void GEMMsize<2>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<2>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getRows();
   Acols= A.getCols();
   Brows= B.getCols();
   Bcols= B.getRows();
 }
- template<> inline void GEMMsize<3>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<3>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getCols();
   Acols= A.getRows();
   Brows= B.getCols();
   Bcols= B.getRows();
 }
 
- template<> inline void GEMMsize<4>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<4>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getRows();
   Acols= A.getCols();
   Brows= B.getRows();
   Bcols= B.getCols();
 }
 
- template<> inline void GEMMsize<5>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<5>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getCols();
   Acols= A.getRows();
   Brows= B.getRows();
   Bcols= B.getCols();
 }
 
- template<> inline void GEMMsize<6>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<6>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getRows();
   Acols= A.getCols();
   Brows= B.getCols();
   Bcols= B.getRows();
 }
 
- template<> inline void GEMMsize<7>(const vpMatrix & A,const vpMatrix & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
+template<> inline void GEMMsize<7>(const vpArray2D<double> & A,const vpArray2D<double> & B, unsigned int &Arows, unsigned int &Acols, unsigned int &Brows, unsigned int &Bcols){
   Arows= A.getCols();
   Acols= A.getRows();
   Brows= B.getCols();
@@ -123,146 +121,147 @@ template<unsigned int> inline void GEMMsize(const vpMatrix & /*A*/,const vpMatri
 
 
 
- template<unsigned int> inline void GEMM1(const unsigned int &/*Arows*/,const unsigned int &/*Brows*/, const unsigned int &/*Bcols*/, const vpMatrix & /*A*/, const vpMatrix & /*B*/, const double & /*alpha*/,vpMatrix &/*D*/){}
+template<unsigned int> inline void GEMM1(const unsigned int &/*Arows*/,const unsigned int &/*Brows*/, const unsigned int &/*Bcols*/, const vpArray2D<double> & /*A*/, const vpArray2D<double> & /*B*/, const double & /*alpha*/,vpArray2D<double> &/*D*/){}
 
- template<> inline void GEMM1<0>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A, const vpMatrix & B, const double & alpha,vpMatrix &D){
+template<> inline void GEMM1<0>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A, const vpArray2D<double> & B, const double & alpha,vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[r][n]*B[n][c]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[r][n]*B[n][c]*alpha;
       D[r][c]=sum;
     }
 }
 
- template<> inline void GEMM1<1>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A, const vpMatrix & B, const double & alpha,vpMatrix &D){
+template<> inline void GEMM1<1>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A, const vpArray2D<double> & B, const double & alpha,vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[n][r]*B[n][c]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[n][r]*B[n][c]*alpha;
       D[r][c]=sum;
     }
 }
 
- template<> inline void GEMM1<2>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha,vpMatrix &D){
+template<> inline void GEMM1<2>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha,vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[r][n]*B[c][n]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[r][n]*B[c][n]*alpha;
       D[r][c]=sum;
     }
 }
 
- template<> inline void GEMM1<3>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha,vpMatrix &D){
+template<> inline void GEMM1<3>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha,vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[n][r]*B[c][n]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[n][r]*B[c][n]*alpha;
       D[r][c]=sum;
     }
 }
 
- template<unsigned int> inline void GEMM2(const unsigned int &/*Arows*/,const unsigned int &/*Brows*/, const unsigned int &/*Bcols*/, const vpMatrix & /*A*/,const vpMatrix & /*B*/, const double & /*alpha*/, const vpMatrix & /*C*/ , const double &/*beta*/, vpMatrix &/*D*/){}
+template<unsigned int> inline void GEMM2(const unsigned int &/*Arows*/,const unsigned int &/*Brows*/, const unsigned int &/*Bcols*/, const vpArray2D<double> & /*A*/,const vpArray2D<double> & /*B*/, const double & /*alpha*/, const vpArray2D<double> & /*C*/ , const double &/*beta*/, vpArray2D<double> &/*D*/){}
 
- template<> inline void GEMM2<0>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
+template<> inline void GEMM2<0>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
   
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[r][n]*B[n][c]*alpha;
-      D[r][c]=sum+C[r][c]*beta;
-    } 
-}
-
- template<> inline void GEMM2<1>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
-  for(unsigned int r=0;r<Arows;r++)
-    for(unsigned int c=0;c<Bcols;c++){
-      double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[n][r]*B[n][c]*alpha;
-	D[r][c]=sum+C[r][c]*beta;
-    }
-}
-
- template<> inline void GEMM2<2>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
-  for(unsigned int r=0;r<Arows;r++)
-    for(unsigned int c=0;c<Bcols;c++){
-      double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[r][n]*B[c][n]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[r][n]*B[n][c]*alpha;
       D[r][c]=sum+C[r][c]*beta;
     }
 }
 
- template<> inline void GEMM2<3>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
+template<> inline void GEMM2<1>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[n][r]*B[c][n]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[n][r]*B[n][c]*alpha;
       D[r][c]=sum+C[r][c]*beta;
-    } 
+    }
+}
+
+template<> inline void GEMM2<2>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
+  for(unsigned int r=0;r<Arows;r++)
+    for(unsigned int c=0;c<Bcols;c++){
+      double sum=0;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[r][n]*B[c][n]*alpha;
+      D[r][c]=sum+C[r][c]*beta;
+    }
+}
+
+template<> inline void GEMM2<3>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
+  for(unsigned int r=0;r<Arows;r++)
+    for(unsigned int c=0;c<Bcols;c++){
+      double sum=0;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[n][r]*B[c][n]*alpha;
+      D[r][c]=sum+C[r][c]*beta;
+    }
 }
 
 
- template<> inline void GEMM2<4>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
+template<> inline void GEMM2<4>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[r][n]*B[n][c]*alpha;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[r][n]*B[n][c]*alpha;
       D[r][c]=sum+C[c][r]*beta;
     }
 }
 
- template<> inline void GEMM2<5>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
+template<> inline void GEMM2<5>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[n][r]*B[n][c]*alpha;
-	D[r][c]=sum+C[c][r]*beta;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[n][r]*B[n][c]*alpha;
+      D[r][c]=sum+C[c][r]*beta;
     }
-    
+
 }
 
- template<> inline void GEMM2<6>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
+template<> inline void GEMM2<6>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
   for(unsigned int r=0;r<Arows;r++)
     for(unsigned int c=0;c<Bcols;c++){
       double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[r][n]*B[c][n]*alpha;
-	D[r][c]=sum+C[c][r]*beta;
-    } 
-}
-
- template<> inline void GEMM2<7>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpMatrix & A,const vpMatrix & B, const double & alpha, const vpMatrix & C , const double &beta, vpMatrix &D){
-  //vpMatrix &D = *dynamic_cast<double***>(Dptr);
-  for(unsigned int r=0;r<Arows;r++)
-    for(unsigned int c=0;c<Bcols;c++){
-      double sum=0;
-            for(unsigned int n=0;n<Brows;n++)
-	sum+=A[n][r]*B[c][n]*alpha;
-	D[r][c]=sum+C[c][r]*beta;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[r][n]*B[c][n]*alpha;
+      D[r][c]=sum+C[c][r]*beta;
     }
 }
 
- template<unsigned int T> inline  void vpTGEMM(const vpMatrix & A,const vpMatrix & B, const double & alpha ,const vpMatrix & C, const double & beta, vpMatrix & D){
-  
+template<> inline void GEMM2<7>(const unsigned int &Arows,const unsigned int &Brows, const unsigned int &Bcols, const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha, const vpArray2D<double> & C , const double &beta, vpArray2D<double> &D){
+  //vpArray2D<double> &D = *dynamic_cast<double***>(Dptr);
+  for(unsigned int r=0;r<Arows;r++)
+    for(unsigned int c=0;c<Bcols;c++){
+      double sum=0;
+      for(unsigned int n=0;n<Brows;n++)
+        sum+=A[n][r]*B[c][n]*alpha;
+      D[r][c]=sum+C[c][r]*beta;
+    }
+}
+
+template<unsigned int T> inline
+void vpTGEMM(const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha ,const vpArray2D<double> & C, const double & beta, vpArray2D<double> & D)
+{
   unsigned int Arows;
   unsigned int Acols;
   unsigned int Brows;
   unsigned int Bcols;
   
-//   std::cout << T << std::endl;
+  //   std::cout << T << std::endl;
   GEMMsize<T>(A,B,Arows,Acols,Brows,Bcols);
-//   std::cout << Arows<<" " <<Acols << " "<< Brows << " "<< Bcols<<std::endl;
+  //   std::cout << Arows<<" " <<Acols << " "<< Brows << " "<< Bcols<<std::endl;
   
-  try 
+  try
   {
     if ((Arows != D.getRows()) || (Bcols != D.getCols())) D.resize(Arows,Bcols);
   }
@@ -275,16 +274,18 @@ template<unsigned int> inline void GEMMsize(const vpMatrix & /*A*/,const vpMatri
   
   if (Acols != Brows)
   {
-    vpERROR_TRACE("\n\t\tvpMatrix mismatch size in vpGEMM") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,"\n\t\tvpMatrix mismatch size in vpGEMM")) ;
+    throw(vpException(vpException::dimensionError,
+                      "In vpGEMM, cannot multiply (%dx%d) matrix by (%dx%d) matrix",
+                      Arows, Acols, Brows, Bcols)) ;
   }
   
   if(C.getRows()!=0 && C.getCols()!=0){
 
     if ((Arows != C.getRows()) || (Bcols != C.getCols()))
     {
-      vpERROR_TRACE("\n\t\tvpMatrix mismatch size in vpGEMM") ;
-      throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,"\n\t\tvpMatrix mismatch size in vpGEMM")) ;
+      throw(vpException(vpException::dimensionError,
+                        "In vpGEMM, cannot add resulting (%dx%d) matrix to (%dx%d) matrix",
+                        Arows, Bcols, C.getRows(), C.getCols())) ;
     }
     
     
@@ -296,7 +297,7 @@ template<unsigned int> inline void GEMMsize(const vpMatrix & /*A*/,const vpMatri
 }
 
 /*!
-  \brief This function performs generalized matrix multiplication: 
+  \brief This function performs generalized matrix multiplication:
    D = alpha*op(A)*op(B) + beta*op(C), where op(X) is X or X^T.
    Operation on A, B and C matrices is described by enumeration vpGEMMmethod.
    
@@ -305,12 +306,12 @@ template<unsigned int> inline void GEMMsize(const vpMatrix & /*A*/,const vpMatri
    vpGEMM(A,B,alpha,C,beta, VP_GEMM_A_T + VP_GEMM_B_T);
    \endcode
    
-   If C is not used, vpGEMM must be called using an empty matrix \e null :
+   If C is not used, vpGEMM must be called using an empty array \e vpArrayNull :
    \code
-   vpGEMM(A,B,alpha,C, null,0);
+   vpGEMM(A,B,alpha,C, vpArrayNull,0);
    \endcode
    
-   \throw vpMatrixException::incorrectMatrixSizeError if the sizes of the matrices
+   \throw vpArray2D<double>Exception::incorrectMatrixSizeError if the sizes of the matrices
    do not allow the operations.
    
    \param A : a Matrix
@@ -321,39 +322,39 @@ template<unsigned int> inline void GEMMsize(const vpMatrix & /*A*/,const vpMatri
    \param D : a Matrix
    \param ops : a scalar describing operation applied on the matrices
    
-   \relates vpMatrix
+   \relates vpArray2D
    
 */  
-inline void vpGEMM(const vpMatrix & A,const vpMatrix & B, const double & alpha ,const vpMatrix & C, const double & beta, vpMatrix & D, const unsigned int &ops=0){
+inline void vpGEMM(const vpArray2D<double> & A,const vpArray2D<double> & B, const double & alpha ,const vpArray2D<double> & C, const double & beta, vpArray2D<double> & D, const unsigned int &ops=0){
   switch(ops){
-    case 0 :
-      vpTGEMM<0>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 1 :
-      vpTGEMM<1>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 2 :
-      vpTGEMM<2>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 3 :
-      vpTGEMM<3>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 4 :
-      vpTGEMM<4>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 5 :
-      vpTGEMM<5>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 6 :
-      vpTGEMM<6>( A, B,  alpha , C,  beta,  D);
-      break;
-    case 7 :
-      vpTGEMM<7>( A, B,  alpha , C,  beta,  D);
-      break;
-    default:
-      vpERROR_TRACE("\n\t\tvpMatrix mismatch operation in vpGEMM") ;
-      throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,"\n\t\tvpMatrix mismatch operation in vpGEMM")) ;
-      break;
+  case 0 :
+    vpTGEMM<0>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 1 :
+    vpTGEMM<1>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 2 :
+    vpTGEMM<2>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 3 :
+    vpTGEMM<3>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 4 :
+    vpTGEMM<4>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 5 :
+    vpTGEMM<5>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 6 :
+    vpTGEMM<6>( A, B,  alpha , C,  beta,  D);
+    break;
+  case 7 :
+    vpTGEMM<7>( A, B,  alpha , C,  beta,  D);
+    break;
+  default:
+    throw(vpException(vpException::functionNotImplementedError,
+                      "Operation on vpGEMM not implemented")) ;
+    break;
   }
 }
 

--- a/modules/core/include/visp3/core/vpGEMM.h
+++ b/modules/core/include/visp3/core/vpGEMM.h
@@ -261,14 +261,10 @@ void vpTGEMM(const vpArray2D<double> & A,const vpArray2D<double> & B, const doub
   GEMMsize<T>(A,B,Arows,Acols,Brows,Bcols);
   //   std::cout << Arows<<" " <<Acols << " "<< Brows << " "<< Bcols<<std::endl;
   
-  try
-  {
+  try  {
     if ((Arows != D.getRows()) || (Bcols != D.getCols())) D.resize(Arows,Bcols);
   }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("Error caught") ;
-    std::cout << me << std::endl ;
+  catch(...) {
     throw ;
   }
   
@@ -281,13 +277,11 @@ void vpTGEMM(const vpArray2D<double> & A,const vpArray2D<double> & B, const doub
   
   if(C.getRows()!=0 && C.getCols()!=0){
 
-    if ((Arows != C.getRows()) || (Bcols != C.getCols()))
-    {
+    if ((Arows != C.getRows()) || (Bcols != C.getCols())) {
       throw(vpException(vpException::dimensionError,
                         "In vpGEMM, cannot add resulting (%dx%d) matrix to (%dx%d) matrix",
                         Arows, Bcols, C.getRows(), C.getCols())) ;
     }
-    
     
     GEMM2<T>(Arows,Brows,Bcols,A,B,alpha,C,beta,D);
   }else{

--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -191,6 +191,11 @@ class VISP_EXPORT vpHomogeneousMatrix : public vpArray2D<double>
   */
   //@{
   /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
+  /*!
      \deprecated You should rather use eye().
    */
   vp_deprecated void setIdentity();

--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -46,6 +46,7 @@
 #ifndef VPHOMOGENEOUSMATRIX_HH
 #define VPHOMOGENEOUSMATRIX_HH
 
+class vpTranslationVector;
 class vpPoseVector;
 class vpMatrix;
 class vpRotationMatrix;
@@ -57,10 +58,10 @@ class vpPoint;
 #include <vector>
 #include <fstream>
 
-#include <visp3/core/vpMatrix.h>
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpRotationMatrix.h>
 #include <visp3/core/vpThetaUVector.h>
-#include <visp3/core/vpTranslationVector.h>
+//#include <visp3/core/vpTranslationVector.h>
 #include <visp3/core/vpPoseVector.h>
 
 /*!
@@ -71,7 +72,7 @@ class vpPoint;
   \brief  The class provides a data structure for the homogeneous matrices
   as well as a set of operations on these matrices.
 
-  The vpHomogeneousMatrix is derived from vpMatrix.
+  The vpHomogeneousMatrix is derived from vpArray2D.
 
   \author  Eric Marchand   (Eric.Marchand@irisa.fr) Irisa / Inria Rennes
 
@@ -89,62 +90,41 @@ class vpPoint;
   \f$ ^a{\bf t}_b \f$ is a translation vector.
 
 */
-class VISP_EXPORT vpHomogeneousMatrix : public vpMatrix
+class VISP_EXPORT vpHomogeneousMatrix : public vpArray2D<double>
 {
  public:
-  //! Basic constructor.
-  vpHomogeneousMatrix()   ;
-  //! Copy constructor.
+  vpHomogeneousMatrix();
   vpHomogeneousMatrix(const vpHomogeneousMatrix &M) ;
-  //! Construction from translation vector and rotation matrix.
   vpHomogeneousMatrix(const vpTranslationVector &t, const vpRotationMatrix &R) ;
-  //! Construction from translation vector and theta u rotation vector.
   vpHomogeneousMatrix(const vpTranslationVector &t, const vpThetaUVector &tu) ;
-  //! Construction from translation vector and quaternion rotation vector.
   vpHomogeneousMatrix(const vpTranslationVector &t, const vpQuaternionVector &q) ;
-  /*!
-    Construction from translation vector and theta u rotation vector 
-    defined as a pose vector.
-  */
   vpHomogeneousMatrix(const vpPoseVector &p) ;  
-
-  //! Construction from translation and rotation defined as a theta u vector.
-  vpHomogeneousMatrix(const double tx, const double ty, const double tz,
-		      const double tux, const double tuy, const double tuz) ;
   vpHomogeneousMatrix(const std::vector<float> &v);
   vpHomogeneousMatrix(const std::vector<double> &v);
+  vpHomogeneousMatrix(const double tx, const double ty, const double tz,
+                      const double tux, const double tuy, const double tuz) ;
 
-  //! Construction from translation vector and rotation matrix.
   void buildFrom(const vpTranslationVector &t, const vpRotationMatrix &R) ;
-  //! Construction from translation vector and theta u rotation vector.
   void buildFrom(const vpTranslationVector &t, const vpThetaUVector &tu) ;
-  //! Construction from translation vector and quaternion rotation vector.
   void buildFrom(const vpTranslationVector &t, const vpQuaternionVector& q) ;
+  void buildFrom(const vpPoseVector &p) ;
   void buildFrom(const std::vector<float> &v) ;
   void buildFrom(const std::vector<double> &v) ;
+  void buildFrom(const double tx, const double ty, const double tz,
+                 const double tux, const double tuy, const double tuz) ;
 
-  /*!
-    Construction from translation vector and theta u rotation vector 
-    defined as a pose vector.
-  */
-  void buildFrom(const vpPoseVector &p) ;
-
-  //! Construction from translation and rotation defined as a theta u vector.
-  void buildFrom(const double tx,const  double ty, const double tz,
-		 const double tux,const  double tuy, const double tuz  ) ;
-    
   void convert(std::vector<float> &M);
   void convert(std::vector<double> &M);
 
-  /*!
-    Return the translation vector from the homogeneous transformation matrix.
-   */
-  vpTranslationVector getTranslationVector()
-  {
-    vpTranslationVector tr;
-    this->extract(tr);
-    return tr;
-  }
+//  /*!
+//    Return the translation vector from the homogeneous transformation matrix.
+//   */
+//  vpTranslationVector getTranslationVector()
+//  {
+//    vpTranslationVector tr;
+//    this->extract(tr);
+//    return tr;
+//  }
 //  /*!
 //    Return the rotation matrix from the homogeneous transformation matrix.
 //   */
@@ -156,16 +136,8 @@ class VISP_EXPORT vpHomogeneousMatrix : public vpMatrix
 //    return R;
 //  }
 
-  //! Copy operator from vpHomogeneousMatrix.
-  vpHomogeneousMatrix &operator=(const vpHomogeneousMatrix &M);
-
-  //! Multiply two homogeneous matrices:  aMb = aMc*cMb
-  vpHomogeneousMatrix operator*(const vpHomogeneousMatrix &M) const;
-
-  //! Multiply by a vector ! size 4 !!!
-  vpColVector operator*(const vpColVector &v) const;
-  // Multiply by a point
-  vpPoint operator*(const vpPoint &bP) const;
+  // Set to identity
+  void eye();
 
   // Invert the homogeneous matrix.
   vpHomogeneousMatrix inverse() const ;
@@ -190,15 +162,40 @@ class VISP_EXPORT vpHomogeneousMatrix : public vpMatrix
   // Save an homogeneous matrix in a file
   void save(std::ofstream &f) const ;
 
-  // Set to identity
-  void eye();
-  //! Basic initialisation (identity).
-  void init() ;
-  // Basic initialisation (identity).
-  void setIdentity() ;
+  vpHomogeneousMatrix &operator=(const vpHomogeneousMatrix &M);
+  vpHomogeneousMatrix operator*(const vpHomogeneousMatrix &M) const;
 
-  //! Print the matrix as a vector [T thetaU]
+  vpColVector operator*(const vpColVector &v) const;
+  // Multiply by a point
+  vpPoint operator*(const vpPoint &bP) const;
+
   void print() ;
+
+  /*!
+    This function is not applicable to an homogeneous matrix that is always a
+    4-by-4 matrix.
+    \exception vpException::fatalError When this function is called.
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    (void)nrows;
+    (void)ncols;
+    (void)flagNullify;
+    throw(vpException(vpException::fatalError, "Cannot resize an homogeneous matrix"));
+  };
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use eye().
+   */
+  vp_deprecated void setIdentity();
+  //@}
+#endif
 
 } ;
 

--- a/modules/core/include/visp3/core/vpIoTools.h
+++ b/modules/core/include/visp3/core/vpIoTools.h
@@ -193,6 +193,10 @@ public:
   static std::pair<std::string, std::string> splitDrive(const std::string& pathname);
   static std::vector<std::string> splitChain(const std::string & chain, const std::string & sep);
 
+  /*!
+    @name Configuration file parsing
+  */
+  //@{
   // read configuration file
   static bool loadConfigFile(const std::string &confFile);
   static bool readConfigVar(const std::string &var, float &value);
@@ -202,9 +206,9 @@ public:
   static bool readConfigVar(const std::string &var, bool &value);
   static bool readConfigVar(const std::string &var, std::string &value);
   static bool readConfigVar(const std::string &var, vpColor &value);
-  static bool readConfigVar(const std::string &var, vpMatrix &value, 
-			    const unsigned int &nCols = 0, 
-			    const unsigned int &nRows = 0);
+  static bool readConfigVar(const std::string &var, vpArray2D<double> &value,
+                            const unsigned int &nCols = 0,
+                            const unsigned int &nRows = 0);
   
   // construct experiment filename & path
   static void setBaseName(const std::string &s);
@@ -219,6 +223,7 @@ public:
   // write files
   static void saveConfigFile(const bool &actuallySave = true);
   static void createBaseNamePath(const bool &empty = false);
+  //@}
 
  protected:
   static std::string baseName;

--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -43,6 +43,7 @@
 #include <visp3/core/vpTime.h>
 #include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpRotationMatrix.h>
+#include <visp3/core/vpHomogeneousMatrix.h>
 #include <visp3/core/vpVelocityTwistMatrix.h>
 #include <visp3/core/vpForceTwistMatrix.h>
 
@@ -119,12 +120,18 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
   vpMatrix(unsigned int r, unsigned int c, double val) : vpArray2D<double>(r, c, val) {};
   vpMatrix(const vpMatrix &M, unsigned int r, unsigned int c,
            unsigned int nrows, unsigned int ncols) ;
-  vpMatrix(const vpMatrix& M);
-  vpMatrix(const vpColVector& v);
-  vpMatrix(const vpRowVector& v);
-  vpMatrix(const vpRotationMatrix& R);
-  vpMatrix(const vpVelocityTwistMatrix& V);
-  vpMatrix(const vpForceTwistMatrix& F);
+  /*!
+     Create a matrix from a 2D array that could be one of the following container that
+     inherit from vpArray2D such as vpMatrix, vpRotationMatrix, vpHomogeneousMatrix,
+     vpPoseVector, vpColVector, vpRowVector...
+
+     The following example shows how to create a matrix from an homogeneous matrix:
+     \code
+     vpRotationMatrix R;
+     vpMatrix M(R);
+     \endcode
+   */
+  vpMatrix(const vpArray2D<double>& A) : vpArray2D<double>(A) {};
 
   //! Destructor (Memory de-allocation)
   virtual ~vpMatrix() {};
@@ -166,12 +173,7 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
   /** @name Assignment operators */
   //@{
   vpMatrix &operator<<(double*);
-  vpMatrix &operator=(const vpMatrix &B);
-  vpMatrix &operator=(const vpRotationMatrix &R);
-  vpMatrix &operator=(const vpVelocityTwistMatrix &V);
-  vpMatrix &operator=(const vpForceTwistMatrix &F);
-  vpMatrix &operator=(const vpColVector &v);
-  vpMatrix &operator=(const vpRowVector &v);
+  vpMatrix &operator=(const vpArray2D<double> &A);
   vpMatrix &operator=(const double x);
   //@}
 
@@ -496,23 +498,23 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
   /** @name Matrix I/O with Static Public Member Functions  */
   //@{
   /*!
-    Load a matrix from a file.
+    Load a matrix from a file. This function overloads vpArray2D::load().
 
-    \param filename : absolute file name
-    \param M : matrix to be loaded
+    \param filename : absolute file name.
+    \param M : matrix to be loaded.
     \param binary :If true the matrix is loaded from a binary file, else from a text file.
-    \param Header : Header of the file is loaded in this parameter
+    \param header : Header of the file is loaded in this parameter
 
     \return Returns true if no problem appends.
   */
-  static inline bool loadMatrix(std::string filename, vpMatrix &M,
-                                const bool binary = false, char *Header = NULL)
+  static inline bool loadMatrix(const std::string &filename, vpArray2D<double> &M,
+                                const bool binary = false, char *header = NULL)
   {
-    return vpMatrix::loadMatrix(filename.c_str(), M, binary, Header);
+    return vpArray2D::load(filename, M, binary, header);
   }
-  static bool loadMatrix(const char *filename, vpMatrix &M, const bool binary = false, char *Header = NULL);
+
   /*!
-    Load a matrix from a YAML-formatted file.
+    Load a matrix from a YAML-formatted file. This function overloads vpArray2D::loadYAML().
 
     \param filename : absolute file name.
     \param M : matrix to be loaded from the file.
@@ -520,33 +522,32 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
 
     \return Returns true if no problem appends.
   */
-  static inline bool loadMatrixYAML(std::string filename, vpMatrix &M, char *header = NULL)
+  static inline bool loadMatrixYAML(const std::string &filename, vpArray2D<double> &M, char *header = NULL)
   {
-    return vpMatrix::loadMatrixYAML(filename.c_str(), M, header);
+    return vpArray2D::loadYAML(filename, M, header);
   }
-  static bool loadMatrixYAML(const char *filename, vpMatrix &M, char *header = NULL);
-  /*!
-    Save a matrix to a file.
 
-    \param filename : absolute file name
-    \param M : matrix to be saved
-    \param binary :If true the matrix is save in a binary file, else a text file.
-    \param Header : optional line that will be saved at the beginning of the file
+  /*!
+    Save a matrix to a file. This function overloads vpArray2D::load().
+
+    \param filename : absolute file name.
+    \param M : matrix to be saved.
+    \param binary : If true the matrix is save in a binary file, else a text file.
+    \param header : optional line that will be saved at the beginning of the file.
 
     \return Returns true if no problem appends.
 
     Warning : If you save the matrix as in a text file the precision is less than if you save it in a binary file.
   */
-  static inline bool saveMatrix(std::string filename, const vpMatrix &M,
+  static inline bool saveMatrix(const std::string &filename, const vpArray2D<double> &M,
                                 const bool binary = false,
-                                const char *Header = "")
+                                const char *header = "")
   {
-    return vpMatrix::saveMatrix(filename.c_str(), M, binary, Header);
+    return vpArray2D::save(filename, M, binary, header);
   }
-  static bool saveMatrix(const char *filename, const vpMatrix &M, const bool binary = false, const char *Header = "");
 
   /*!
-    Save a matrix in a YAML-formatted file.
+    Save a matrix in a YAML-formatted file. This function overloads vpArray2D::saveYAML().
 
     \param filename : absolute file name.
     \param M : matrix to be saved in the file.
@@ -555,11 +556,10 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
     \return Returns true if success.
 
   */
-  static inline bool saveMatrixYAML(std::string filename, const vpMatrix &M, const char *header = "")
+  static inline bool saveMatrixYAML(const std::string &filename, const vpArray2D<double> &M, const char *header = "")
   {
-    return vpMatrix::saveMatrixYAML(filename.c_str(), M, header);
+    return vpArray2D::saveYAML(filename, M, header);
   }
-  static bool saveMatrixYAML(const char *filename, const vpMatrix &M, const char *header = "");
   //@}
 
 
@@ -568,6 +568,10 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
     @name Deprecated functions
   */
   //@{
+  /*!
+     \deprecated Only provided for compatibilty with ViSP previous releases. This function does nothing.
+   */
+  vp_deprecated void init() { };
   /*!
      \deprecated You should rather use stack(const vpMatrix &A)
    */

--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -159,6 +159,7 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
   //-------------------------------------------------
   /** @name Setting a diagonal matrix  */
   //@{
+  void diag(const double &val = 1.0);
   void diag(const vpColVector &A);
   // Initialize an identity matrix n-by-n
   void eye();
@@ -607,7 +608,7 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
   vp_deprecated static void stackMatrices(const vpColVector &A, const vpColVector &B, vpColVector &C);
 
   /*!
-     \deprecated You should rather use eye()
+     \deprecated You should rather use diag(const double &)
    */
   vp_deprecated void setIdentity(const double & val=1.0) ;
   //@}

--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -35,14 +35,16 @@
  *
  *****************************************************************************/
 
-
-
 #ifndef vpMatrix_H
 #define vpMatrix_H
 
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpException.h>
 #include <visp3/core/vpTime.h>
+#include <visp3/core/vpArray2D.h>
+#include <visp3/core/vpRotationMatrix.h>
+#include <visp3/core/vpVelocityTwistMatrix.h>
+#include <visp3/core/vpForceTwistMatrix.h>
 
 #ifdef VISP_HAVE_GSL
 #  include <gsl/gsl_math.h>
@@ -56,6 +58,8 @@ class vpRowVector;
 class vpColVector;
 class vpTranslationVector;
 class vpHomogeneousMatrix;
+class vpVelocityTwistMatrix;
+class vpForceTwistMatrix;
 
 /*!
   \file vpMatrix.h
@@ -75,8 +79,6 @@ class vpHomogeneousMatrix;
   vpMatrix class provides a data structure for the matrices as well
   as a set of operations on these matrices
 
-  \author Eric Marchand (IRISA - INRIA Rennes)
-
   \warning Note the matrix in the class (*this) will be noted A in the comment
 
   \ingroup libmath
@@ -84,7 +86,7 @@ class vpHomogeneousMatrix;
   \sa vpRowVector, vpColVector, vpHomogeneousMatrix, vpRotationMatrix,
   vpTwistMatrix, vpHomography
 */
-class VISP_EXPORT vpMatrix
+class VISP_EXPORT vpMatrix : public vpArray2D<double>
 {
  public:
   /*!
@@ -95,231 +97,125 @@ class VISP_EXPORT vpMatrix
     LU_DECOMPOSITION     /*!< LU decomposition method. */
   } vpDetMethod;
 
-
-protected:
-  //! number of rows
-  unsigned int rowNum;
-  //! number of columns
-  unsigned int colNum;
-
  public:
-  //! address of the first element of the data array
-  double *data;
- protected:
-  //! address of the first element of each rows
-  double **rowPtrs;
+  /*!
+    Basic constructor of a matrix of double. Number of columns and rows are zero.
+  */
+  vpMatrix() : vpArray2D<double>(0, 0) {};
+  /*!
+    Constructor that initialize a matrix of double with 0.
 
-  //! Current size (rowNum * colNum)
-  unsigned int dsize;
-  //! Total row space
-  unsigned int trsize;
+    \param r : Matrix number of rows.
+    \param c : Matrix number of columns.
+  */
+  vpMatrix(unsigned int r, unsigned int c) : vpArray2D<double>(r, c) {};
+  /*!
+    Constructor that initialize a matrix of double with \e val.
 
- public:
-  //! Basic constructor
-  vpMatrix() ;
-  //! Constructor. Initialization of A as an r x c matrix with 0.
-  vpMatrix(unsigned int r, unsigned int c) ;
-  vpMatrix(unsigned int r, unsigned int c, double val);
-  //! sub vpMatrix constructor
-  vpMatrix(const vpMatrix &m, unsigned int r, unsigned int c, 
-     unsigned int nrows, unsigned int ncols) ;
+    \param r : Matrix number of rows.
+    \param c : Matrix number of columns.
+    \param val : Each element of the matrix is set to \e val.
+  */
+  vpMatrix(unsigned int r, unsigned int c, double val) : vpArray2D<double>(r, c, val) {};
+  vpMatrix(const vpMatrix &M, unsigned int r, unsigned int c,
+           unsigned int nrows, unsigned int ncols) ;
+  vpMatrix(const vpMatrix& M);
+  vpMatrix(const vpColVector& v);
+  vpMatrix(const vpRowVector& v);
+  vpMatrix(const vpRotationMatrix& R);
+  vpMatrix(const vpVelocityTwistMatrix& V);
+  vpMatrix(const vpForceTwistMatrix& F);
 
   //! Destructor (Memory de-allocation)
-  virtual ~vpMatrix();
+  virtual ~vpMatrix() {};
 
-  //! Initialization of the object matrix
-  void  init() ;
+  /*!
+    Removes all elements from the matrix (which are destroyed),
+    leaving the container with a size of 0.
+  */
+  void clear()
+  {
+    if (data != NULL ) {
+      free(data);
+      data=NULL;
+    }
 
-  //! Destruction of the matrix  (Memory de-allocation)
-  void kill() ;
+    if (rowPtrs!=NULL) {
+      free(rowPtrs);
+      rowPtrs=NULL ;
+    }
+    rowNum = colNum = dsize = 0;
+  }
 
+  //-------------------------------------------------
+  // Setting a diagonal matrix
+  //-------------------------------------------------
+  /** @name Setting a diagonal matrix  */
+  //@{
+  void diag(const vpColVector &A);
   // Initialize an identity matrix n-by-n
+  void eye();
   void eye(unsigned int n) ;
   // Initialize an identity matrix m-by-n
   void eye(unsigned int m, unsigned int n) ;
-  void setIdentity(const double & val=1.0) ;
-
-  //---------------------------------
-  // Set/get Matrix size
-  //---------------------------------
-  /** @name Set/get Matrix size  */
-  //@{
-  //! Return the number of rows of the matrix
-  inline unsigned int getRows() const { return rowNum ;}
-  //! Return the number of columns of the matrix
-  inline unsigned int getCols() const { return colNum; }
-  //! Return the number of elements of the matrix.
-  inline unsigned int size() const { return colNum*rowNum; }
-
-  // Set the size of the matrix A, initialization with a zero matrix
-  void resize(const unsigned int nrows, const unsigned int ncols, 
-	      const bool nullify = true);
-  
-  double getMinValue() const;
-  
-  double getMaxValue() const;
-  //@}
-
-  //---------------------------------
-  // Printing
-  //---------------------------------
-
-  friend VISP_EXPORT std::ostream &operator << (std::ostream &s,const vpMatrix &m);
-  /** @name Printing  */
-  //@{
-
-  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
-  std::ostream & matlabPrint(std::ostream & os) const;
-  std::ostream & maplePrint(std::ostream & os) const;
-  std::ostream & csvPrint(std::ostream & os) const;
-  std::ostream & cppPrint(std::ostream & os, const char * matrixName = NULL, bool octet = false) const;
-
-  void printSize() { std::cout << getRows() <<" x " << getCols() <<"  " ; }
   //@}
   
-
   //---------------------------------
-  // Copy / assignment
+  // Assignment
   //---------------------------------
-  /** @name Copy / assignment  */
+  /** @name Assignment operators */
   //@{
-  //! Copy constructor
-  vpMatrix (const vpMatrix& m);
-
-  // Assignment from an array
   vpMatrix &operator<<(double*);
-
-  //! Copy operator.   Allow operation such as A = B
   vpMatrix &operator=(const vpMatrix &B);
-  //! Set all the element of the matrix A to x
+  vpMatrix &operator=(const vpRotationMatrix &R);
+  vpMatrix &operator=(const vpVelocityTwistMatrix &V);
+  vpMatrix &operator=(const vpForceTwistMatrix &F);
+  vpMatrix &operator=(const vpColVector &v);
+  vpMatrix &operator=(const vpRowVector &v);
   vpMatrix &operator=(const double x);
-  void diag(const vpColVector &A);
   //@}
 
-  //---------------------------------
-  // Access/modification operators
-  //---------------------------------
-  /** @name Access/modification operators  */
+  //-------------------------------------------------
+  // Stacking
+  //-------------------------------------------------
+  /** @name Stacking  */
   //@{
-  //! write elements Aij (usage : A[i][j] = x )
-  inline double *operator[](unsigned int i) { return rowPtrs[i]; }
-  //! read elements Aij  (usage : x = A[i][j] )
-  inline double *operator[](unsigned int i) const {return rowPtrs[i];}
+  // Stack the matrix A below the current one, copy if not initialized this = [ this A ]^T
+  void stack(const vpMatrix &A);
+  void stack(const vpRowVector &r);
+  // Stacks columns of a matrix in a vector
+  void stackColumns(vpColVector &out );
+
+  // Stacks columns of a matrix in a vector
+  vpColVector stackColumns();
+
+  // Stacks columns of a matrix in a vector
+  void stackRows(vpRowVector  &out );
+
+  // Stacks columns of a matrix in a vector
+  vpRowVector stackRows();
   //@}
 
   //---------------------------------
-  // Matrix operations (Static).
-  //---------------------------------  
-
-private:
-  static void computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls, vpMatrix &Js, vpColVector &deltaP);
-
-public:
-  static void add2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
-  static void add2WeightedMatrices(const vpMatrix &A, const double &wA, const vpMatrix &B,const double &wB, vpMatrix &C);
-  static vpMatrix computeCovarianceMatrix(const vpMatrix &A, const vpColVector &x, const vpColVector &b);
-  static vpMatrix computeCovarianceMatrix(const vpMatrix &A, const vpColVector &x, const vpColVector &b, const vpMatrix &w);
-  static vpMatrix computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls, const vpMatrix &W);
-  static vpMatrix computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls);
-  static void computeHLM(const vpMatrix &H, const double &alpha, vpMatrix &HLM);
-
-  // Create a diagonal matrix with the element of a vector DAii = Ai
-  static void createDiagonalMatrix(const vpColVector &A, vpMatrix &DA)  ;
+  // Matrix insertion with Static Public Member Functions
+  //---------------------------------
+  /** @name Matrix insertion */
+  //@{
   // Insert matrix A in the current matrix at the given position (r, c).
   void insert(const vpMatrix&A, const unsigned int r, const unsigned int c);
-  // Insert matrix B in matrix A at the given position (r, c).
-  static vpMatrix insert(const vpMatrix &A,const  vpMatrix &B, const unsigned int r, const unsigned int c) ;
-  // Insert matrix B in matrix A (not modified) at the given position (r, c), the result is given in matrix C.
-  static void insert(const vpMatrix &A, const vpMatrix &B, vpMatrix &C, const unsigned int r, const unsigned int c) ;
+  //@}
 
-  // Juxtapose to matrices C = [ A B ]
-  static vpMatrix juxtaposeMatrices(const vpMatrix &A,const  vpMatrix &B) ;
-  // Juxtapose to matrices C = [ A B ]
-  static void juxtaposeMatrices(const vpMatrix &A,const  vpMatrix &B, vpMatrix &C) ;
-  // Compute Kronecker product matrix
-  static void kron(const vpMatrix  &m1, const vpMatrix  &m2 , vpMatrix  &out);
-
-  // Compute Kronecker product matrix
-  static vpMatrix kron(const vpMatrix  &m1, const vpMatrix  &m2 );
-
-  /*!
-    Load a matrix from a file.
-
-    \param filename : absolute file name
-    \param M : matrix to be loaded
-    \param binary :If true the matrix is loaded from a binary file, else from a text file.
-    \param Header : Header of the file is loaded in this parameter
-
-    \return Returns true if no problem appends.
-  */
-  static inline bool loadMatrix(std::string filename, vpMatrix &M,
-                                const bool binary = false, char *Header = NULL)
-  {
-    return vpMatrix::loadMatrix(filename.c_str(), M, binary, Header);
-  }
-  static bool loadMatrix(const char *filename, vpMatrix &M, const bool binary = false, char *Header = NULL);
-  static void mult2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
-  static void multMatrixVector(const vpMatrix &A, const vpColVector &b, vpColVector &c);
-  static void negateMatrix(const vpMatrix &A, vpMatrix &C);
-  /*!
-    Save a matrix to a file.
-
-    \param filename : absolute file name
-    \param M : matrix to be saved
-    \param binary :If true the matrix is save in a binary file, else a text file.
-    \param Header : optional line that will be saved at the beginning of the file
-
-    \return Returns true if no problem appends.
-
-    Warning : If you save the matrix as in a text file the precision is less than if you save it in a binary file.
-  */
-  static inline bool saveMatrix(std::string filename, const vpMatrix &M,
-        const bool binary = false,
-        const char *Header = "")
-  {
-    return vpMatrix::saveMatrix(filename.c_str(), M, binary, Header);
-  }
-  static bool saveMatrix(const char *filename, const vpMatrix &M, const bool binary = false, const char *Header = "");
-
-  /*!
-    Save a matrix in a YAML-formatted file.
-
-    \param filename : absolute file name.
-    \param M : matrix to be saved in the file.
-    \param header : optional lines that will be saved at the beginning of the file. Should be YAML-formatted and will adapt to the indentation if any.
-
-    \return Returns true if success.
-
-  */
-  static inline bool saveMatrixYAML(std::string filename, const vpMatrix &M, const char *header = "")
-  {
-    return vpMatrix::saveMatrixYAML(filename.c_str(), M, header);
-  }
-  static bool saveMatrixYAML(const char *filename, const vpMatrix &M, const char *header = "");
-  /*!
-    Load a matrix from a YAML-formatted file.
-
-    \param filename : absolute file name.
-    \param M : matrix to be loaded from the file.
-    \param header : Header of the file is loaded in this parameter.
-
-    \return Returns true if no problem appends.
-  */
-  static inline bool loadMatrixYAML(std::string filename, vpMatrix &M, char *header = NULL)
-  {
-    return vpMatrix::loadMatrixYAML(filename.c_str(), M, header);
-  }
-  static bool loadMatrixYAML(const char *filename, vpMatrix &M, char *header = NULL);
-
-
-  // Stack the matrix A below the current one, copy if not initialized this = [ this A ]^T
-  void stackMatrices(const vpMatrix &A);
-  //! Stack two Matrices C = [ A B ]^T
-  static vpMatrix stackMatrices(const vpMatrix &A,const  vpMatrix &B) ;
-  //! Stack two Matrices C = [ A B ]^T
-  static void stackMatrices(const vpMatrix &A,const  vpMatrix &B, vpMatrix &C) ;
-  static void sub2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
-  
+  //-------------------------------------------------
+  // Columns, Rows extraction, SubMatrix
+  //-------------------------------------------------
+  /** @name Columns, rows, sub-matrices extraction */
+  //@{
+  vpRowVector getRow(const unsigned int i) const;
+  vpRowVector getRow(const unsigned int i, const unsigned int j_begin, const unsigned int size) const;
+  vpColVector getCol(const unsigned int j) const;
+  vpColVector getCol(const unsigned int j, const unsigned int i_begin, const unsigned int size) const;
+  void init(const vpMatrix &M, unsigned int r, unsigned int c, unsigned int nrows, unsigned int ncols);
+  //@}
 
   //---------------------------------
   // Matrix operations.
@@ -330,22 +226,16 @@ public:
   vpMatrix &operator+=(const vpMatrix &B);
   // operation A = A - B
   vpMatrix &operator-=(const vpMatrix &B);
-
   vpMatrix operator*(const vpMatrix &B) const;
+  vpMatrix operator*(const vpRotationMatrix &R) const;
+  vpMatrix operator*(const vpVelocityTwistMatrix &V) const;
+  vpMatrix operator*(const vpForceTwistMatrix &V) const;
+  // operation t_out = A * t (A is unchanged, t and t_out are translation vectors)
+  vpTranslationVector operator*(const vpTranslationVector &t) const;
+  vpColVector operator*(const vpColVector &v) const;
   vpMatrix operator+(const vpMatrix &B) const;
   vpMatrix operator-(const vpMatrix &B) const;
   vpMatrix operator-() const;
-
-  //---------------------------------
-  // Matrix/vector operations.
-  //---------------------------------
-
-  vpColVector operator*(const vpColVector &b) const;
-  // operation c = A * b (A is unchanged, c and b are translation vectors)
-  vpTranslationVector operator*(const vpTranslationVector  &b) const;
-  //---------------------------------
-  // Matrix/real operations.
-  //---------------------------------
 
   //! Add x to all the element of the matrix : Aij = Aij + x
   vpMatrix &operator+=(const double x);
@@ -367,13 +257,7 @@ public:
     \return \f$\sum a_{ij}\f$
     */
   double sum() const;
-  /*!
-    Return the sum square of all the \f$a_{ij}\f$ elements of the matrix.
-
-    \return \f$\sum a_{ij}^{2}\f$
-    */
   double sumSquare() const;
-
   // return the determinant of the matrix.
   double det(vpDetMethod method = LU_DECOMPOSITION) const;
   
@@ -381,55 +265,10 @@ public:
   vpMatrix expm();
 
   //-------------------------------------------------
-  // Columns, Rows extraction, SubMatrix
-  //-------------------------------------------------
-  /** @name Columns, Rows extraction, Submatrix  */
-  //@{
-  vpRowVector getRow(const unsigned int i) const;
-  vpRowVector getRow(const unsigned int i, const unsigned int j_begin, const unsigned int size) const;
-  vpColVector getCol(const unsigned int j) const;
-  vpColVector getCol(const unsigned int j, const unsigned int i_begin, const unsigned int size) const;
-  void init(const vpMatrix &M, unsigned int r, unsigned int c, unsigned int nrows, unsigned int ncols);
-  //@}
-
-  //-------------------------------------------------
-  // transpose
-  //-------------------------------------------------
-  /** @name Transpose, Identity  */
-  //@{
-  // Compute the transpose C = A^T
-  vpMatrix t() const;
-
-  // Compute the transpose C = A^T
-  vpMatrix transpose()const;
-  void  transpose(vpMatrix & C )const;
-    
-  vpMatrix AAt() const;
-  void AAt(vpMatrix &B) const;
-   
-  vpMatrix AtA() const;
-  void AtA(vpMatrix &B) const;
-  //@}
-
-
-  //-------------------------------------------------
   // Kronecker product
   //-------------------------------------------------
   /** @name Kronecker product  */
-  //@{
-  
-  // Stacks columns of a matrix in a vector
-  void stackColumns(vpColVector  &out );
-
-  // Stacks columns of a matrix in a vector
-  vpColVector stackColumns();
-
-  // Stacks columns of a matrix in a vector
-  void stackRows(vpRowVector  &out );
-
-  // Stacks columns of a matrix in a vector
-  vpRowVector stackRows();
-  
+  //@{  
   // Compute Kronecker product matrix 
   void kron(const vpMatrix  &m1 , vpMatrix  &out);
   
@@ -437,6 +276,25 @@ public:
   vpMatrix kron(const vpMatrix  &m1);
   //@}
   
+  //-------------------------------------------------
+  // Transpose
+  //-------------------------------------------------
+  /** @name Transpose  */
+  //@{
+  // Compute the transpose C = A^T
+  vpMatrix t() const;
+
+  // Compute the transpose C = A^T
+  vpMatrix transpose()const;
+  void  transpose(vpMatrix & C )const;
+
+  vpMatrix AAt() const;
+  void AAt(vpMatrix &B) const;
+
+  vpMatrix AtA() const;
+  void AtA(vpMatrix &B) const;
+  //@}
+
   //-------------------------------------------------
   // Matrix inversion
   //-------------------------------------------------
@@ -524,7 +382,6 @@ public:
   //-------------------------------------------------
   // Eigen values and vectors
   //-------------------------------------------------
-
   /** @name Eigen values  */
 
   //@{
@@ -533,42 +390,213 @@ public:
   void eigenValues(vpColVector &evalue, vpMatrix &evector);
   //@}
 
-  // -------------------------
+  //-------------------------------------------------
   // Norms
-  // -------------------------
+  //-------------------------------------------------
   /** @name Norms  */
   //@{
-  // Euclidean norm ||x||=sqrt(sum(x_i^2))
-  double euclideanNorm () const;
-  // Infinity norm ||x||=max(sum(fabs(x_i)))
-  double infinityNorm () const;
+  double euclideanNorm() const;
+  double infinityNorm() const;
   //@}
+
+  //---------------------------------
+  // Printing
+  //---------------------------------
+  /** @name Printing  */
+  //@{
+  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
+  std::ostream & matlabPrint(std::ostream & os) const;
+  std::ostream & maplePrint(std::ostream & os) const;
+  std::ostream & csvPrint(std::ostream & os) const;
+  std::ostream & cppPrint(std::ostream & os, const char * matrixName = NULL, bool octet = false) const;
+  void printSize() { std::cout << getRows() <<" x " << getCols() <<"  " ; }
+  //@}
+
+  //------------------------------------------------------------------
+  // Static functionalities
+  //------------------------------------------------------------------
+
+  //---------------------------------
+  // Setting a diagonal matrix with Static Public Member Functions
+  //---------------------------------
+  /** @name Setting a diagonal matrix with Static Public Member Functions  */
+  //@{
+  // Create a diagonal matrix with the element of a vector DAii = Ai
+  static void createDiagonalMatrix(const vpColVector &A, vpMatrix &DA)  ;
+  //@}
+
+  //---------------------------------
+  // Matrix insertion with Static Public Member Functions
+  //---------------------------------
+  /** @name Matrix insertion with Static Public Member Functions  */
+  //@{
+  // Insert matrix B in matrix A at the given position (r, c).
+  static vpMatrix insert(const vpMatrix &A,const  vpMatrix &B, const unsigned int r, const unsigned int c) ;
+  // Insert matrix B in matrix A (not modified) at the given position (r, c), the result is given in matrix C.
+  static void insert(const vpMatrix &A, const vpMatrix &B, vpMatrix &C, const unsigned int r, const unsigned int c) ;
+
+  //---------------------------------
+  // Stacking with Static Public Member Functions
+  //---------------------------------
+  /** @name Stacking with Static Public Member Functions  */
+  //@{
+  // Juxtapose to matrices C = [ A B ]
+  static vpMatrix juxtaposeMatrices(const vpMatrix &A,const  vpMatrix &B) ;
+  // Juxtapose to matrices C = [ A B ]
+  static void juxtaposeMatrices(const vpMatrix &A,const  vpMatrix &B, vpMatrix &C) ;
+  // Stack two matrices C = [ A B ]^T
+  static vpMatrix stack(const vpMatrix &A, const vpMatrix &B) ;
+  static vpMatrix stack(const vpMatrix &A, const vpRowVector &r) ;
+
+  // Stack two matrices C = [ A B ]^T
+  static void stack(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
+  static void stack(const vpMatrix &A, const vpRowVector &r, vpMatrix &C);
+  //@}
+
+  //---------------------------------
+  // Matrix operations Static Public Member Functions
+  //---------------------------------
+  /** @name Matrix operations with Static Public Member Functions  */
+  //@{
+  static void add2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
+  static void add2WeightedMatrices(const vpMatrix &A, const double &wA, const vpMatrix &B,const double &wB, vpMatrix &C);
+  static void computeHLM(const vpMatrix &H, const double &alpha, vpMatrix &HLM);
+  static void mult2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
+  static void multMatrixVector(const vpMatrix &A, const vpColVector &v, vpColVector &w);
+  static void negateMatrix(const vpMatrix &A, vpMatrix &C);
+  static void sub2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C);
+  //@}
+
+  //---------------------------------
+  // Kronecker product Static Public Member Functions
+  //---------------------------------
+  /** @name Kronecker product with Static Public Member Functions  */
+  //@{
+  // Compute Kronecker product matrix
+  static void kron(const vpMatrix  &m1, const vpMatrix  &m2 , vpMatrix  &out);
+
+  // Compute Kronecker product matrix
+  static vpMatrix kron(const vpMatrix  &m1, const vpMatrix  &m2 );
+  //@}
+
+  //---------------------------------
+  // Covariance computation Static Public Member Functions
+  //---------------------------------
+  /** @name Covariance computation with Static Public Member Functions  */
+  //@{
+  static vpMatrix computeCovarianceMatrix(const vpMatrix &A, const vpColVector &x, const vpColVector &b);
+  static vpMatrix computeCovarianceMatrix(const vpMatrix &A, const vpColVector &x, const vpColVector &b, const vpMatrix &w);
+  static vpMatrix computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls, const vpMatrix &W);
+  static vpMatrix computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls);
+  //@}
+
+  //---------------------------------
+  // Matrix I/O  Static Public Member Functions
+  //---------------------------------
+  /** @name Matrix I/O with Static Public Member Functions  */
+  //@{
+  /*!
+    Load a matrix from a file.
+
+    \param filename : absolute file name
+    \param M : matrix to be loaded
+    \param binary :If true the matrix is loaded from a binary file, else from a text file.
+    \param Header : Header of the file is loaded in this parameter
+
+    \return Returns true if no problem appends.
+  */
+  static inline bool loadMatrix(std::string filename, vpMatrix &M,
+                                const bool binary = false, char *Header = NULL)
+  {
+    return vpMatrix::loadMatrix(filename.c_str(), M, binary, Header);
+  }
+  static bool loadMatrix(const char *filename, vpMatrix &M, const bool binary = false, char *Header = NULL);
+  /*!
+    Load a matrix from a YAML-formatted file.
+
+    \param filename : absolute file name.
+    \param M : matrix to be loaded from the file.
+    \param header : Header of the file is loaded in this parameter.
+
+    \return Returns true if no problem appends.
+  */
+  static inline bool loadMatrixYAML(std::string filename, vpMatrix &M, char *header = NULL)
+  {
+    return vpMatrix::loadMatrixYAML(filename.c_str(), M, header);
+  }
+  static bool loadMatrixYAML(const char *filename, vpMatrix &M, char *header = NULL);
+  /*!
+    Save a matrix to a file.
+
+    \param filename : absolute file name
+    \param M : matrix to be saved
+    \param binary :If true the matrix is save in a binary file, else a text file.
+    \param Header : optional line that will be saved at the beginning of the file
+
+    \return Returns true if no problem appends.
+
+    Warning : If you save the matrix as in a text file the precision is less than if you save it in a binary file.
+  */
+  static inline bool saveMatrix(std::string filename, const vpMatrix &M,
+                                const bool binary = false,
+                                const char *Header = "")
+  {
+    return vpMatrix::saveMatrix(filename.c_str(), M, binary, Header);
+  }
+  static bool saveMatrix(const char *filename, const vpMatrix &M, const bool binary = false, const char *Header = "");
+
+  /*!
+    Save a matrix in a YAML-formatted file.
+
+    \param filename : absolute file name.
+    \param M : matrix to be saved in the file.
+    \param header : optional lines that will be saved at the beginning of the file. Should be YAML-formatted and will adapt to the indentation if any.
+
+    \return Returns true if success.
+
+  */
+  static inline bool saveMatrixYAML(std::string filename, const vpMatrix &M, const char *header = "")
+  {
+    return vpMatrix::saveMatrixYAML(filename.c_str(), M, header);
+  }
+  static bool saveMatrixYAML(const char *filename, const vpMatrix &M, const char *header = "");
+  //@}
+
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use stack(const vpMatrix &A)
+   */
+  vp_deprecated void stackMatrices(const vpMatrix &A) { stack(A); };
+  /*!
+     \deprecated You should rather use stack(const vpMatrix &A, const vpMatrix &B)
+   */
+  vp_deprecated static vpMatrix stackMatrices(const vpMatrix &A, const vpMatrix &B) { return vpMatrix::stack(A, B); };
+  /*!
+     \deprecated You should rather use stack(const vpMatrix &A, const vpMatrix &B, vpMatrix &C)
+   */
+  vp_deprecated static void stackMatrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C) { vpMatrix::stack(A, B, C); };
+
+  /*!
+     \deprecated You should rather use eye()
+   */
+  vp_deprecated void setIdentity(const double & val=1.0) ;
+  //@}
+#endif
 
  private:
   double detByLU() const;
+  static void computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls, vpMatrix &Js, vpColVector &deltaP);
 
 };
 
 
 //////////////////////////////////////////////////////////////////////////
 
-
-//////////////////////////////////////////////////////////////////////////
-
-
-//! multiplication by a scalar C = x*A
 VISP_EXPORT vpMatrix operator*(const double &x, const vpMatrix &A) ;
 
-  //! multiplication by a scalar C = x*A
-VISP_EXPORT vpColVector operator*(const double &x, const vpColVector &A) ;
-
-
-
 #endif
-
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */

--- a/modules/core/include/visp3/core/vpPoseVector.h
+++ b/modules/core/include/visp3/core/vpPoseVector.h
@@ -53,7 +53,9 @@ class vpRotationMatrix;
 class vpHomogeneousMatrix;
 class vpTranslationVector;
 class vpThetaUVector;
+class vpRowVector;
 
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpMatrix.h>
 #include <visp3/core/vpRotationMatrix.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -64,64 +66,63 @@ class vpThetaUVector;
 
   \ingroup group_core_transformations
 
-  \brief The pose is a complete representation of every rigid motion in the
+  The pose is a complete representation of every rigid motion in the
   euclidian space.  
 
   It is composed of a translation and a rotation
   minimaly represented by a 6 dimension pose vector as: \f[ ^{a}{\bf
-  r}_b = [^{a}{\bf t}_{b},\Theta {\bf u}]^\top \in R^6\f]
+  r}_b = [^{a}{\bf t}_{b},\theta {\bf u}]^\top \in R^6\f]
 
   where \f$ ^{a}{\bf r}_b \f$ is the pose from frame \f$ a \f$ to
   frame \f$ b \f$, with \f$ ^{a}{\bf t}_{b} \f$ being the translation
   vector between these frames along the x,y,z
-  axis and \f$\Theta \bf u \f$, the \f$\Theta \bf u \f$ representation of the
+  axis and \f$\theta \bf u \f$, the axis-angle representation of the
   rotation \f$^{a}\bf{R}_{b}\f$ between these frames.
 
-  To know more about the \f$\Theta \bf u\f$ rotation representation,
+  Translations are expressed in meters, while the angles in the \f$\theta {\bf u}\f$
+  axis-angle representation are expressed in radians.
+
+  To know more about the \f$\theta \bf u\f$ rotation representation,
   see vpThetaUVector documentation.
 
 */
-class VISP_EXPORT vpPoseVector : public vpColVector
+class VISP_EXPORT vpPoseVector : public vpArray2D<double>
 {
-
- private:
-  // initialize a size 6 vector
-  void init() ;
-
- public:
+public:
   // constructor
   vpPoseVector() ;
   // constructor from 3 angles (in radian)
   vpPoseVector(const double tx, const double ty, const double tz,
-	       const double tux, const double tuy, const double tuz) ;
+               const double tux, const double tuy, const double tuz) ;
   // constructor convert an homogeneous matrix in a pose
   vpPoseVector(const vpHomogeneousMatrix& M) ;
   // constructor  convert a translation and a "thetau" vector into a pose
   vpPoseVector(const vpTranslationVector& t,
-	       const vpThetaUVector& tu) ;
+               const vpThetaUVector& tu) ;
   // constructor  convert a translation and a rotation matrix into a pose
   vpPoseVector(const vpTranslationVector& t,
-	       const vpRotationMatrix& R) ;
+               const vpRotationMatrix& R) ;
   
-
   // convert an homogeneous matrix in a pose
   vpPoseVector buildFrom(const vpHomogeneousMatrix& M) ;
   //  convert a translation and a "thetau" vector into a pose
   vpPoseVector buildFrom(const vpTranslationVector& t,
-			 const vpThetaUVector& tu) ;
+                         const vpThetaUVector& tu) ;
   //  convert a translation and a rotation matrix into a pose
   vpPoseVector buildFrom(const vpTranslationVector& t,
-			 const vpRotationMatrix& R) ;
-    
+                         const vpRotationMatrix& R) ;
 
-  /*! 
+  // Load an homogeneous matrix from a file
+  void load(std::ifstream &f) ;
+
+  /*!
     Set the value of an element of the pose vector: r[i] = x.
 
     \param i : Pose vector element index
 
     \code
     // Create a pose vector with translation and rotation set to zero
-    vpPoseVector r; 
+    vpPoseVector r;
 
     // Initialize the pose vector
     r[0] = 1;
@@ -159,20 +160,29 @@ class VISP_EXPORT vpPoseVector : public vpColVector
   */
   inline const double &operator [](unsigned int i) const { return *(data+i);  }
 
-  // Load an homogeneous matrix from a file
-  void load(std::ifstream &f) ;
-  // Save an homogeneous matrix in a file
-  void save(std::ofstream &f) const ;
-
   // Print  a vector [T thetaU] thetaU in degree
   void print() ;
+  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
+
+  /*!
+    This function is not applicable to a pose vector that is always a
+    6-by-1 column vector.
+    \exception vpException::fatalError When this function is called.
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    (void)nrows;
+    (void)ncols;
+    (void)flagNullify;
+    throw(vpException(vpException::fatalError, "Cannot resize a pose vector"));
+  };
+
+  // Save an homogeneous matrix in a file
+  void save(std::ofstream &f) const ;
+  void set(const double tx, const double ty, const double tz,
+           const double tux, const double tuy, const double tuz);
+  vpRowVector t() const;
 } ;
 
 #endif
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */
-

--- a/modules/core/include/visp3/core/vpPoseVector.h
+++ b/modules/core/include/visp3/core/vpPoseVector.h
@@ -183,6 +183,19 @@ public:
   void set(const double tx, const double ty, const double tz,
            const double tux, const double tuy, const double tuz);
   vpRowVector t() const;
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
+  //@}
+#endif
 } ;
 
 #endif

--- a/modules/core/include/visp3/core/vpQuaternionVector.h
+++ b/modules/core/include/visp3/core/vpQuaternionVector.h
@@ -48,8 +48,6 @@
 
 */
 
-class vpHomogeneousMatrix;
-
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpRotationMatrix.h>
 #include <visp3/core/vpRotationVector.h>

--- a/modules/core/include/visp3/core/vpRotationMatrix.h
+++ b/modules/core/include/visp3/core/vpRotationMatrix.h
@@ -45,7 +45,7 @@
 */
 
 #include <visp3/core/vpHomogeneousMatrix.h>
-#include <visp3/core/vpMatrix.h>
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpRxyzVector.h>
 #include <visp3/core/vpRzyxVector.h>
 #include <visp3/core/vpRzyzVector.h>
@@ -59,43 +59,40 @@
 
   \ingroup group_core_transformations
 
-  \brief The vpRotationMatrix considers the particular case of
-  a rotation matrix.
-  
-  It is derived from vpMatrix. 
-
-  \author  Eric Marchand   (Eric.Marchand@irisa.fr) Irisa / Inria Rennes
+  The vpRotationMatrix considers the particular case of
+  a rotation matrix. It is derived from vpArray2D.
 
 */
-class VISP_EXPORT vpRotationMatrix : public vpMatrix
+class VISP_EXPORT vpRotationMatrix : public vpArray2D<double>
 {
 public:
-  //! Basic initialisation (identity)
-  void init() ;
-
-  //! Basic initialisation (identity)
-  void setIdentity() ;
-  void eye();
-  //! Default constructor.
-  vpRotationMatrix()   ;
-  //! Copy constructor.
-  vpRotationMatrix(const vpRotationMatrix &R) ;
-  //! Copy constructor.
-  vpRotationMatrix(const vpHomogeneousMatrix &M) ;
-  //! Construction from rotation (theta U parameterization)
-  vpRotationMatrix(const vpThetaUVector &r) ;
-  //! Construction from a pose vector.
-  vpRotationMatrix(const vpPoseVector &p) ;
-  //! Construction from rotation (Euler parameterization)
-  vpRotationMatrix(const vpRzyzVector &r) ;
-  //! Construction from rotation Rxyz
-  vpRotationMatrix(const vpRxyzVector &r) ;
-  //! Construction from rotation Rzyx
-  vpRotationMatrix(const vpRzyxVector &r) ;
-  //! Construction from rotation (theta U parameterization)
-  vpRotationMatrix(const double tux, const  double tuy, const double tuz) ;
-
+  vpRotationMatrix();
+  vpRotationMatrix(const vpRotationMatrix &R);
+  vpRotationMatrix(const vpHomogeneousMatrix &M);
+  vpRotationMatrix(const vpThetaUVector &r);
+  vpRotationMatrix(const vpPoseVector &p);
+  vpRotationMatrix(const vpRzyzVector &r);
+  vpRotationMatrix(const vpRxyzVector &r);
+  vpRotationMatrix(const vpRzyxVector &r);
   vpRotationMatrix(const vpQuaternionVector& q);
+  vpRotationMatrix(const double tux, const  double tuy, const double tuz);
+
+  vpRotationMatrix buildFrom(const vpHomogeneousMatrix &M);
+  vpRotationMatrix buildFrom(const vpThetaUVector &v) ;
+  vpRotationMatrix buildFrom(const vpPoseVector &p);
+  vpRotationMatrix buildFrom(const vpRzyzVector &v);
+  vpRotationMatrix buildFrom(const vpRxyzVector &v);
+  vpRotationMatrix buildFrom(const vpRzyxVector &v);
+  vpRotationMatrix buildFrom(const vpQuaternionVector& q);
+  vpRotationMatrix buildFrom(const double tux, const double tuy, const double tuz);
+
+  void eye();
+
+  vpRotationMatrix inverse() const;
+  void inverse(vpRotationMatrix &R) const;
+
+  bool isARotationMatrix() const  ;
+
 
 //  /*!
 //    Return the \f$\theta u\f$ vector that corresponds to tha rotation matrix.
@@ -107,66 +104,56 @@ public:
 //    return tu;
 //  }
 
-  //! copy operator from vpRotationMatrix
+  // copy operator from vpRotationMatrix
   vpRotationMatrix &operator=(const vpRotationMatrix &R);
-  //! copy operator from vpMatrix (handle with care)
-  vpRotationMatrix &operator=(const vpMatrix &m) ;
-  //! operation c = A * b (A is unchanged)
-  vpTranslationVector operator*(const vpTranslationVector &mat) const ;
-  //! operation C = A * B (A is unchanged)
-  vpRotationMatrix operator*(const vpRotationMatrix &B) const ;
-  //! operation C = A * B (A is unchanged)
-  vpMatrix operator*(const vpMatrix &B) const ;
+  // copy operator from vpMatrix (handle with care)
+  vpRotationMatrix &operator=(const vpMatrix &M);
+  // operation c = A * b (A is unchanged)
+  vpTranslationVector operator*(const vpTranslationVector &t) const;
+  // operation C = A * B (A is unchanged)
+  vpRotationMatrix operator*(const vpRotationMatrix &R) const;
+  // operation C = A * B (A is unchanged)
+  vpMatrix operator*(const vpMatrix &M) const;
   // operation v2 = A * v1 (A is unchanged)
-  vpColVector operator*(const vpColVector &v) const ;
-   //! overload + operator (to say it forbidden operation, throw exception)
-  vpRotationMatrix operator+(const vpRotationMatrix &B) const ;
-   //! overload - operator (to say it forbidden operation, throw exception)
-  vpRotationMatrix operator-(const vpRotationMatrix &B) const ;
+  vpColVector operator*(const vpColVector &v) const;
+  vpRotationMatrix operator*(const double x) const;
+  vpRotationMatrix &operator*=(const double x);
 
-  //! transpose
-  vpRotationMatrix t() const ;
-
-  //! invert the rotation matrix
-  vpRotationMatrix inverse() const ;
-  //! invert the rotation matrix
-  void inverse(vpRotationMatrix &M) const;
-
-  //! test if the  matrix is an rotation matrix
-  bool isARotationMatrix() const  ;
-
-  //! Print the matrix as a vector [T thetaU]
   void printVector() ;
-  friend VISP_EXPORT std::ostream &operator << (std::ostream &s, const vpRotationMatrix &m);
 
-  //! Build a rotation matrix from an homogeneous matrix.
-  vpRotationMatrix buildFrom(const vpHomogeneousMatrix &M) ;
-  //! Transform a vector vpThetaUVector into a rotation matrix
-  vpRotationMatrix buildFrom(const vpThetaUVector &v) ;
-  //! Transform a pose vector into a rotation matrix
-  vpRotationMatrix buildFrom(const vpPoseVector &p) ;
-  //! Transform a vector reprensenting the euler (Rzyz) angle
-  //! into a rotation matrix
-  vpRotationMatrix buildFrom(const vpRzyzVector &v) ;
-  //! Transform a vector reprensenting the Rxyz angle into a rotation matrix
-  vpRotationMatrix buildFrom(const vpRxyzVector &v) ;
-  //! Transform a vector reprensenting the Rzyx angle into a rotation matrix
-  vpRotationMatrix buildFrom(const vpRzyxVector &v) ;
-  //! Construction from  rotation (theta U parameterization)
-  vpRotationMatrix buildFrom(const double tux,
-			     const double tuy,
-			     const double tuz) ;
-  
-  vpRotationMatrix buildFrom(const vpQuaternionVector& q);
-private:
-  static const double threshold;
-  static const double minimum; // useful only for debug
+  /*!
+    This function is not applicable to a rotation matrix that is always a
+    3-by-3 matrix.
+    \exception vpException::fatalError When this function is called.
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    (void)nrows;
+    (void)ncols;
+    (void)flagNullify;
+    throw(vpException(vpException::fatalError, "Cannot resize a rotation matrix"));
   };
 
+  // transpose
+  vpRotationMatrix t() const;
+  
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use eye().
+   */
+  vp_deprecated void setIdentity();
+  //@}
 #endif
 
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */
+private:
+  static const double threshold;
+};
+
+VISP_EXPORT vpRotationMatrix operator*(const double &x, const vpRotationMatrix &R) ;
+
+#endif

--- a/modules/core/include/visp3/core/vpRotationMatrix.h
+++ b/modules/core/include/visp3/core/vpRotationMatrix.h
@@ -144,6 +144,11 @@ public:
   */
   //@{
   /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
+  /*!
      \deprecated You should rather use eye().
    */
   vp_deprecated void setIdentity();

--- a/modules/core/include/visp3/core/vpRotationVector.h
+++ b/modules/core/include/visp3/core/vpRotationVector.h
@@ -44,16 +44,15 @@
   (cannot be used as is !)
 */
 
-
-
+#include <iostream>
+#include <math.h>
+#include <stdio.h>
 
 #include <visp3/core/vpMath.h>
-#include <visp3/core/vpRowVector.h>
-#include <stdio.h>
-#include <iostream>
+//#include <visp3/core/vpRowVector.h>
 
-
-#include <math.h>
+class vpRowVector;
+class vpColVector; //
 
 /*!
   \class vpRotationVector
@@ -89,11 +88,11 @@ int main()
 
 class VISP_EXPORT vpRotationVector
 {  
-  friend class vpColVector;
 protected:
   double *r ;
   unsigned int _size;
   void init(const unsigned int size);
+
 public:
   //! Constructor that constructs a vector of size 3 and initialize all values to zero.
   vpRotationVector()
@@ -119,6 +118,9 @@ public:
 
   virtual ~vpRotationVector();
 
+  /** @name Common inherited functionalities  */
+  //@{
+
   /*!
     Operator that allows to set the value of an element of the rotation 
     vector: r[i] = value
@@ -142,6 +144,7 @@ public:
     }
     return *this;
   }
+  vpRotationVector operator*(double x) const;
 
   /*! Returns the size of the rotation vector
    */
@@ -151,8 +154,10 @@ public:
   vpRowVector t() const;
 
   friend VISP_EXPORT std::ostream &operator << (std::ostream &s, const vpRotationVector &m);
-
+  //@}
 } ;
+
+VISP_EXPORT vpRotationVector operator*(const double &x, const vpRotationVector &A) ;
 
 #endif
 

--- a/modules/core/include/visp3/core/vpRowVector.h
+++ b/modules/core/include/visp3/core/vpRowVector.h
@@ -232,6 +232,11 @@ public:
   */
   //@{
   /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
+  /*!
      \deprecated You should rather use stack(const vpRowVector &)
    */
   vp_deprecated void stackMatrices(const vpRowVector &r) { stack(r); };

--- a/modules/core/include/visp3/core/vpRowVector.h
+++ b/modules/core/include/visp3/core/vpRowVector.h
@@ -43,6 +43,7 @@
 #include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpMatrix.h>
+#include <visp3/core/vpMath.h>
 
 class vpMatrix;
 class vpColVector;

--- a/modules/core/include/visp3/core/vpRowVector.h
+++ b/modules/core/include/visp3/core/vpRowVector.h
@@ -35,15 +35,17 @@
  *
  *****************************************************************************/
 
-
-
-
 #ifndef vpRowVector_H
 #define vpRowVector_H
 
+#include <vector>
+
+#include <visp3/core/vpArray2D.h>
+#include <visp3/core/vpColVector.h>
 #include <visp3/core/vpMatrix.h>
 
 class vpMatrix;
+class vpColVector;
 
 /*!
   \file vpRowVector.h
@@ -55,113 +57,201 @@ class vpMatrix;
   \class vpRowVector
 
   \ingroup group_core_matrices
-  \brief Definition of the row vector class.
 
-  vpRowVector class provides a data structure for the row vectors as well
-  as a set of operations on these vectors
+  This class provides a data structure for a row vector that contains values of double.
+  It contains also some functions to achieve a set of operations on these vectors.
 
-  \author Eric Marchand (IRISA - INRIA Rennes)
-
-  \warning Note the vector in the class (*this) will be noted A in the comment
-
-  \ingroup libmath
+  The vpRowVector is derived from vpArray2D.
 */
-class VISP_EXPORT vpRowVector : public vpMatrix
+class VISP_EXPORT vpRowVector : public vpArray2D<double>
 {
-protected:
-  //! Constructor  (Take line i of matrix m)
-  vpRowVector(vpMatrix &m, unsigned int i);
-
 public:
-  //! Basic constructor.
-  vpRowVector() : vpMatrix() {};
-  //! Constructor of vector of size n.
-  vpRowVector(unsigned int n) : vpMatrix(1, n){};
-  //! Constructor of vector of size n. Each element is set to \e val.
-  vpRowVector(unsigned int n, double val) : vpMatrix(1, n, val){};
-  //! Copy constructor.
-  vpRowVector(const vpRowVector &v);
+  //! Basic constructor that creates an empty 0-size row vector.
+  vpRowVector() : vpArray2D<double>() {};
+  //! Construct a row vector of size n. All the elements are initialized to zero.
+  vpRowVector(unsigned int n) : vpArray2D<double>(1, n){};
+  //! Construct a row vector of size n. Each element is set to \e val.
+  vpRowVector(unsigned int n, double val) : vpArray2D<double>(1, n, val){};
+  //! Copy constructor that allows to construct a row vector from an other one.
+  vpRowVector(const vpRowVector &v) : vpArray2D<double>(v) {};
+  vpRowVector(const vpRowVector &v, unsigned int c, unsigned int ncols) ;
+  vpRowVector(const vpMatrix &M);
+  vpRowVector(const vpMatrix &M, unsigned int i);
+  vpRowVector(const std::vector<double> &v);
+  vpRowVector(const std::vector<float> &v);
 
+  /*!
+    Removes all elements from the vector (which are destroyed),
+    leaving the container with a size of 0.
+  */
+  void clear()
+  {
+    if (data != NULL ) {
+      free(data);
+      data=NULL;
+    }
+
+    if (rowPtrs!=NULL) {
+      free(rowPtrs);
+      rowPtrs=NULL ;
+    }
+    rowNum = colNum = dsize = 0;
+  }
+
+  /*!
+    Convert a column vector containing angles in degrees into radians.
+    \sa rad2deg()
+  */
+  inline void deg2rad() {
+    double d2r = M_PI/180.0;
+
+    (*this) *= d2r;
+  }
+
+  double euclideanNorm() const;
+  /*!
+     Extract a sub-row vector from a row vector.
+     \param c : Index of the column corresponding to the first element of the vector to extract.
+     \param size : Size of the vector to extract.
+     \exception vpException::fatalError If the vector to extract is not contained in the original one.
+
+     \code
+     vpRowVector r1;
+     for (unsigned int i=0; i<4; i++)
+       r1.stack(i);
+     // r1 is equal to [0 1 2 3]
+     vpRowVector r2 = r1.extract(1, 3);
+     // r2 is equal to [1 2 3]
+     \endcode
+   */
+  vpRowVector extract(unsigned int c, unsigned int size) const
+  {
+    if (c >= colNum || c+size > colNum) {
+      throw(vpException(vpException::fatalError,
+                        "Cannot extract a (1x%d) row vector from a (1x%d) row vector starting at index %d",
+                        size, colNum, c));
+    }
+
+    return vpRowVector(*this, c, size);
+  }
+
+  void init(const vpRowVector &v, unsigned int c, unsigned int ncols);
   void insert(unsigned int i, const vpRowVector &v);
 
-  /*! Set the size of the row vector.
-    \param i : Column vector size.
+  vpRowVector &normalize() ;
+  vpRowVector &normalize(vpRowVector &x) const ;
+
+  //! Operator that allows to set a value of an element \f$v_i\f$: v[i] = x
+  inline double &operator[](unsigned int n)             { return *(data+n); }
+  //! Operator that allows to get the value of an element \f$v_i\f$: x = v[i]
+  inline const double &operator[](unsigned int n) const { return *(data+n) ; }
+
+  //! Copy operator.   Allow operation such as A = v
+  vpRowVector &operator=(const vpRowVector &v);
+  vpRowVector &operator=(const vpMatrix &M);
+  vpRowVector &operator=(const std::vector<double> &v);
+  vpRowVector &operator=(const std::vector<float> &v);
+  vpRowVector &operator=(const double x);
+
+  double  operator*(const vpColVector &x) const;
+  vpRowVector operator*(const vpMatrix &M) const;
+  vpRowVector operator*(const double x) const;
+  vpRowVector &operator*=(double x);
+
+  vpRowVector operator/(const double x) const;
+  vpRowVector &operator/=(double x);
+
+  vpRowVector operator+(const vpRowVector &v) const;
+  vpRowVector &operator+=(vpRowVector v);
+
+  vpRowVector operator-(const vpRowVector &v) const;
+  vpRowVector &operator-=(vpRowVector v);
+  vpRowVector operator-() const;
+
+  vpRowVector &operator<<(const vpRowVector &v);
+
+  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
+  /*!
+    Convert a column vector containing angles in radians into degrees.
+    \sa deg2rad()
+  */
+  inline void rad2deg() {
+    double r2d = 180.0/M_PI;
+
+    (*this) *= r2d;
+  }
+  void reshape(vpMatrix & M,const unsigned int &nrows,const unsigned int &ncols);
+  vpMatrix reshape(const unsigned int &nrows,const unsigned int &ncols);
+  
+  /*! Modify the size of the row vector.
+    \param i : Size of the vector. This value corresponds to the vector number
+    of columns.
     \param flagNullify : If true, set the data to zero.
    */
   inline void resize(const unsigned int i, const bool flagNullify = true)
   {
-    vpMatrix::resize(1, i, flagNullify);
+    vpArray2D::resize(1, i, flagNullify);
   }
-  //! Access  V[i] = x
-  inline double &operator [](unsigned int n)             { return *(data+n); }
-  //! Access x = V[i]
-  inline const double &operator [](unsigned int n) const { return *(data+n) ; }
-
-  //! Copy operator.   Allow operation such as A = v
-  vpRowVector &operator=(const vpRowVector &v);
-  //! copy from a matrix
-  vpRowVector & operator=(const vpMatrix &m) ;
-  //! Initialize each element of the vector to x
-  vpRowVector& operator=(const double x);
-
-  //!operator dot product
-  double  operator*(const vpColVector &x) const;
-  //!operator dot product
-  vpRowVector operator*(const vpMatrix &A) const;
-
-  //! Addition of two vectors V = A+v
-  vpRowVector operator+(const vpRowVector &v) const;
-
-  //! Substraction of two vectors V = A-v
-  vpRowVector operator-(const vpRowVector &v) const;
-
-  //! Operator A = -A
-  vpRowVector operator-() const;
-  // Copy operator.   Allow operation such as A << v
-  vpRowVector &operator<<(const vpRowVector &v);
-
-  //! Reshape methods.
-  void reshape(vpMatrix & m,const unsigned int &nrows,const unsigned int &ncols);
-  vpMatrix reshape(const unsigned int &nrows,const unsigned int &ncols);
-  
-  void stack(const double &b);
-  void stack(const vpRowVector &B);
-  static vpRowVector stack(const vpRowVector &A, const vpRowVector &B);
-  static void stack(const vpRowVector &A, const vpRowVector &B, vpRowVector &C);
-
-  //! Transpose the vector.
-  vpColVector t() const;
-
-  //! Normalise the vector.
-  vpRowVector &normalize() ;
-  //! Normalise the vector.
-  vpRowVector &normalize(vpRowVector &x) const ;
-
-  //! compute the median
-  static double median(const vpRowVector &v) ;
-  //! compute the mean
-  static double mean(const vpRowVector &v)  ;
-  //! compute the standard deviation
-  static double stdev(const vpRowVector &v, const bool useBesselCorrection=false);
 
   /*!
+    Resize the row vector to a \e ncols-dimension vector.
+    This function can only be used with \e nrows = 1.
+    \param nrows : Vector number of rows. This value should be set to 1.
+    \param ncols : Vector number of columns. This value corresponds
+    to the size of the vector.
+    \param flagNullify : If true, set the data to zero.
+    \exception vpException::fatalError When \e nrows is not equal to 1.
 
-    Return the size of the vector in term of number of columns.
-
-  */
-  inline unsigned int size() const
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
   {
-    return getCols();
-  }
+    if (nrows != 1)
+      throw(vpException(vpException::fatalError,
+                        "Cannot resize a row vector to a (%dx%d) dimension vector that has more than one row",
+                        nrows, ncols));
+    vpArray2D::resize(nrows, ncols, flagNullify);
+  };
+
+  void stack(const double &d);
+  void stack(const vpRowVector &v);
+
+  double sumSquare() const;
+  vpColVector t() const;
+
+  static double mean(const vpRowVector &v)  ;
+  static double median(const vpRowVector &v) ;
+  static vpRowVector stack(const vpRowVector &A, const vpRowVector &B);
+  static void stack(const vpRowVector &A, const vpRowVector &B, vpRowVector &C);
+  static double stdev(const vpRowVector &v, const bool useBesselCorrection=false);
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use stack(const vpRowVector &)
+   */
+  vp_deprecated void stackMatrices(const vpRowVector &r) { stack(r); };
+  /*!
+     \deprecated You should rather use stack(const vpRowVector &A, const vpRowVector &B)
+   */
+  vp_deprecated static vpRowVector stackMatrices(const vpRowVector &A, const vpRowVector &B) { return stack(A, B); };
+  /*!
+     \deprecated You should rather use stack(const vpRowVector &A, const vpRowVector &B, vpRowVector &C)
+   */
+  vp_deprecated static void stackMatrices(const vpRowVector &A, const vpRowVector &B, vpRowVector &C) { stack(A, B, C); };
+
+  /*!
+     \deprecated You should rather use eye()
+   */
+  vp_deprecated void setIdentity(const double & val=1.0) ;
+  //@}
+#endif
 
 };
 
+VISP_EXPORT vpRowVector operator*(const double &x, const vpRowVector &v) ;
 
 #endif
-
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */

--- a/modules/core/include/visp3/core/vpRxyzVector.h
+++ b/modules/core/include/visp3/core/vpRxyzVector.h
@@ -52,8 +52,8 @@
 
 class vpRotationMatrix;
 class vpThetaUVector;
+class vpRotationVector;
 
-#include <visp3/core/vpMatrix.h>
 #include <visp3/core/vpRotationVector.h>
 #include <visp3/core/vpRotationMatrix.h>
 

--- a/modules/core/include/visp3/core/vpSubColVector.h
+++ b/modules/core/include/visp3/core/vpSubColVector.h
@@ -49,52 +49,43 @@
 /*!
   \class vpSubColVector
   \ingroup group_core_matrices
-  \brief Definition of the vpSubColVector
-  vpSubColVector class provides a mask on a vpColVector
-  all properties of vpColVector are available with
-  a vpSubColVector
+  This class provides a mask on a vpColVector. It has internally a
+  pointer to the parent vpColVector.
+  All properties of vpColVector are available with
+  a vpSubColVector.
 
   \author Jean Laneurit (IRISA - INRIA Rennes)
 
   \sa vpMatrix vpColvector vpRowVector
 */
-class VISP_EXPORT vpSubColVector : public vpColVector {
+class VISP_EXPORT vpSubColVector : public vpColVector
+{
 
-  private :
-      //!Copy constructor
-      vpSubColVector(const vpSubColVector& /* m */);      
-       
-  protected :
- 
-      //!Number of row of parent vpColvector at initialization
-      unsigned int pRowNum;
-      //!Parent vpColvector
-      vpColVector *parent;
-      
-  public:
+private :
+  //! Copy constructor unavaible
+  vpSubColVector(const vpSubColVector& /* m */);
 
-    //!Default constructor
-    vpSubColVector();
-    //!Constructor
-    vpSubColVector(vpColVector &v, const unsigned int & offset,const unsigned int & nrows);
-    //!Destructor
-    ~vpSubColVector();
-    
-    //! Initialisation of vpSubColVector
-    void init(vpColVector &v, const unsigned int & offset,const unsigned int & nrows);
-    
-    //!Check is partent vpColVector has changed since initialization
-    void checkParentStatus();
-      
-    //! Operation such as subA = subB
-    vpSubColVector & operator=(const vpSubColVector &B);
-    //! Operation such as subA = B
-    vpSubColVector & operator=(const vpColVector &B);
-    //! Operation such as subA = matrix B with size of B(N,1)
-    vpSubColVector & operator=(const vpMatrix &B); 
-    //! Operation such as subA = x
-    vpSubColVector & operator=(const double &x);
-        
+protected :
+
+  //! Number of row of parent vpColvector at initialization
+  unsigned int pRowNum;
+  //! Parent vpColvector
+  vpColVector *parent;
+
+public:
+
+  vpSubColVector();
+  vpSubColVector(vpColVector &v, const unsigned int & offset,const unsigned int & nrows);
+  virtual ~vpSubColVector();
+
+  void checkParentStatus();
+
+  void init(vpColVector &v, const unsigned int & offset,const unsigned int & nrows);
+
+  vpSubColVector & operator=(const vpSubColVector &B);
+  vpSubColVector & operator=(const vpColVector &B);
+  vpSubColVector & operator=(const vpMatrix &B);
+  vpSubColVector & operator=(const double &x);
 };
 
 #endif

--- a/modules/core/include/visp3/core/vpSubRowVector.h
+++ b/modules/core/include/visp3/core/vpSubRowVector.h
@@ -50,53 +50,44 @@
 /*!
   \class vpSubRowVector
   \ingroup group_core_matrices
-  \brief Definition of the vpSubRowVector
-  vpSubRowVector class provides a mask on a vpRowVector
-  all properties of vpRowVector are available with
-  a vpSubRowVector
+  This class provides a mask on a vpRowVector. It has internally a
+  pointer to the parent vpRowVector.
+  All properties of vpRowVector are available with
+  a vpSubRowVector.
 
   \author Jean Laneurit (IRISA - INRIA Rennes)
 
   \sa vpMatrix vpColvector vpRowVector
 */
 
-class VISP_EXPORT vpSubRowVector : public vpRowVector {
+class VISP_EXPORT vpSubRowVector : public vpRowVector
+{
 
-  private :
-      //!Copy constructor unavaible
-      vpSubRowVector(const vpSubRowVector& /* m */);
-       
-  protected :
- 
-      //!Number of row of parent vpColvector at initialization
-      unsigned int pColNum;
-      //!Parent vpColvector
-      vpRowVector *parent;
-      
-  public:
+private :
+  //! Copy constructor unavaible
+  vpSubRowVector(const vpSubRowVector& /* m */);
 
-    //!Default constructor
-    vpSubRowVector();
-    //!Constructor
-    vpSubRowVector(vpRowVector &v, const unsigned int & offset,const unsigned int & ncols);
-    //!Destructor
-    ~vpSubRowVector();
-    
-    //! Initialisation of vpSubRowVector
-    void init(vpRowVector &v, const unsigned int & offset,const unsigned int & ncols);
-    
-    //!Check is parent vpRowVector has changed since initialization
-    void checkParentStatus();
-      
-    //! Operation such as subA = subB
-    vpSubRowVector & operator=(const vpSubRowVector &B);
-    //! Operation such as subA = B
-    vpSubRowVector & operator=(const vpRowVector &B);
-    //! Operation such as subA = matrix B with size of B(N,1)
-    vpSubRowVector & operator=(const vpMatrix &B); 
-    //! Operation such as subA = x
-    vpSubRowVector & operator=(const double &x);
-    
+protected :
+
+  //! Number of row of parent vpColvector at initialization
+  unsigned int pColNum;
+  //! Parent vpColvector
+  vpRowVector *parent;
+
+public:
+
+  vpSubRowVector();
+  vpSubRowVector(vpRowVector &v, const unsigned int & offset,const unsigned int & ncols);
+  virtual ~vpSubRowVector();
+
+  void checkParentStatus();
+
+  void init(vpRowVector &v, const unsigned int & offset,const unsigned int & ncols);
+
+  vpSubRowVector & operator=(const vpSubRowVector &B);
+  vpSubRowVector & operator=(const vpRowVector &B);
+  vpSubRowVector & operator=(const vpMatrix &B);
+  vpSubRowVector & operator=(const double &x);
 };
 
 #endif

--- a/modules/core/include/visp3/core/vpThetaUVector.h
+++ b/modules/core/include/visp3/core/vpThetaUVector.h
@@ -47,10 +47,13 @@
 
 class vpHomogeneousMatrix;
 class vpRotationMatrix;
+class vpPoseVector;
 class vpRzyxVector;
 class vpRxyzVector;
 class vpRzyzVector;
+class vpColVector;
 
+#include <visp3/core/vpColVector.h>
 #include <visp3/core/vpRotationVector.h>
 #include <visp3/core/vpRotationMatrix.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -188,10 +191,3 @@ public:
 } ;
 
 #endif
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */
-

--- a/modules/core/include/visp3/core/vpTranslationVector.h
+++ b/modules/core/include/visp3/core/vpTranslationVector.h
@@ -46,7 +46,8 @@
   \brief Class that consider the case of a translation vector.
 */
 
-#include <visp3/core/vpColVector.h>
+#include <visp3/core/vpArray2D.h>
+#include <visp3/core/vpMatrix.h>
 
 
 /*!
@@ -56,7 +57,7 @@
   
   \brief Class that consider the case of a translation vector.
 
-  Let be \f$^{a}{\bf t}_{b} = [t_x,t_y,t_z]^\top\f$ be a translation
+  Let us denote \f$^{a}{\bf t}_{b} = [t_x,t_y,t_z]^\top\f$ the translation
   from frame \f$ a \f$ to frame \f$ b \f$.  The representation of a
   translation is a column vector of dimension 3.
 
@@ -86,55 +87,68 @@ int main()
   vpHomogeneousMatrix M(t, R);
 }
   \endcode
-
 */
-class VISP_EXPORT vpTranslationVector : public vpColVector
+class VISP_EXPORT vpTranslationVector : public vpArray2D<double>
 {
-private:
-    //! initialize a size 3 vector
-    void init() ;
-
 public:
 
-    /*!
+  /*!
       Default constructor.
       The translation vector is initialized to zero.
     */
-    vpTranslationVector() { init() ; }
-    // constructor from double in meter
-    vpTranslationVector(const double tx, const double ty, const double tz) ;
-    // copy constructor
-    vpTranslationVector(const vpTranslationVector &t);
-    void set(const double tx, const double ty, const double tz) ;
+  vpTranslationVector() : vpArray2D<double>(3, 1) {};
+  vpTranslationVector(const double tx, const double ty, const double tz) ;
+  vpTranslationVector(const vpTranslationVector &t);
 
-    // operators
+  // operators
 
-    // translation vectors additions  c = a + b (a, b  unchanged)
-    vpTranslationVector operator+(const vpTranslationVector &t) const ;
-    // translation vectors substraction  c = a - b (a, b  unchanged)
-    vpTranslationVector operator-(const vpTranslationVector &t) const ;
-    // negate t = -a  (t is unchanged)
-    vpTranslationVector operator-() const ;
-    // b = x * a (x=scalar)
-    vpTranslationVector operator*(const double x) const;
-    // Copy operator.   Allow operation such as A = v
-    vpTranslationVector &operator=(const vpTranslationVector &t);
+  // translation vectors additions  c = a + b (a, b  unchanged)
+  vpTranslationVector operator+(const vpTranslationVector &t) const ;
+  // translation vectors substraction  c = a - b (a, b  unchanged)
+  vpTranslationVector operator-(const vpTranslationVector &t) const ;
+  // negate t = -a  (t is unchanged)
+  vpTranslationVector operator-() const ;
+  vpMatrix  operator*(const vpRowVector &v) const;
+  // b = x * a (x=scalar)
+  vpTranslationVector operator*(const double x) const;
+  vpTranslationVector & operator*=(double x);
+  vpTranslationVector operator/(const double x) const;
+  vpTranslationVector & operator/=(double x);
+  // Copy operator.   Allow operation such as A = v
+  vpTranslationVector &operator=(const vpTranslationVector &t);
 
-    vpTranslationVector &operator=(double x) ;
+  vpTranslationVector &operator=(double x) ;
 
+  //! Operator that allows to set a value of an element \f$t_i\f$: t[i] = x
+  inline double &operator [](unsigned int n) {  return *(data + n);  }
+  //! Operator that allows to get the value of an element \f$t_i\f$: x = t[i]
+  inline const double &operator [](unsigned int n) const { return *(data+n);  }
 
-    // Skew Symmetric matrix
-    vpMatrix skew() const ;
-    static vpMatrix skew(const vpTranslationVector &t) ;
-    static void skew(const  vpTranslationVector &t, vpMatrix &M) ;
-    static vpTranslationVector cross(const vpTranslationVector &a,
-				     const vpTranslationVector &b) ;
+  /*!
+    This function is not applicable to a translation vector that is always a
+    3-by-1 column vector.
+    \exception vpException::fatalError When this function is called.
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    (void)nrows;
+    (void)ncols;
+    (void)flagNullify;
+    throw(vpException(vpException::fatalError, "Cannot resize a translation vector"));
+  };
+
+  void set(const double tx, const double ty, const double tz) ;
+
+  // Skew Symmetric matrix
+  vpMatrix skew() const ;
+
+  vpRowVector t() const;
+
+  static vpTranslationVector cross(const vpTranslationVector &a,
+                                   const vpTranslationVector &b) ;
+  static vpMatrix skew(const vpTranslationVector &t) ;
+  static void skew(const  vpTranslationVector &t, vpMatrix &M) ;
 } ;
 
 #endif
-
-/*
- * Local variables:
- * c-basic-offset: 4
- * End:
- */

--- a/modules/core/include/visp3/core/vpVelocityTwistMatrix.h
+++ b/modules/core/include/visp3/core/vpVelocityTwistMatrix.h
@@ -39,6 +39,7 @@
 #ifndef vpVelocityRwistMatrix_h
 #define vpVelocityRwistMatrix_h
 
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpMatrix.h>
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -50,13 +51,12 @@
 
   \ingroup group_core_transformations
 
-  \brief Class that consider the particular case of twist
+  Class that consider the particular case of twist
   transformation matrix that allows to transform a velocity skew from
   one frame to an other.
 
-  The vpVelocityTwistMatrix is derived from vpMatrix.
-
-  A twist transformation matrix is 6x6 matrix defined as
+  A twist transformation matrix is a 6x6 matrix that express a velocity in frame <em>a</em> knowing
+  velocity in <em>b</em>. This matrix is defined as:
   \f[
   ^a{\bf V}_b = \left[\begin{array}{cc}
   ^a{\bf R}_b & [^a{\bf t}_b]_\times \; ^a{\bf R}_b\\
@@ -64,10 +64,11 @@
   \end{array}
   \right]
   \f]
-  that expressed a velocity in frame <em>a</em> knowing velocity in <em>b</em>.
 
-  \f$ ^a{\bf R}_b \f$ is a rotation matrix and
+  where \f$ ^a{\bf R}_b \f$ is a rotation matrix and
   \f$ ^a{\bf t}_b \f$ is a translation vector.
+
+  The vpVelocityTwistMatrix is derived from vpArray2D.
 
   The code belows shows for example how to convert a velocity skew
   from camera frame to a fix frame.
@@ -95,60 +96,74 @@ int main()
 }
   \endcode
 */
-class VISP_EXPORT vpVelocityTwistMatrix : public vpMatrix
+class VISP_EXPORT vpVelocityTwistMatrix : public vpArray2D<double>
 {
   friend class vpMatrix;
 
  public:
   // basic constructor
-  vpVelocityTwistMatrix()   ;
+  vpVelocityTwistMatrix();
   // copy constructor
-  vpVelocityTwistMatrix(const vpVelocityTwistMatrix &V) ;
+  vpVelocityTwistMatrix(const vpVelocityTwistMatrix &V);
   // constructor from an homogeneous transformation
-  vpVelocityTwistMatrix(const vpHomogeneousMatrix &M) ;
+  vpVelocityTwistMatrix(const vpHomogeneousMatrix &M);
 
   // Construction from Translation and rotation (ThetaU parameterization)
   vpVelocityTwistMatrix(const vpTranslationVector &t, const vpThetaUVector &thetau) ;
   // Construction from Translation and rotation (matrix parameterization)
-  vpVelocityTwistMatrix(const vpTranslationVector &t, const vpRotationMatrix &R) ;
-  vpVelocityTwistMatrix(const double tx,   const double ty,   const double tz,
-			const double tux,  const double tuy,  const double tuz) ;
+  vpVelocityTwistMatrix(const vpTranslationVector &t, const vpRotationMatrix &R);
+  vpVelocityTwistMatrix(const double tx,  const double ty,  const double tz,
+                        const double tux, const double tuy, const double tuz);
 
-  // Basic initialisation (identity)
-  void init() ;
 
   vpVelocityTwistMatrix buildFrom(const vpTranslationVector &t,
-				  const vpRotationMatrix &R);
+                                  const vpRotationMatrix &R);
   vpVelocityTwistMatrix buildFrom(const vpTranslationVector &t,
-				  const vpThetaUVector &thetau);
+                                  const vpThetaUVector &thetau);
   vpVelocityTwistMatrix buildFrom(const vpHomogeneousMatrix &M) ;
 
+  void extract( vpRotationMatrix &R) const;
+  void extract(vpTranslationVector &t) const;
+
   // Basic initialisation (identity)
-  void setIdentity() ;
+  void eye() ;
+
+  vpVelocityTwistMatrix inverse() const ;
+  void inverse(vpVelocityTwistMatrix &V) const;
 
   vpVelocityTwistMatrix operator*(const vpVelocityTwistMatrix &V) const ;
   vpMatrix operator*(const vpMatrix &M) const ;
-
   vpColVector operator*(const vpColVector &v) const ;
 
-  // copy operator from vpMatrix (handle with care)
   vpVelocityTwistMatrix &operator=(const vpVelocityTwistMatrix &V);
 
-  //! invert the twist matrix
-  vpVelocityTwistMatrix inverse() const ;
-  //! invert the twist matrix
-  void inverse(vpVelocityTwistMatrix &Wi) const;
+  int print(std::ostream& s, unsigned int length, char const* intro=0) const;
 
-  //! extract the rotational matrix from the twist matrix
-  void extract( vpRotationMatrix &R) const;
-  //! extract the translation vector from the twist matrix
-  void extract(vpTranslationVector &t) const;
+  /*!
+    This function is not applicable to a velocity twist matrix that is always a
+    6-by-6 matrix.
+    \exception vpException::fatalError When this function is called.
+    */
+  void resize(const unsigned int nrows, const unsigned int ncols,
+              const bool flagNullify = true)
+  {
+    (void)nrows;
+    (void)ncols;
+    (void)flagNullify;
+    throw(vpException(vpException::fatalError, "Cannot resize a velocity twist matrix"));
+  };
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+     \deprecated You should rather use eye().
+   */
+  vp_deprecated void setIdentity();
+  //@}
+#endif
 } ;
 
 #endif
-
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */

--- a/modules/core/include/visp3/core/vpVelocityTwistMatrix.h
+++ b/modules/core/include/visp3/core/vpVelocityTwistMatrix.h
@@ -159,6 +159,11 @@ class VISP_EXPORT vpVelocityTwistMatrix : public vpArray2D<double>
   */
   //@{
   /*!
+     \deprecated Provided only for compat with previous releases.
+     This function does nothing.
+   */
+  vp_deprecated void init() {};
+  /*!
      \deprecated You should rather use eye().
    */
   vp_deprecated void setIdentity();

--- a/modules/core/src/math/matrix/vpColVector.cpp
+++ b/modules/core/src/math/matrix/vpColVector.cpp
@@ -276,7 +276,7 @@ vpColVector::vpColVector (const vpMatrix &M)
    Constructor that creates a column vector from a std vector of double.
  */
 vpColVector::vpColVector (const std::vector<double> &v)
-  : vpArray2D<double>(1, v.size())
+  : vpArray2D<double>(1, (unsigned int)v.size())
 {
   for(unsigned int i=0; i< v.size(); i++)
     (*this)[i] = v[i];
@@ -285,7 +285,7 @@ vpColVector::vpColVector (const std::vector<double> &v)
    Constructor that creates a column vector from a std vector of float.
  */
 vpColVector::vpColVector (const std::vector<float> &v)
-  : vpArray2D<double>(1, v.size())
+  : vpArray2D<double>(1, (unsigned int)v.size())
 {
   for(unsigned int i=0; i< v.size(); i++)
     (*this)[i] = (double)(v[i]);
@@ -459,7 +459,7 @@ vpColVector &vpColVector::operator=(const vpMatrix &M)
 */
 vpColVector & vpColVector::operator=(const std::vector<double> &v)
 {
-  resize(v.size());
+  resize((unsigned int)v.size());
   for(unsigned int i=0; i<v.size(); i++)
     (*this)[i] = v[i];
   return *this;
@@ -469,7 +469,7 @@ vpColVector & vpColVector::operator=(const std::vector<double> &v)
 */
 vpColVector & vpColVector::operator=(const std::vector<float> &v)
 {
-  resize(v.size());
+	resize((unsigned int)v.size());
   for(unsigned int i=0; i<v.size(); i++)
     (*this)[i] = (float)v[i];
   return *this;

--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -89,48 +89,6 @@ vpMatrix::vpMatrix(const vpMatrix &M,
   init(M, r, c, nrows, ncols);
 }
 
-//! Copy constructor
-vpMatrix::vpMatrix(const vpMatrix& M)
-  : vpArray2D<double>(M.rowNum, M.colNum)
-{
-  memcpy(data, M.data, rowNum*colNum*sizeof(double)) ;
-}
-
-//! Create a matrix from a rotation matrix.
-vpMatrix::vpMatrix(const vpRotationMatrix& R)
-  : vpArray2D<double>(R.getRows(), R.getCols())
-{
-  memcpy(data, R.data, rowNum*colNum*sizeof(double)) ;
-}
-
-//! Create a matrix from a velocity twist matrix.
-vpMatrix::vpMatrix(const vpVelocityTwistMatrix& V)
-  : vpArray2D<double>(V.getRows(), V.getCols())
-{
-  memcpy(data, V.data, rowNum*colNum*sizeof(double)) ;
-}
-
-//! Create a matrix from a force/torque twist matrix.
-vpMatrix::vpMatrix(const vpForceTwistMatrix& F)
-  : vpArray2D<double>(F.getRows(), F.getCols())
-{
-  memcpy(data, F.data, rowNum*colNum*sizeof(double)) ;
-}
-
-//! Create a matrix from a column vector.
-vpMatrix::vpMatrix(const vpColVector& v)
-  : vpArray2D<double>(v.getRows(), v.getCols())
-{
-  memcpy(data, v.data, rowNum*colNum*sizeof(double)) ;
-}
-//! Create a matrix from a row vector.
-vpMatrix::vpMatrix(const vpRowVector& v)
-  : vpArray2D<double>(v.getRows(), v.getCols())
-{
-  memcpy(data, v.data, rowNum*colNum*sizeof(double)) ;
-}
-
-
 /*!
   Initialize the matrix from a part of an input matrix \e M.
 
@@ -206,7 +164,7 @@ vpMatrix::eye(unsigned int n)
   try {
     eye(n, n);
   }
-  catch(vpException &e) {
+  catch(...) {
     throw ;
   }
 }
@@ -221,7 +179,7 @@ vpMatrix::eye(unsigned int m, unsigned int n)
   try {
     resize(m,n) ;
   }
-  catch(vpException &e) {
+  catch(...) {
     throw ;
   }
 
@@ -440,93 +398,30 @@ vpMatrix vpMatrix::AtA() const
 }
 
 /*!
-  Copy operator.
-  Allow operation such as A = B
+  Copy operator that allows to convert on of the following container that
+  inherit from vpArray2D such as vpMatrix, vpRotationMatrix, vpHomogeneousMatrix,
+  vpPoseVector, vpColVector, vpRowVector... into a vpMatrix.
 
-  \param B : matrix to be copied.
+  \param A : 2D array to be copied.
+
+  The following example shows how to create a matrix from an homogeneous matrix:
+  \code
+  vpRotationMatrix R;
+  vpMatrix M = R;
+  \endcode
+
 */
 vpMatrix &
-vpMatrix::operator=(const vpMatrix &B)
+vpMatrix::operator=(const vpArray2D<double> &A)
 {
   try {
-    resize(B.rowNum, B.colNum) ;
+    resize(A.getRows(), A.getCols()) ;
   }
   catch(...) {
     throw ;
   }
 
-  memcpy(data, B.data, dsize*sizeof(double));
-
-  return *this;
-}
-/*!
-  Allow to set a matrix from a rotation matrix.
-
-  \param R : matrix to be copied.
-*/
-vpMatrix &
-vpMatrix::operator=(const vpRotationMatrix &R)
-{
-  resize(R.getRows(), R.getCols()) ;
-
-  memcpy(data, R.data, R.size()*sizeof(double));
-
-  return *this;
-}
-/*!
-  Allow to set a matrix from a velocity twist matrix.
-
-  \param V : matrix to be copied.
-*/
-vpMatrix &
-vpMatrix::operator=(const vpVelocityTwistMatrix &V)
-{
-  resize(V.getRows(), V.getCols()) ;
-
-  memcpy(data, V.data, V.size()*sizeof(double));
-
-  return *this;
-}
-/*!
-  Allow to set a matrix from a force/torque twist matrix.
-
-  \param V : matrix to be copied.
-*/
-vpMatrix &
-vpMatrix::operator=(const vpForceTwistMatrix &F)
-{
-  resize(F.getRows(), F.getCols()) ;
-
-  memcpy(data, F.data, F.size()*sizeof(double));
-
-  return *this;
-}
-
-/*!
-  Allow to set a matrix from a column vector.
-
-  \param v : vector to be copied.
-*/
-vpMatrix &
-vpMatrix::operator=(const vpColVector &v)
-{
-  resize(v.getRows(), v.getCols()) ;
-
-  memcpy(data, v.data, v.size()*sizeof(double));
-
-  return *this;
-}
-/*!
-  Allow to set a matrix from a row vector.
-
-  \param v : vector to be copied.
-*/
-vpMatrix &
-vpMatrix::operator=(const vpRowVector &v)
-{
-  resize(v.getRows(), v.getCols()) ;
-
-  memcpy(data, v.data, v.size()*sizeof(double));
+  memcpy(data, A.data, dsize*sizeof(double));
 
   return *this;
 }
@@ -2248,7 +2143,7 @@ vpMatrix::getRow(const unsigned int i, const unsigned int j_begin, const unsigne
 }
 
 /*!
-  Stack matrix \e B to the end of matrix \A and return the resulting matrix  [ A B ]^T
+  Stack matrix \e B to the end of matrix \e A and return the resulting matrix  [ A B ]^T
 
   \param A : Upper matrix.
   \param B : Lower matrix.
@@ -2275,10 +2170,10 @@ vpMatrix::stack(const vpMatrix &A, const vpMatrix &B)
   Stack row vector \e r to matrix \e A and return the resulting matrix [ A r ]^T
 
   \param A : Upper matrix.
-  \param B : Lower matrix.
+  \param r : Lower matrix.
   \return Stacked matrix [ A r ]^T
 
-  \warning A and r must have the same number of columns.
+  \warning \e A and \e r must have the same number of columns.
 */
 vpMatrix
 vpMatrix::stack(const vpMatrix &A, const vpRowVector &r)
@@ -2296,7 +2191,7 @@ vpMatrix::stack(const vpMatrix &A, const vpRowVector &r)
 }
 
 /*!
-  Stack matrix \e B to the end of matrix \A and return the resulting matrix in \e C.
+  Stack matrix \e B to the end of matrix \e A and return the resulting matrix in \e C.
 
   \param  A : Upper matrix.
   \param  B : Lower matrix.
@@ -2338,7 +2233,7 @@ vpMatrix::stack(const vpMatrix &A, const vpMatrix &B, vpMatrix &C)
 }
 
 /*!
-  Stack row vector \e v to the end of matrix \A and return the resulting matrix in \e C.
+  Stack row vector \e v to the end of matrix \e A and return the resulting matrix in \e C.
 
   \param  A : Upper matrix.
   \param  r : Lower row vector.
@@ -3200,358 +3095,6 @@ double vpMatrix::det(vpDetMethod method) const
   return (det_);
 }
 
-
-/*!
-  Save a matrix to a file.
-
-  \param filename : Absolute file name.
-  \param M : Matrix to be saved.
-  \param binary : If true the matrix is saved in a binary file, else a text file.
-  \param header : Optional line that will be saved at the beginning of the file.
-
-  \return Returns true if no problem happened.
-
-  Warning : If you save the matrix as in a text file the precision is
-  less than if you save it in a binary file.
-*/
-bool
-vpMatrix::saveMatrix(const char *filename, const vpMatrix &M, 
-                     const bool binary, const char *header)
-{
-  std::fstream file;
-
-  if (!binary)
-    file.open(filename, std::fstream::out);
-  else
-    file.open(filename, std::fstream::out|std::fstream::binary);
-
-  if(!file)
-  {
-    file.close();
-    return false;
-  }
-
-  else
-  {
-    if (!binary)
-    {
-      unsigned int i = 0;
-      file << "# ";
-      while (header[i] != '\0')
-      {
-        file << header[i];
-        if (header[i] == '\n')
-          file << "# ";
-        i++;
-      }
-      file << '\0';
-      file << std::endl;
-      file << M.getRows() << "\t" << M.getCols() << std::endl;
-      file << M << std::endl;
-    }
-    else
-    {
-      int headerSize = 0;
-      while (header[headerSize] != '\0') headerSize++;
-      file.write(header,headerSize+1);
-      unsigned int matrixSize;
-      matrixSize = M.getRows();
-      file.write((char*)&matrixSize,sizeof(int));
-      matrixSize = M.getCols();
-      file.write((char*)&matrixSize,sizeof(int));
-      double value;
-      for(unsigned int i = 0; i < M.getRows(); i++)
-      {
-        for(unsigned int j = 0; j < M.getCols(); j++)
-        {
-          value = M[i][j];
-          file.write((char*)&value,sizeof(double));
-        }
-      }
-    }
-  }
-
-  file.close();
-  return true;
-}
-
-/*!
-  Save a matrix in a YAML-formatted file.
-
-  \param filename : absolute file name.
-  \param M : matrix to be saved in the file.
-  \param header : optional lines that will be saved at the beginning of the file. Should be YAML-formatted and will adapt to the indentation if any.
-
-  \return Returns true if success.
-
-  Here is an example of outputs.
-\code
-vpMatrix M(3,4);
-vpMatrix::saveMatrixYAML("matrix.yml", M, "example: a YAML-formatted header");
-vpMatrix::saveMatrixYAML("matrixIndent.yml", M, "example:\n    - a YAML-formatted header\n    - with inner indentation");
-\endcode
-Content of matrix.yml:
-\code
-example: a YAML-formatted header
-rows: 3
-cols: 4
-data:
-  - [0, 0, 0, 0]
-  - [0, 0, 0, 0]
-  - [0, 0, 0, 0]
-\endcode
-Content of matrixIndent.yml:
-\code
-example:
-    - a YAML-formatted header
-    - with inner indentation
-rows: 3
-cols: 4
-data:
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-    - [0, 0, 0, 0]
-\endcode
-
-  \sa loadMatrixYAML()
-*/
-bool vpMatrix::saveMatrixYAML(const char *filename, const vpMatrix &M, const char *header)
-{
-  std::fstream file;
-
-  file.open(filename, std::fstream::out);
-
-  if(!file)
-  {
-    file.close();
-    return false;
-  }
-
-  unsigned int i = 0;
-  bool inIndent = false;
-  std::string indent = "";
-  bool checkIndent = true;
-  while (header[i] != '\0')
-  {
-    file << header[i];
-    if(checkIndent)
-    {
-      if (inIndent)
-      {
-        if(header[i] == ' ')
-          indent +=  " ";
-        else if (indent.length() > 0)
-          checkIndent = false;
-      }
-      if (header[i] == '\n' || (inIndent && header[i] == ' '))
-        inIndent = true;
-      else
-        inIndent = false;
-    }
-    i++;
-  }
-
-  if(i != 0)
-    file << std::endl;
-  file << "rows: " << M.getRows() << std::endl;
-  file << "cols: " << M.getCols() << std::endl;
-
-  if(indent.length() == 0)
-    indent = "  ";
-
-  file << "data: " << std::endl;
-  unsigned int j;
-  for(i=0;i<M.getRows();++i)
-  {
-    file << indent << "- [";
-    for(j=0;j<M.getCols()-1;++j)
-      file << M[i][j] << ", ";
-    file << M[i][j] << "]" << std::endl;
-  }
-
-  file.close();
-  return true;
-}
-
-
-/*!
-  Load a matrix from a file.
-
-  \param filename : Absolute file name.
-  \param M : Matrix to be loaded.
-  \param binary : If true the matrix is loaded from a binary file, 
-  else from a text file.
-  \param header : header of the file loaded in this parameter.
-
-  \return Returns true if no problem happened.
-*/
-bool
-vpMatrix::loadMatrix(const char *filename, vpMatrix &M, const bool binary, 
-                     char *header)
-{
-  std::fstream file;
-
-  if (!binary)
-    file.open(filename, std::fstream::in);
-  else
-    file.open(filename, std::fstream::in|std::fstream::binary);
-
-  if(!file)
-  {
-    file.close();
-    return false;
-  }
-
-  else
-  {
-    if (!binary)
-    {
-      char c='0';
-      std::string h;
-      while ((c != '\0') && (c != '\n'))
-      {
-        file.read(&c,1);
-        h+=c;
-      }
-      if (header != NULL)
-        strncpy(header, h.c_str(), h.size() + 1);
-
-      unsigned int rows, cols;
-      file >> rows;
-      file >> cols;
-
-      if (rows > std::numeric_limits<unsigned int>::max()
-          || cols > std::numeric_limits<unsigned int>::max())
-        throw vpException(vpException::badValue, "Matrix exceed the max size.");
-
-      M.resize(rows,cols);
-
-      double value;
-      for(unsigned int i = 0; i < rows; i++)
-      {
-        for(unsigned int j = 0; j < cols; j++)
-        {
-          file >> value;
-          M[i][j] = value;
-        }
-      }
-    }
-    else
-    {
-      char c='0';
-      std::string h;
-      while ((c != '\0') && (c != '\n'))
-      {
-        file.read(&c,1);
-        h+=c;
-      }
-      if (header != NULL)
-        strncpy(header, h.c_str(), h.size() + 1);
-
-      unsigned int rows, cols;
-      file.read((char*)&rows,sizeof(unsigned int));
-      file.read((char*)&cols,sizeof(unsigned int));
-      M.resize(rows,cols);
-
-      double value;
-      for(unsigned int i = 0; i < rows; i++)
-      {
-        for(unsigned int j = 0; j < cols; j++)
-        {
-          file.read((char*)&value,sizeof(double));
-          M[i][j] = value;
-        }
-      }
-    }
-  }
-
-  file.close();
-  return true;
-}
-
-
-/*!
-  Load a matrix from a YAML-formatted file.
-
-  \param filename : absolute file name.
-  \param M : matrix to be loaded from the file.
-  \param header : header of the file is loaded in this parameter.
-
-  \return Returns true on success.
-
-  \sa saveMatrixYAML()
-
-*/
-bool
-vpMatrix::loadMatrixYAML(const char *filename, vpMatrix &M, char *header)
-{
-  std::fstream file;
-
-  file.open(filename, std::fstream::in);
-
-  if(!file)
-  {
-    file.close();
-    return false;
-  }
-
-  unsigned int rows = 0,cols = 0;
-  std::string h;
-  std::string line,subs;
-  bool inheader = true;
-  unsigned int i=0, j;
-  unsigned int lineStart = 0;
-
-  while ( getline (file,line) )
-  {
-    if(inheader)
-    {
-      if(rows == 0 && line.compare(0,5,"rows:") == 0)
-      {
-        std::stringstream ss(line);
-        ss >> subs;
-        ss >> rows;
-      }
-      else if (cols == 0 && line.compare(0,5,"cols:") == 0)
-      {
-        std::stringstream ss(line);
-        ss >> subs;
-        ss >> cols;
-      }
-      else if (line.compare(0,5,"data:") == 0)
-        inheader = false;
-      else
-        h += line + "\n";
-    }
-    else
-    {
-      // if i == 0, we just got out of the header: initialize matrix dimensions
-      if(i == 0)
-      {
-        if(rows == 0 || cols == 0)
-        {
-          file.close();
-          return false;
-        }
-        M.resize(rows, cols);
-        // get indentation level which is common to all lines
-        lineStart = (unsigned int)line.find("[") + 1;
-      }
-      std::stringstream ss(line.substr(lineStart, line.find("]") - lineStart));
-      j = 0;
-      while(getline(ss, subs, ','))
-        M[i][j++] = atof(subs.c_str());
-      i++;
-    }
-  }
-
-  if (header != NULL)
-    strncpy(header, h.substr(0,h.length()-1).c_str(), h.size());
-
-  file.close();
-  return true;
-}
-
 /*!
 
   Compute the exponential matrix of a square matrix.
@@ -3590,7 +3133,7 @@ vpMatrix::expm()
     vpMatrix _expcX(rowNum, colNum);
     vpMatrix _eye(rowNum, colNum);
 
-    _eye.setIdentity();
+    _eye.eye();
     vpMatrix exp(*this);
 
     //      double f;

--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -506,6 +506,47 @@ vpMatrix::diag(const vpColVector &A)
 
 /*!
 
+  Set the matrix as a diagonal matrix where each element on the diagonal is set to \e val.
+  Elements that are not on the diagonal are set to 0.
+
+  \param val : Value to set.
+
+  \sa eye()
+
+\code
+#include <iostream>
+
+#include <visp3/core/vpMatrix.h>
+
+int main()
+{
+  vpMatrix A(3, 4);
+
+  A.diag(2);
+
+  std::cout << "A:\n" << A << std::endl;
+}
+\endcode
+
+  Matrix A is now equal to:
+\code
+2 0 0 0
+0 2 0 0
+0 0 2 0
+\endcode
+*/
+void
+vpMatrix::diag(const double &val)
+{
+  (*this) = 0;
+  unsigned int min_ = (rowNum < colNum) ? rowNum : colNum;
+  for (unsigned int i=0 ; i< min_ ; i++ )
+    (* this)[i][i] = val;
+}
+
+
+/*!
+
   Create a diagonal matrix with the element of a vector \f$ DA_{ii} = A_i \f$.
 
   \param  A : Vector which element will be put in the diagonal.
@@ -927,7 +968,7 @@ void vpMatrix::add2Matrices(const vpMatrix &A, const vpMatrix &B, vpMatrix &C)
 void vpMatrix::add2Matrices(const vpColVector &A, const vpColVector &B, vpColVector &C)
 {
   try  {
-    if ((A.rowNum != C.rowNum) || (B.colNum != C.colNum)) C.resize(A.rowNum,B.colNum);
+    if ((A.rowNum != C.rowNum) || (B.colNum != C.colNum)) C.resize(A.rowNum);
   }
   catch(...) {
     throw ;
@@ -979,7 +1020,7 @@ vpMatrix vpMatrix::operator+(const vpMatrix &B) const
 void vpMatrix::sub2Matrices(const vpColVector &A, const vpColVector &B, vpColVector &C)
 {
   try {
-    if ((A.rowNum != C.rowNum) || (A.colNum != C.colNum)) C.resize(A.rowNum,A.colNum);
+    if ((A.rowNum != C.rowNum) || (A.colNum != C.colNum)) C.resize(A.rowNum);
   }
   catch(...) {
     throw ;

--- a/modules/core/src/math/matrix/vpMatrix_covariance.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_covariance.cpp
@@ -172,7 +172,7 @@ vpMatrix::computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpCol
 //    vpMatrix Lthetau(3,3);
     vpMatrix LthetauInvAnalytic(3,3);
     vpMatrix I3(3,3);
-    I3.setIdentity();
+    I3.eye();
 //    Lthetau = -I3;
     LthetauInvAnalytic = -I3;
 

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -41,14 +41,17 @@
   \brief Definition of vpRowVector class member
 */
 
+#include <string.h>
+#include <stdlib.h>
+#include <sstream>
+#include <assert.h>
 
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpMatrix.h>
-#include <visp3/core/vpMatrixException.h>
+#include <visp3/core/vpException.h>
 #include <visp3/core/vpRowVector.h>
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpDebug.h>
-#include <string.h>
-#include <stdlib.h>
 
 //! Copy operator.   Allow operation such as A = v
 vpRowVector & vpRowVector::operator=(const vpRowVector &v)
@@ -58,10 +61,8 @@ vpRowVector & vpRowVector::operator=(const vpRowVector &v)
     try {
       resize(k);
     }
-    catch(vpException &/*e*/)
+    catch(...)
     {
-//      vpERROR_TRACE("Error caught");
-      std::cerr << "Problem with resize(" << k << ") !" << std::endl;
       throw;
     }
   }
@@ -72,25 +73,48 @@ vpRowVector & vpRowVector::operator=(const vpRowVector &v)
 }
 
 /*!
-  \brief copy from a matrix
-  \warning  Handled with care m should be a 1 column matrix
-*/
-vpRowVector & vpRowVector::operator=(const vpMatrix &m)
-{
-  if (m.getCols() != colNum)
-    resize(m.getCols());
+  Initialize a row vector from a 1-by-n size matrix.
+  \warning  Handled with care m should be a 1 column matrix.
 
-  memcpy(data, m.data, colNum*sizeof(double)) ;
-  /*
-  for (int i=0; i<rowNum; i++) {
-    for (int j=0; j<colNum; j++) {
-      rowPtrs[i][j] = m.rowPtrs[i][j];
-    }
-    }*/
+  \exception vpException::dimensionError If the matrix is not a 1-by-n dimension matrix.
+*/
+vpRowVector & vpRowVector::operator=(const vpMatrix &M)
+{
+  if (M.getRows() != 1 ) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot initialize a (1x%d) row vector from a (%dx%d) matrix",
+                      M.getCols(), M.getRows(), M.getCols())) ;
+  }
+
+  if (M.getCols() != colNum)
+    resize(M.getCols());
+
+  memcpy(data, M.data, colNum*sizeof(double)) ;
   return *this;
 }
 
-//! initialisation each element of the vector is x
+/*!
+  Initialize a row vector from a standard vector of double.
+*/
+vpRowVector & vpRowVector::operator=(const std::vector<double> &v)
+{
+  resize(v.size());
+  for(unsigned int i=0; i<v.size(); i++)
+    (*this)[i] = v[i];
+  return *this;
+}
+/*!
+  Initialize a row vector from a standard vector of double.
+*/
+vpRowVector & vpRowVector::operator=(const std::vector<float> &v)
+{
+  resize(v.size());
+  for(unsigned int i=0; i<v.size(); i++)
+    (*this)[i] = (float)v[i];
+  return *this;
+}
+
+//! Initialize each element of the vector with \e x.
 vpRowVector & vpRowVector::operator=(double x)
 {
   for (unsigned int i=0; i<rowNum; i++) {
@@ -109,7 +133,7 @@ vpRowVector & vpRowVector::operator=(double x)
 
   \warning The number of elements of the two vectors must be equal.
 
-  \exception vpMatrixException::matrixError : If the number of elements of the
+  \exception vpException::dimensionError : If the number of elements of the
   two vectors is not the same.
 
   \return A scalar.
@@ -120,7 +144,7 @@ double vpRowVector::operator*(const vpColVector &x) const
   unsigned int nelements = x.getRows();
   if (getCols() != nelements ) {
     throw(vpException(vpException::dimensionError,
-                      "Bad size during vpRowVector (1x%d) by vpColVector (%dx1) multiplication",
+                      "Cannot multiply (1x%d) row vector by (%dx1) column vector",
                       colNum, x.getRows())) ;
   }
 
@@ -133,71 +157,181 @@ double vpRowVector::operator*(const vpColVector &x) const
 }
 /*!
 
-  Multiply a row vector by a Matrix.
+  Multiply a row vector by a matrix.
 
-  \param A : Matrix.
+  \param M : Matrix.
 
-  \warning The number of elements of the rowVector must be equal to the number
+  \warning The number of elements of the row vector must be equal to the number
   of rows of the matrix.
 
-  \exception vpMatrixException::matrixError : If the number of elements of the
-  rowVector is not equal to the number of rows of the matrix.
+  \exception vpException::dimensionError If the number of elements of the
+  row vector is not equal to the number of rows of the matrix.
 
-  \return A vpRowVector.
+  \return The resulting row vector.
 
 */
-vpRowVector vpRowVector::operator*(const vpMatrix &A) const
+vpRowVector vpRowVector::operator*(const vpMatrix &M) const
 {
-  vpRowVector c(A.getCols());
+  vpRowVector c(M.getCols());
 
-  if (colNum != A.getRows())
-  {
-    vpERROR_TRACE("vpMatrix mismatch in vpRowVector/matrix multiply") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-                            "vpMatrix mismatch in vpRowVector/matrix multiply")) ;
+  if (colNum != M.getRows()) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot multiply (1x%d) row vector by (%dx%d) matrix",
+                      colNum, M.getRows(), M.getCols())) ;
   }
 
   c = 0.0;
 
   for (unsigned int i=0;i<colNum;i++) {
-    {
-      double bi = data[i] ; // optimization em 5/12/2006
-      for (unsigned int j=0;j<A.getCols();j++) {
-        c[j]+=bi*A[i][j];
-      }
+    double bi = data[i] ; // optimization em 5/12/2006
+    for (unsigned int j=0;j<M.getCols();j++) {
+      c[j]+=bi*M[i][j];
     }
   }
 
   return c ;
 }
 
-//! Operator A = -A
-vpRowVector vpRowVector::operator-() const
+/*!
+  Operator that allows to multiply each element of a row vector by a scalar.
+
+  \param x : The scalar.
+
+  \return The row vector multiplied by the scalar. The current
+  row vector (*this) is unchanged.
+
+  \code
+  vpRowVector v(3);
+  v[0] = 1;
+  v[1] = 2;
+  v[2] = 3;
+
+  vpRowVector w = v * 3;
+  // v is unchanged
+  // w is now equal to : [3 6 9]
+  \endcode
+*/
+vpRowVector vpRowVector::operator*(double x) const
 {
- vpRowVector A ;
- try {
-   A.resize(colNum)  ;
- }
- catch(vpException &/*e*/)
- {
-   vpERROR_TRACE("Error caught") ;
-   throw ;
- }
+  vpRowVector v(colNum);
 
- double *vd = A.data ;   double *d = data ;
+  double *vd = v.data ;   double *d = data ;
 
- for (unsigned int i=0; i<colNum; i++)
-   *(vd++)= - (*d++);
-
- return A;
+  for (unsigned int i=0;i<colNum;i++)
+    *(vd++) = (*d++) * x;
+  return v;
 }
 
-//! Substraction of two vectors V = A-v
+/*!
+  Operator that allows to multiply each element of a row vector by a scalar.
+
+  \param x : The scalar.
+
+  \return The row vector multiplied by the scalar.
+
+  \code
+  vpRowVector v(3);
+  v[0] = 1;
+  v[1] = 2;
+  v[2] = 3;
+
+  v *= 3;
+  // v is now equal to : [3 6 9]
+  \endcode
+*/
+vpRowVector &vpRowVector::operator*=(double x)
+{
+  for (unsigned int i=0;i<colNum;i++)
+    (*this)[i] *= x;
+  return (*this);
+}
+
+/*!
+  Operator that allows to divide each element of a row vector by a scalar.
+
+  \param x : The scalar.
+
+  \return The row vector divided by the scalar. The current
+  row vector (*this) is unchanged.
+
+  \code
+  vpRowVector v(3);
+  v[0] = 8;
+  v[1] = 4;
+  v[2] = 2;
+
+  vpRowVector w = v / 2;
+  // v is equal to : [8 4 2]
+  // w is equal to : [4 2 1]
+  \endcode
+*/
+vpRowVector vpRowVector::operator/(double x) const
+{
+  vpRowVector v(colNum);
+
+  double *vd = v.data ;   double *d = data ;
+
+  for (unsigned int i=0;i<colNum;i++)
+    *(vd++) = (*d++) / x;
+  return v;
+}
+
+/*!
+  Operator that allows to divide each element of a row vector by a scalar.
+
+  \param x : The scalar.
+
+  \return The row vector divided by the scalar.
+
+  \code
+  vpRowVector v(3);
+  v[0] = 8;
+  v[1] = 4;
+  v[2] = 2;
+  // v is equal to : [8 4 2]
+
+  v /= 2;
+  // v is equal to : [4 2 1]
+  \endcode
+*/
+vpRowVector &vpRowVector::operator/=(double x)
+{
+  for (unsigned int i=0;i<colNum;i++)
+    (*this)[i] /= x;
+  return (*this);
+}
+
+/*!
+   Operator that allows to negate all the row vector elements.
+
+   \code
+   vpRowVector r(3, 1);
+   // r contains [1 1 1]
+   vpRowVector v = -r;
+   // v contains [-1 -1 -1]
+   \endcode
+ */
+vpRowVector vpRowVector::operator-() const
+{
+  vpRowVector A(colNum);
+
+  double *vd = A.data ;   double *d = data ;
+
+  for (unsigned int i=0; i<colNum; i++)
+    *(vd++)= - (*d++);
+
+  return A;
+}
+
+/*!
+   Operator that allows to substract to row vectors that have the same size.
+   \exception vpException::dimensionError If the vectors size differ.
+ */
 vpRowVector vpRowVector::operator-(const vpRowVector &m) const
 {
   if (getCols() != m.getCols() ) {
     throw(vpException(vpException::dimensionError,
-                      "Bad size during vpRowVector (1x%d) and vpRowVector (1x%d) substraction",
+                      "Cannot substract (1x%d) row vector to (1x%d) row vector",
                       getCols(), m.getCols())) ;
   }
 
@@ -208,20 +342,59 @@ vpRowVector vpRowVector::operator-(const vpRowVector &m) const
   return v;
 }
 
-//! Addition of two vectors V = A-v
-vpRowVector vpRowVector::operator+(const vpRowVector &m) const
+/*!
+   Operator that allows to add to row vectors that have the same size.
+   \exception vpException::dimensionError If the vectors size differ.
+ */
+vpRowVector vpRowVector::operator+(const vpRowVector &v) const
 {
-  if (getCols() != m.getCols() ) {
+  if (getCols() != v.getCols() ) {
     throw(vpException(vpException::dimensionError,
-                      "Bad size during vpRowVector (1x%d) and vpRowVector (1x%d) substraction",
-                      getCols(), m.getCols())) ;
+                      "Cannot add (1x%d) row vector to (1x%d) row vector",
+                      getCols(), v.getCols())) ;
   }
 
-  vpRowVector v(colNum) ;
+  vpRowVector r(colNum) ;
 
   for (unsigned int i=0;i<colNum;i++)
-    v[i] = (*this)[i] + m[i];
-  return v;
+    r[i] = (*this)[i] + v[i];
+  return r;
+}
+
+/*!
+   Operator that allows to add two row vectors that have the same size.
+   \exception vpException::dimensionError If the size of the two vectors differ.
+ */
+vpRowVector &
+vpRowVector::operator+=(vpRowVector v)
+{
+  if (getCols() != v.getCols() ) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot add (1x%d) row vector to (1x%d) row vector",
+                      getCols(), v.getCols())) ;
+  }
+
+  for (unsigned int i=0;i<colNum;i++)
+    (*this)[i] += v[i];
+  return (*this);
+}
+
+/*!
+   Operator that allows to substract two row vectors that have the same size.
+   \exception vpException::dimensionError If the size of the two vectors differ.
+ */
+vpRowVector &
+vpRowVector::operator-=(vpRowVector v)
+{
+  if (getCols() != v.getCols() ) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot substract (1x%d) row vector to (1x%d) row vector",
+                      getCols(), v.getCols())) ;
+  }
+
+  for (unsigned int i=0;i<colNum;i++)
+    (*this)[i] -= v[i];
+  return (*this);
 }
 
 /*!
@@ -236,13 +409,12 @@ int main()
   for (unsigned int i=0; i<B.size(); i++)
     B[i] = i;
   A << B;
-  std::cout << "A: \n" << A << std::endl;
+  std::cout << "A: " << A << std::endl;
 }
   \endcode
   In row vector A we get:
   \code
-A:
-0  1  2  3  4
+A: 0  1  2  3  4
   \endcode
 
   */
@@ -253,40 +425,87 @@ vpRowVector & vpRowVector::operator<<(const vpRowVector &v)
 }
 
 /*!
-  \brief Transpose the row vector A
-
-  A is defined inside the class
-
-  \return  A^T
+  Transpose the row vector. The resulting vector becomes a column vector.
 */
 vpColVector vpRowVector::t() const
 {
-  vpColVector tmp(colNum);
-  memcpy(tmp.data, data, colNum*sizeof(double)) ;
-  /*
-  for (int i=0;i<colNum;i++)
-      tmp[i] = (*this)[i];
-  */
-  return tmp;
-}
-
-//! copy constructor
-vpRowVector::vpRowVector (const vpRowVector &v) : vpMatrix(v)
-{
-}
-
-//! Constructor  (Take line i of matrix m)
-vpRowVector::vpRowVector (vpMatrix &m, unsigned int i) : vpMatrix(m, i, 0, 1, m.getCols())
-{
+  vpColVector v(colNum);
+  memcpy(v.data, data, colNum*sizeof(double)) ;
+  return v;
 }
 
 /*!
-  \relates vpRowVector
-  \brief normalise the vector
+   Constructor that creates a row vector corresponding to row \e i
+   of matrix \e M.
+ */
+vpRowVector::vpRowVector (const vpMatrix &M, unsigned int i)
+  : vpArray2D<double>(1, M.getCols())
+{
+  for(unsigned int j=0; j< M.getCols(); j++)
+    (*this)[j] = M[i][j];
+}
+/*!
+   Constructor that creates a row vector from a 1-by-n matrix \e M.
+
+   \exception vpException::dimensionError If the matrix is not a 1-by-n matrix.
+ */
+vpRowVector::vpRowVector (const vpMatrix &M)
+  : vpArray2D<double>(1, M.getCols())
+{
+  if(M.getRows()!=1) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot construct a (1x%d) row vector from a (%dx%d) matrix",
+                      M.getCols(), M.getRows(), M.getCols())) ;
+  }
+
+  for(unsigned int j=0; j< M.getCols(); j++)
+    (*this)[j] = M[0][j];
+}
+
+/*!
+   Constructor that creates a row vector from a std vector of double.
+ */
+vpRowVector::vpRowVector (const std::vector<double> &v)
+  : vpArray2D<double>(1, v.size())
+{
+  for(unsigned int j=0; j< v.size(); j++)
+    (*this)[j] = v[j];
+}
+/*!
+   Constructor that creates a row vector from a std vector of float.
+ */
+vpRowVector::vpRowVector (const std::vector<float> &v)
+  : vpArray2D<double>(1, v.size())
+{
+  for(unsigned int j=0; j< v.size(); j++)
+    (*this)[j] = (double)(v[j]);
+}
+
+/*!
+  Construct a row vector from a part of an input row vector \e v.
+
+  \param v : Input row vector used for initialization.
+  \param c : column index in \e v that corresponds to the first element of the row vector to contruct.
+  \param ncols : Number of columns of the constructed row vector.
+
+  The sub-vector starting from v[c] element and ending on v[c+ncols-1] element
+  is used to initialize the contructed row vector.
+
+  \sa init()
+*/
+vpRowVector::vpRowVector (const vpRowVector &v, unsigned int c, unsigned int ncols)
+  : vpArray2D<double>(1, ncols)
+{
+  init(v, c, ncols);
+}
+
+/*!
+  Normalise the vector given as input parameter and return the normalized vector:
 
   \f[
-  {\bf x}_i = \frac{{\bf x}_i}{\sqrt{\sum_{i=1}^{n}x^2_i}}
+  {\bf x} = \frac{{\bf x}}{\sqrt{\sum_{i=1}^{n}x^2_i}}
   \f]
+  where \f$x_i\f$ is an element of the row vector \f$\bf x\f$.
 */
 vpRowVector &vpRowVector::normalize(vpRowVector &x) const
 {
@@ -297,12 +516,12 @@ vpRowVector &vpRowVector::normalize(vpRowVector &x) const
 
 
 /*!
-  \relates vpRowVector
-  \brief normalise the vector
+  Normalise the vector modifying the vector as:
 
   \f[
-  {\bf x}_i = \frac{{\bf x}_i}{\sqrt{\sum_{i=1}^{n}x^2_i}}
+  {\bf x} = \frac{{\bf x}}{\sqrt{\sum_{i=1}^{n}x^2_i}}
   \f]
+  where \f$x_i\f$ is an element of the row vector \f$\bf x\f$.
 */
 vpRowVector &vpRowVector::normalize()
 {
@@ -316,43 +535,43 @@ vpRowVector &vpRowVector::normalize()
 }
 
 /*!
-  \brief reshape the row vector in a matrix
-  \param nrows : number of rows of the matrix
-  \param ncols : number of columns of the matrix
-  \return a vpMatrix
+  Reshape the row vector in a matrix.
+  \param nrows : number of rows of the matrix.
+  \param ncols : number of columns of the matrix.
+  \return The resulting matrix.
+
+  \exception vpException::dimensionError If the matrix and the row vector have not the same size.
 */
-vpMatrix vpRowVector::reshape(const unsigned int &nrows,const unsigned int &ncols){
-  vpMatrix m(nrows,ncols);
-  reshape(m,nrows,ncols);
-  return m;
+vpMatrix vpRowVector::reshape(const unsigned int &nrows,const unsigned int &ncols)
+{
+  vpMatrix M(nrows,ncols);
+  reshape(M, nrows, ncols);
+  return M;
 }
 
 /*!
-  \brief reshape the row vector in a matrix
-  \param m : the reshaped Matrix
-  \param nrows : number of rows of the matrix
-  \param ncols : number of columns of the matrix
+  Reshape the row vector in a matrix.
+  \param M : the reshaped matrix.
+  \param nrows : number of rows of the matrix.
+  \param ncols : number of columns of the matrix.
+
+  \exception vpException::dimensionError If the matrix and the row vector have not the same size.
 */
-void vpRowVector::reshape(vpMatrix & m,const unsigned int &nrows,const unsigned int &ncols){
-  if(dsize!=nrows*ncols)
-  {
-    vpERROR_TRACE("\n\t\t vpSubRowVector mismatch size for reshape vpSubColVector in a vpMatrix") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-			    "\n\t\t \n\t\t vpSubRowVector mismatch size for reshape vpSubColVector in a vpMatrix")) ;
+void vpRowVector::reshape(vpMatrix & M,const unsigned int &nrows,const unsigned int &ncols){
+  if(dsize!=nrows*ncols) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot reshape (1x%d) row vector in (%dx%d) matrix",
+                      colNum, M.getRows(), M.getCols())) ;
   }
-  try 
-  {
-    if ((m.getRows() != nrows) || (m.getCols() != ncols)) m.resize(nrows,ncols);
+  try {
+    if ((M.getRows() != nrows) || (M.getCols() != ncols)) M.resize(nrows,ncols);
   }
-  catch(vpException &e)
-  {
-    vpERROR_TRACE("Error caught") ;
-    std::cout << e << std::endl ;
+  catch(...) {
     throw ;
   }
-     for(unsigned int i =0; i< nrows; i++)
-         for(unsigned int j =0; j< ncols; j++)
-         	  m[i][j]=data[i*nrows+j];
+  for(unsigned int i =0; i< nrows; i++)
+    for(unsigned int j =0; j< ncols; j++)
+      M[i][j]=data[i*nrows+j];
 }
 
 /*!
@@ -362,74 +581,74 @@ void vpRowVector::reshape(vpMatrix & m,const unsigned int &nrows,const unsigned 
 
   The following example shows how to use this function:
   \code
-#include <visp3/core/vpRowVector.h>
+#include <visp/vpRowVector.h>
 
 int main()
 {
   vpRowVector v(4);
   for (unsigned int i=0; i < v.size(); i++)
     v[i] = i;
-  std::cout << "v:\n" << v << std::endl;
+  std::cout << "v: " << v << std::endl;
 
   vpRowVector w(2);
   for (unsigned int i=0; i < w.size(); i++)
     w[i] = i+10;
-  std::cout << "w:\n" << w << std::endl;
+  std::cout << "w: " << w << std::endl;
 
   v.insert(1, w);
-  std::cout << "v:\n" << v << std::endl;
-}
-  \endcode
+  std::cout << "v: " << v << std::endl;
+}  \endcode
   It produces the following output:
   \code
-v:
-0  1  2  3
-w:
-10  11
-v:
-0  10  11  3
+v: 0  1  2  3
+w: 10  11
+v: 0  10  11  3
   \endcode
  */
 void vpRowVector::insert(unsigned int i, const vpRowVector &v)
 {
   if (i+v.size() > this->size())
-    throw(vpException(vpException::dimensionError, "Unable to insert a row vector"));
+    throw(vpException(vpException::dimensionError,
+                      "Unable to insert (1x%d) row vector in (1x%d) row vector at position (%d)",
+                      v.getCols(), colNum, i));
   for (unsigned int j=0; j < v.size(); j++)
     (*this)[i+j] = v[j];
 }
 
 /*!
-  Stack row vector with new element.
+  Stack row vector with a new element at the end of the vector.
 
-  \param b : Element to stack to the existing one.
+  \param d : Element to stack to the existing one.
 
   \code
-  vpRowVector A(3);
-  double b = 3;
-  A.stack(b); // A = [A b]
-  // A is now a 4 dimension row vector
+  vpRowVector v(3, 1);
+  // v is equal to [1 1 1]
+  v.stack(-2);
+  // v is equal to [1 1 1 -2]
   \endcode
 
   \sa stack(const vpRowVector &, const vpRowVector &)
   \sa stack(const vpRowVector &, const vpRowVector &, vpRowVector &)
 
 */
-void vpRowVector::stack(const double &b)
+void vpRowVector::stack(const double &d)
 {
   this->resize(colNum+1,false);
-  (*this)[colNum-1] = b;
+  (*this)[colNum-1] = d;
 }
 
 /*!
   Stack row vectors.
 
-  \param B : Vector to stack to the existing one.
+  \param v : Vector to stack to the existing one.
 
   \code
-  vpRowVector A(3);
-  vpRowVector B(5);
-  A.stack(B); // A = [A B]
-  // A is now an 8 dimension row vector
+  vpRowVector v1(3, 1);
+  // v1 is equal to [1 1 1]
+  vpRowVector v2(2, 3);
+  // v2 is equal to [3 3]
+  v1.stack(v2);
+  // v1 is equal to [1 1 1 3 3]
   \endcode
 
   \sa stack(const vpRowVector &, const double &)
@@ -437,9 +656,9 @@ void vpRowVector::stack(const double &b)
   \sa stack(const vpRowVector &, const vpRowVector &, vpRowVector &)
 
 */
-void vpRowVector::stack(const vpRowVector &B)
+void vpRowVector::stack(const vpRowVector &v)
 {
-  *this = vpRowVector::stack(*this, B);
+  *this = vpRowVector::stack(*this, v);
 }
 
 /*!
@@ -450,11 +669,13 @@ void vpRowVector::stack(const vpRowVector &B)
   \return Stacked vector \f$[A B]\f$.
 
   \code
-  vpRowVector A(3);
-  vpRowVector B(5);
-  vpRowVector C;
-  C = vpRowVector::stack(A, B); // C = [A B]
-  // C is now an 8 dimension row vector
+  vpRowVector r1(3, 1);
+  // r1 is equal to [1 1 1]
+  vpRowVector r2(2, 3);
+  // r2 is equal to [3 3]
+  vpRowVector v;
+  v = vpRowVector::stack(r1, r2);
+  // v is equal to [1 1 1 3 3]
   \endcode
 
   \sa stack(const vpRowVector &)
@@ -475,11 +696,13 @@ vpRowVector vpRowVector::stack(const vpRowVector &A, const vpRowVector &B)
   \param C : Resulting stacked vector \f$C = [A B]\f$.
 
   \code
-  vpRowVector A(3);
-  vpRowVector B(5);
-  vpRowVector C;
-  vpRowVector::stack(A, B, C); // C = [A B]
-  // C is now an 8 dimension row vector
+  vpRowVector r1(3, 1);
+  // r1 is equal to [1 1 1]
+  vpRowVector r2(2, 3);
+  // r2 is equal to [3 3]
+  vpRowVector v;
+  vpRowVector::stack(r1, r2, v);
+  // v is equal to [1 1 1 3 3]
   \endcode
 
   \sa stack(const vpRowVector &)
@@ -516,13 +739,13 @@ void vpRowVector::stack(const vpRowVector &A, const vpRowVector &B, vpRowVector 
 }
 
 /*!
-  \brief Compute the mean value of all the elements of the vector
+  Compute the mean value of all the elements of the vector.
 */
 double vpRowVector::mean(const vpRowVector &v)
 {
   if (v.data == NULL) {
-    vpERROR_TRACE("vpColVector v non initialized");
-    throw(vpMatrixException(vpMatrixException::notInitializedError));
+    throw(vpException(vpException::fatalError,
+                      "Cannot compute mean value of an empty row vector"));
   }
 
   double mean = 0;
@@ -534,15 +757,14 @@ double vpRowVector::mean(const vpRowVector &v)
 }
 
 /*!
-  Compute the median value of all the elements of the vector
+  Compute the median value of all the elements of the vector.
 */
 double
 vpRowVector::median(const vpRowVector &v)
 {
-  if (v.data==NULL)
-  {
-    vpERROR_TRACE("vpColVector v non initialized") ;
-    throw(vpMatrixException(vpMatrixException::notInitializedError)) ;
+  if (v.data==NULL) {
+    throw(vpException(vpException::fatalError,
+                      "Cannot compute mean value of an empty row vector"));
   }
 
   std::vector<double> vectorOfDoubles(v.size());
@@ -554,15 +776,14 @@ vpRowVector::median(const vpRowVector &v)
 }
 
 /*!
-  Compute the standard deviation value of all the elements of the vector
+  Compute the standard deviation value of all the elements of the vector.
 */
 double
 vpRowVector::stdev(const vpRowVector &v, const bool useBesselCorrection)
 {
-  if (v.data==NULL)
-  {
-    vpERROR_TRACE("vpColVector v non initialized") ;
-    throw(vpMatrixException(vpMatrixException::notInitializedError)) ;
+  if (v.data==NULL) {
+    throw(vpException(vpException::fatalError,
+                      "Cannot compute mean value of an empty row vector"));
   }
 
   double mean_value = mean(v);
@@ -577,4 +798,201 @@ vpRowVector::stdev(const vpRowVector &v, const bool useBesselCorrection)
   }
 
   return std::sqrt(sum_squared_diff / divisor);
+}
+
+/*!
+
+  Pretty print a row vector. The data are tabulated.
+  The common widths before and after the decimal point
+  are set with respect to the parameter maxlen.
+
+  \param s Stream used for the printing.
+
+  \param length The suggested width of each row vector element.
+  The actual width grows in order to accomodate the whole integral part,
+  and shrinks if the whole extent is not needed for all the numbers.
+  \param intro The introduction which is printed before the vector.
+  Can be set to zero (or omitted), in which case
+  the introduction is not printed.
+
+  \return Returns the common total width for all vector elements.
+
+  \sa std::ostream &operator<<(std::ostream &s, const vpArray2D<Type> &A)
+*/
+int
+vpRowVector::print(std::ostream& s, unsigned int length, char const* intro) const
+{
+  typedef std::string::size_type size_type;
+
+  unsigned int m = 1;
+  unsigned int n = getCols();
+
+  std::vector<std::string> values(m*n);
+  std::ostringstream oss;
+  std::ostringstream ossFixed;
+  std::ios_base::fmtflags original_flags = oss.flags();
+
+  // ossFixed <<std::fixed;
+  ossFixed.setf ( std::ios::fixed, std::ios::floatfield );
+
+  size_type maxBefore=0;  // the length of the integral part
+  size_type maxAfter=0;   // number of decimals plus
+  // one place for the decimal point
+  for (unsigned int j=0;j<n;++j){
+    oss.str("");
+    oss << (*this)[j];
+    if (oss.str().find("e")!=std::string::npos){
+      ossFixed.str("");
+      ossFixed << (*this)[j];
+      oss.str(ossFixed.str());
+    }
+
+    values[j]=oss.str();
+    size_type thislen=values[j].size();
+    size_type p=values[j].find('.');
+
+    if (p==std::string::npos){
+      maxBefore=vpMath::maximum(maxBefore, thislen);
+      // maxAfter remains the same
+    } else{
+      maxBefore=vpMath::maximum(maxBefore, p);
+      maxAfter=vpMath::maximum(maxAfter, thislen-p-1);
+    }
+  }
+
+
+  size_type totalLength=length;
+  // increase totalLength according to maxBefore
+  totalLength=vpMath::maximum(totalLength,maxBefore);
+  // decrease maxAfter according to totalLength
+  maxAfter=std::min(maxAfter, totalLength-maxBefore);
+  if (maxAfter==1) maxAfter=0;
+
+  // the following line is useful for debugging
+  //std::cerr <<totalLength <<" " <<maxBefore <<" " <<maxAfter <<"\n";
+
+  if (intro) s <<intro;
+  s <<"["<<m<<","<<n<<"]=\n";
+
+  s <<"  ";
+  for (unsigned int j=0;j<n;j++){
+    size_type p=values[j].find('.');
+    s.setf(std::ios::right, std::ios::adjustfield);
+    s.width((std::streamsize)maxBefore);
+    s <<values[j].substr(0,p).c_str();
+
+    if (maxAfter>0){
+      s.setf(std::ios::left, std::ios::adjustfield);
+      if (p!=std::string::npos){
+        s.width((std::streamsize)maxAfter);
+        s <<values[j].substr(p,maxAfter).c_str();
+      } else{
+        assert(maxAfter>1);
+        s.width((std::streamsize)maxAfter);
+        s <<".0";
+      }
+    }
+
+    s <<' ';
+  }
+  s <<std::endl;
+
+
+  s.flags(original_flags); // restore s to standard state
+
+  return (int)(maxBefore+maxAfter);
+}
+
+/*!
+  Allows to multiply a scalar by row vector.
+*/
+vpRowVector operator*(const double &x,const vpRowVector &v)
+{
+  vpRowVector vout ;
+  vout = v*x ;
+  return vout ;
+}
+
+/*!
+  Return the sum square of all the elements \f$v_{i}\f$ of the row vector v(n).
+
+  \return The sum square value: \f$\sum_{j=0}^{n} v_j^{2}\f$.
+  */
+double vpRowVector::sumSquare() const
+{
+  double sum_square=0.0;
+  double x ;
+
+  for (unsigned int j=0;j<colNum;j++) {
+    x=rowPtrs[0][j];
+    sum_square += x*x;
+  }
+
+  return sum_square;
+}
+
+/*!
+  Compute and return the Euclidean norm \f$ ||x|| = \sqrt{ \sum{v_{i}^2}} \f$.
+
+  \return The Euclidean norm if the vector is initialized, 0 otherwise.
+*/
+double vpRowVector::euclideanNorm() const
+{
+  double norm=0.0;
+  double x ;
+  for (unsigned int i=0;i<dsize;i++) {
+    x = *(data +i); norm += x*x;
+  }
+
+  return sqrt(norm);
+}
+
+/*!
+  Initialize the row vector from a part of an input row vector \e v.
+
+  \param v : Input row vector used for initialization.
+  \param c : column index in \e v that corresponds to the first element of the row vector to contruct.
+  \param ncols : Number of columns of the constructed row vector.
+
+  The sub-vector starting from v[c] element and ending on v[c+ncols-1] element
+  is used to initialize the contructed row vector.
+
+  The following code shows how to use this function:
+\code
+#include <visp3/core/vpRowVector.h>
+
+int main()
+{
+  vpRowVector v(4);
+  int val = 0;
+  for(size_t i=0; i<v.getCols(); i++) {
+    v[i] = val++;
+  }
+  std::cout << "v: " << v << std::endl;
+
+  vpRowVector w;
+  w.init(v, 1, 2);
+  std::cout << "w: " << w << std::endl;
+}
+\endcode
+  It produces the following output:
+  \code
+v: 0 1 2 3
+w: 1 2
+  \endcode
+ */
+void
+vpRowVector::init(const vpRowVector &v, unsigned int c, unsigned int ncols)
+{
+  unsigned int cncols = c+ncols ;
+
+  if (cncols > v.getCols())
+    throw(vpException(vpException::dimensionError,
+                      "Bad column dimension (%d > %d) used to initialize vpRowVector",
+                      cncols, v.getCols()));
+  resize(ncols);
+  if (this->rowPtrs == NULL) // Fix coverity scan: explicit null dereferenced
+    return; // Noting to do
+  for (unsigned int i=0 ; i < ncols; i++)
+    (*this)[i] = v[i+c];
 }

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -98,7 +98,7 @@ vpRowVector & vpRowVector::operator=(const vpMatrix &M)
 */
 vpRowVector & vpRowVector::operator=(const std::vector<double> &v)
 {
-  resize(v.size());
+  resize((unsigned int)v.size());
   for(unsigned int i=0; i<v.size(); i++)
     (*this)[i] = v[i];
   return *this;
@@ -108,7 +108,7 @@ vpRowVector & vpRowVector::operator=(const std::vector<double> &v)
 */
 vpRowVector & vpRowVector::operator=(const std::vector<float> &v)
 {
-  resize(v.size());
+  resize((unsigned int)v.size());
   for(unsigned int i=0; i<v.size(); i++)
     (*this)[i] = (float)v[i];
   return *this;
@@ -466,7 +466,7 @@ vpRowVector::vpRowVector (const vpMatrix &M)
    Constructor that creates a row vector from a std vector of double.
  */
 vpRowVector::vpRowVector (const std::vector<double> &v)
-  : vpArray2D<double>(1, v.size())
+  : vpArray2D<double>(1, (unsigned int)v.size())
 {
   for(unsigned int j=0; j< v.size(); j++)
     (*this)[j] = v[j];
@@ -475,7 +475,7 @@ vpRowVector::vpRowVector (const std::vector<double> &v)
    Constructor that creates a row vector from a std vector of float.
  */
 vpRowVector::vpRowVector (const std::vector<float> &v)
-  : vpArray2D<double>(1, v.size())
+  : vpArray2D<double>(1, (unsigned int)v.size())
 {
   for(unsigned int j=0; j< v.size(); j++)
     (*this)[j] = (double)(v[j]);

--- a/modules/core/src/math/matrix/vpSubColVector.cpp
+++ b/modules/core/src/math/matrix/vpSubColVector.cpp
@@ -35,44 +35,42 @@
  *
  *****************************************************************************/
 
+#include <stdlib.h>
 
 #include <visp3/core/vpSubColVector.h>
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
-#include <visp3/core/vpDebug.h>
-#include <stdlib.h>
 
+//! Default constructor that creates an empty vector.
 vpSubColVector::vpSubColVector()
-  : pRowNum(0), parent(NULL)
+  : vpColVector(), pRowNum(0), parent(NULL)
 {
 }
 
 /*!
-  \brief Constructor
-  \param v : parent col vector
-  \param offset : offset where subColVector start in the parent colVector
-  \param nrows : size of the subColVector
+  Construct a sub-column vector from a parent column vector.
+  \param v : parent column vector.
+  \param offset : offset where the sub-column vector starts in the parent column vector.
+  \param nrows : size of the sub-column vector.
 */
 vpSubColVector::vpSubColVector(vpColVector &v, const unsigned int & offset, const unsigned int & nrows)
-  : pRowNum(0), parent(NULL)
+  : vpColVector(), pRowNum(0), parent(NULL)
 {
-  init(v,offset,nrows);
+  init(v, offset, nrows);
 }
 
 /*!
-  \brief Initialisation of a the subColVector
-  \param v : parent col vector
-  \param offset : offset where subColVector start in the parent colVector
-  \param nrows : size of the subColVector
+  Initialize a sub-column vector from a parent column vector.
+  \param v : parent column vector.
+  \param offset : offset where the sub-column vector starts in the parent column vector.
+  \param nrows : size of the sub-column vector.
 */
 void vpSubColVector::init(vpColVector &v, 
-			  const unsigned int & offset, 
-			  const unsigned int & nrows){
-  
-  if(!v.data){
-    vpERROR_TRACE("\n\t\t vpSubColvector parent vpColVector has been destroyed");
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-			    "\n\t\t \n\t\t vpSubColvector parent vpColVector has been destroyed")) ;
+                          const unsigned int & offset,
+                          const unsigned int & nrows)
+{
+  if (!v.data) {
+    throw(vpException(vpException::fatalError,
+                      "Cannot initialize a sub-column vector from an empty parent column vector")) ;
   }
   
   if(offset+nrows<=v.getRows()){
@@ -88,50 +86,50 @@ void vpSubColVector::init(vpColVector &v,
       free(rowPtrs);
     }
     
-  rowPtrs=(double**)malloc( parent->getRows() * sizeof(double*));
+    rowPtrs=(double**)malloc( parent->getRows() * sizeof(double*));
     for(unsigned int i=0;i<nrows;i++)
       rowPtrs[i]=v.data+i+offset;
     
     dsize = rowNum ;
-    trsize =0 ;
-  }else{
-    vpERROR_TRACE("SubColVector cannot be contain in parent ColVector") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,"SubColVector cannot be contain in parent ColVector")) ;
+  } else {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot create a sub-column vector that is not completely containt in the parrent column vector")) ;
   }
 }
 
+//! Destructor that set the pointer to the parrent column vector to NULL.
 vpSubColVector::~vpSubColVector(){
   data=NULL ;
 }
 
-
 /*!
-  \brief This method can be used to detect if the parent colVector
-  always exits or its size have not changed and throw an exception is not
+  This method can be used to detect if the parent column vector
+  always exits or its size have not changed.
+  If this not the case an exception is thrown.
 */
 void vpSubColVector::checkParentStatus(){
-  if(!data){
-    vpERROR_TRACE("\n\t\t vpSubColvector parent vpColVector has been destroyed");
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-			    "\n\t\t \n\t\t vpSubColvector parent vpColVector has been destroyed")) ;
+  if (!data) {
+    throw(vpException(vpException::fatalError,
+                      "The parent of the current sub-column vector has been destroyed")) ;
   }
   if(pRowNum!=parent->getRows()){
-    vpERROR_TRACE("\n\t\t vpSubColvector size of parent vpColVector has been changed");
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,"\n\t\t \n\t\t vpSubColvector size of parent vpColVector has been changed")) ;
+    throw(vpException(vpException::dimensionError,
+                      "The size of the parent sub-column vector has changed")) ;
   }
 }
 
 /*!
-  \brief Operation A = B
-  \param B : a subColvector
+  Allow to initialize a sub-column vector from an other one using operation A = B.
+  Notice that the sub-column vector is not resized to the dimension of \e B.
+
+  \param B : a sub-column vector.
 */
-vpSubColVector & vpSubColVector::operator=(const vpSubColVector &B){
-  
-  if ( rowNum != B.getRows())
-  {
-    vpERROR_TRACE("\n\t\t vpSubColVector mismatch in operator vpSubColVector=vpSubColVector") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-			    "\n\t\t \n\t\t vpSubMatrix mismatch in operator vpSubColVector=vpSubColVector")) ;
+vpSubColVector & vpSubColVector::operator=(const vpSubColVector &B)
+{
+  if ( rowNum != B.getRows()) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot initialize (%dx1) sub-column vector from (%dx1) sub-column vector",
+                      rowNum, B.getRows())) ;
   }
   
   for (unsigned int i=0;i<rowNum;i++)
@@ -140,15 +138,16 @@ vpSubColVector & vpSubColVector::operator=(const vpSubColVector &B){
 }
 
 /*!
-  \brief Operation A = B
-  \param B : a rowVector
+  Allow to initialize a sub-column vector from a column vector using operation A = B.
+  Notice that the sub-column vector is not resized to the dimension of \e B.
+  \param B : a column vector.
 */
-vpSubColVector & vpSubColVector::operator=(const vpColVector &B){
-  if ( rowNum != B.getRows())
-  {
-    vpERROR_TRACE("\n\t\t vpSubColVector mismatch in operator vpSubColVector=vpColVector") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-			    "\n\t\t \n\t\t vpSubColVector mismatch in operator vpSubColVector=vpColVector")) ;
+vpSubColVector & vpSubColVector::operator=(const vpColVector &B)
+{
+  if ( rowNum != B.getRows()) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot initialize (%dx1) sub-column vector from (%dx1) column vector",
+                      rowNum, B.getRows())) ;
   }
   
   for (unsigned int i=0;i<rowNum;i++)
@@ -158,15 +157,16 @@ vpSubColVector & vpSubColVector::operator=(const vpColVector &B){
 }
 
 /*!
-  \brief Operation A = B 
-  \param B : a vpMatrix of size nrow x 1
+  Allow to initialize a sub-column vector from a m-by-1 matrix using operation A = B.
+  Notice that the sub-column vector is not resized to the dimension of \e B.
+  \param B : a matrix of size m-by-1.
 */
-vpSubColVector & vpSubColVector::operator=(const vpMatrix &B){
-  if ((B.getCols()!=1)||(rowNum != B.getRows()))
-  {
-    vpERROR_TRACE("\n\t\t vpSubColVector mismatch in operator vpSubColVector=vpMatrix") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-			    "\n\t\t \n\t\t vpSubColVector mismatch in operator vpSubColVector=vpMatrix")) ;
+vpSubColVector & vpSubColVector::operator=(const vpMatrix &B)
+{
+  if ((B.getCols()!=1)||(rowNum != B.getRows())) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot initialize (%dx1) sub-column vector from (%dx%d) matrix",
+                      rowNum, B.getRows(), B.getCols())) ;
   }
   
   for (unsigned int i=0;i<rowNum;i++)
@@ -175,10 +175,11 @@ vpSubColVector & vpSubColVector::operator=(const vpMatrix &B){
 }
 
 /*!
-  \brief Operation A = x 
-  \param x : a scalar value
+  Set all the elements of the sub-column vector to \e x.
+  \param x : a scalar value.
 */
-vpSubColVector & vpSubColVector::operator=(const double &x){
+vpSubColVector & vpSubColVector::operator=(const double &x)
+{
   for (unsigned int i=0;i<rowNum;i++)
     data[i] = x;
   return *this;

--- a/modules/core/src/math/matrix/vpSubMatrix.cpp
+++ b/modules/core/src/math/matrix/vpSubMatrix.cpp
@@ -93,7 +93,6 @@ void vpSubMatrix::init(vpMatrix &m, const unsigned int &row_offset, const unsign
       rowPtrs[r]= m.data+col_offset+(r+row_offset)*pColNum;
     
     dsize = pRowNum*pColNum ;
-    trsize =0 ;
   }else{
     vpERROR_TRACE("Submatrix cannot be contain in parent matrix") ;
     throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,"Submatrix cannot be contain in parent matrix")) ;

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -47,91 +47,72 @@
 #include <visp3/core/vpHomogeneousMatrix.h>
 #include <visp3/core/vpQuaternionVector.h>
 #include <visp3/core/vpPoint.h>
-
-// Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
-
-// Debug trace
-#include <visp3/core/vpDebug.h>
-
 
 /*!
-  Initialize a 4x4 momogeneous matrix as identity.
+  Construct an homogeneous matrix from a translation vector and quaternion rotation vector.
+ */
+vpHomogeneousMatrix::vpHomogeneousMatrix(const vpTranslationVector &t,
+                                         const vpQuaternionVector &q)
+  : vpArray2D<double>(4, 4)
+{
+  buildFrom(t,q);
+  (*this)[3][3] = 1.;
+}
+
+/*!
+  Default constructor that initialize an homogeneous matrix as identity.
 */
-void
-vpHomogeneousMatrix::init()
+vpHomogeneousMatrix::vpHomogeneousMatrix()
+  : vpArray2D<double>(4, 4)
 {
-  unsigned int i,j ;
-
-  try {
-    resize(4,4) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("Error caught") ;
-    throw ;
-  }
-
-
-  for (i=0 ; i < 4 ; i++)
-    for (j=0 ; j < 4; j++)
-      if (i==j)
-	(*this)[i][j] = 1.0 ;
-      else
-	(*this)[i][j] = 0.0;
-
-}
-
-vpHomogeneousMatrix::vpHomogeneousMatrix(const vpTranslationVector &tv,
-                                         const vpQuaternionVector &q) : vpMatrix()
-{
-  init();
-  buildFrom(tv,q);
+  eye() ;
 }
 
 /*!
-  Initialize an homogeneous matrix as identity.
+  Copy constructor that initialize an homogeneous matrix from another homogeneous matrix.
 */
-vpHomogeneousMatrix::vpHomogeneousMatrix() : vpMatrix()
+vpHomogeneousMatrix::vpHomogeneousMatrix(const vpHomogeneousMatrix &M)
+  : vpArray2D<double>(4, 4)
 {
-  init() ;
-}
-
-
-/*!
-  Initialize an homogeneous matrix from another homogeneous matrix.
-*/
-vpHomogeneousMatrix::vpHomogeneousMatrix(const vpHomogeneousMatrix &M) : vpMatrix()
-{
-  init() ;
-  *this = M ;
-}
-
-vpHomogeneousMatrix::vpHomogeneousMatrix(const vpTranslationVector &tv,
-                                         const vpThetaUVector &tu) : vpMatrix()
-{
-  init() ;
-  buildFrom(tv,tu) ;
-}
-
-vpHomogeneousMatrix::vpHomogeneousMatrix(const vpTranslationVector &tv,
-                                         const vpRotationMatrix &R) : vpMatrix()
-{
-  init() ;
-  insert(R) ;
-  insert(tv) ;
-}
-
-vpHomogeneousMatrix::vpHomogeneousMatrix(const vpPoseVector &p) : vpMatrix()
-{
-
-  init() ;
-  buildFrom(p[0],p[1],p[2],p[3],p[4],p[5]) ;
+  *this = M;
 }
 
 /*!
-  Creates an homogeneous matrix from a vector.
+  Construct an homogeneous matrix from a translation vector and \f$\theta {\bf u}\f$ rotation vector.
+ */
+vpHomogeneousMatrix::vpHomogeneousMatrix(const vpTranslationVector &t,
+                                         const vpThetaUVector &tu)
+  : vpArray2D<double>(4, 4)
+{
+  buildFrom(t, tu);
+  (*this)[3][3] = 1.;
+}
+
+/*!
+  Construct an homogeneous matrix from a translation vector and a rotation matrix.
+ */
+vpHomogeneousMatrix::vpHomogeneousMatrix(const vpTranslationVector &t,
+                                         const vpRotationMatrix &R)
+  : vpArray2D<double>(4, 4)
+{
+  insert(R);
+  insert(t);
+  (*this)[3][3] = 1.;
+}
+
+/*!
+  Construct an homogeneous matrix from a pose vector.
+ */
+vpHomogeneousMatrix::vpHomogeneousMatrix(const vpPoseVector &p)
+  : vpArray2D<double>(4, 4)
+{
+  buildFrom(p[0], p[1], p[2], p[3], p[4], p[5]) ;
+  (*this)[3][3] = 1.;
+}
+
+/*!
+  Construct an homogeneous matrix from a vector of float.
   \param v : Vector of 12 or 16 values corresponding to the values of the homogeneous matrix.
 
   The following example shows how to use this function:
@@ -168,14 +149,15 @@ M:
 0  0  0  1
   \endcode
   */
-vpHomogeneousMatrix::vpHomogeneousMatrix(const std::vector<float> &v) : vpMatrix()
+vpHomogeneousMatrix::vpHomogeneousMatrix(const std::vector<float> &v)
+  : vpArray2D<double>(4, 4)
 {
-  init() ;
   buildFrom(v) ;
+  (*this)[3][3] = 1.;
 }
 
 /*!
-  Creates an homogeneous matrix from a vector.
+  Construct an homogeneous matrix from a vector of double.
   \param v : Vector of 12 or 16 values corresponding to the values of the homogeneous matrix.
 
   The following example shows how to use this function:
@@ -212,76 +194,98 @@ M:
 0  0  0  1
   \endcode
   */
-vpHomogeneousMatrix::vpHomogeneousMatrix(const std::vector<double> &v) : vpMatrix()
+vpHomogeneousMatrix::vpHomogeneousMatrix(const std::vector<double> &v)
+  : vpArray2D<double>(4, 4)
 {
-  init() ;
   buildFrom(v) ;
+  (*this)[3][3] = 1.;
 }
 
+/*!
+  Construct an homogeneous matrix from a translation vector \f${\bf t}=(t_x, t_y, t_z)^T\f$
+  and a \f$\theta {\bf u}=(\theta u_x, \theta u_y, \theta u_z)^T\f$ rotation vector.
+ */
 vpHomogeneousMatrix::vpHomogeneousMatrix(const double tx,
-					 const double ty,
-					 const double tz,
-					 const double tux,
-					 const double tuy,
-					 const double tuz) : vpMatrix()
+                                         const double ty,
+                                         const double tz,
+                                         const double tux,
+                                         const double tuy,
+                                         const double tuz)
+  : vpArray2D<double>(4, 4)
 {
-  init() ;
-  buildFrom(tx, ty, tz,tux, tuy, tuz) ;
+  buildFrom(tx, ty, tz, tux, tuy, tuz);
+  (*this)[3][3] = 1.;
 }
 
+/*!
+  Build an homogeneous matrix from a translation vector
+  and a \f$\theta {\bf u}\f$ rotation vector.
+ */
 void
-vpHomogeneousMatrix::buildFrom(const vpTranslationVector &tv,
+vpHomogeneousMatrix::buildFrom(const vpTranslationVector &t,
                                const vpThetaUVector &tu)
 {
   insert(tu) ;
-  insert(tv) ;
+  insert(t) ;
 }
 
+/*!
+  Build an homogeneous matrix from a translation vector
+  and a rotation matrix.
+ */
 void
-vpHomogeneousMatrix::buildFrom(const vpTranslationVector &tv,
+vpHomogeneousMatrix::buildFrom(const vpTranslationVector &t,
                                const vpRotationMatrix &R)
 {
-  init() ;
   insert(R) ;
-  insert(tv) ;
+  insert(t) ;
 }
 
-
+/*!
+  Build an homogeneous matrix from a pose vector.
+ */
 void
 vpHomogeneousMatrix::buildFrom(const vpPoseVector &p)
 {
-
-  vpTranslationVector tv(p[0],p[1],p[2]) ;
-  vpThetaUVector tu(p[3],p[4],p[5]) ;
+  vpTranslationVector tv(p[0], p[1], p[2]);
+  vpThetaUVector tu(p[3], p[4], p[5]);
 
   insert(tu) ;
-  insert(tv) ;
-}
-
-void vpHomogeneousMatrix::buildFrom(const vpTranslationVector &tv,
-				    const vpQuaternionVector &q) 
-{
-  insert(tv);
-  insert(q);
-}
-
-void
-vpHomogeneousMatrix::buildFrom(const double tx,
-			       const double ty,
-			       const double tz,
-			       const double tux,
-			       const double tuy,
-			       const double tuz)
-{
-  vpRotationMatrix R(tux, tuy, tuz) ;
-  vpTranslationVector tv(tx, ty, tz) ;
-
-  insert(R) ;
   insert(tv) ;
 }
 
 /*!
-  Converts a vector to an homogeneous matrix.
+  Build an homogeneous matrix from a translation vector
+  and a quaternion rotation vector.
+ */
+void vpHomogeneousMatrix::buildFrom(const vpTranslationVector &t,
+                                    const vpQuaternionVector &q)
+{
+  insert(t);
+  insert(q);
+}
+
+/*!
+  Build an homogeneous matrix from a translation vector \f${\bf t}=(t_x, t_y, t_z)^T\f$
+  and a \f$\theta {\bf u}=(\theta u_x, \theta u_y, \theta u_z)^T\f$ rotation vector.
+ */
+void
+vpHomogeneousMatrix::buildFrom(const double tx,
+                               const double ty,
+                               const double tz,
+                               const double tux,
+                               const double tuy,
+                               const double tuz)
+{
+  vpRotationMatrix R(tux, tuy, tuz) ;
+  vpTranslationVector t(tx, ty, tz) ;
+
+  insert(R) ;
+  insert(t) ;
+}
+
+/*!
+  Build an homogeneous matrix from a vector of float.
   \param v : Vector of 12 or 16 values corresponding to the values of the homogeneous matrix.
 
   The following example shows how to use this function:
@@ -331,7 +335,7 @@ vpHomogeneousMatrix::buildFrom(const std::vector<float> &v)
 }
 
 /*!
-  Converts a vector to an homogeneous matrix.
+  Build an homogeneous matrix from a vector of double.
   \param v : Vector of 12 or 16 values corresponding to the values of the homogeneous matrix.
 
   The following example shows how to use this function:
@@ -381,20 +385,15 @@ vpHomogeneousMatrix::buildFrom(const std::vector<double> &v)
 }
 
 /*!
-  Affectation of two homogeneous matrices.
+  Copy operator that allows to set an homogeneous matrix from an other one.
 
-  \param M : *this = M
+  \param M : Matrix to copy.
 */
 vpHomogeneousMatrix &
 vpHomogeneousMatrix::operator=(const vpHomogeneousMatrix &M)
 {
-
-  if (rowPtrs != M.rowPtrs) init() ;
-
-  for (int i=0; i<4; i++)
-  {
-    for (int j=0; j<4; j++)
-    {
+  for (int i=0; i<4; i++) {
+    for (int j=0; j<4; j++) {
       rowPtrs[i][j] = M.rowPtrs[i][j];
     }
   }
@@ -402,7 +401,7 @@ vpHomogeneousMatrix::operator=(const vpHomogeneousMatrix &M)
 }
 
 /*!
-  Allow homogeneous matrix multiplication.
+  Operator that allow to multiply an homogeneous matrix by an other one.
 
   \code
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -426,7 +425,6 @@ vpHomogeneousMatrix::operator*(const vpHomogeneousMatrix &M) const
   vpRotationMatrix R1, R2, R ;
   vpTranslationVector T1, T2 , T;
 
-
   extract(T1) ;
   M.extract(T2) ;
 
@@ -443,9 +441,19 @@ vpHomogeneousMatrix::operator*(const vpHomogeneousMatrix &M) const
   return p;
 }
 
+/*!
+  Operator that allow to multiply an homogeneous matrix by a 4-dimension column vector.
+
+  \exception vpException::dimensionError : If the vector \e v is not a 4-dimension vector.
+*/
 vpColVector
 vpHomogeneousMatrix::operator*(const vpColVector &v) const
 {
+  if (v.getRows() != 4) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot multiply a (4x4) homogenous matrix by a (%dx1) column vector",
+                      v.getRows()));
+  }
   vpColVector p(rowNum);
 
   p = 0.0;
@@ -522,10 +530,8 @@ vpHomogeneousMatrix::isAnHomogeneousMatrix() const
 void
 vpHomogeneousMatrix::extract(vpRotationMatrix &R) const
 {
-  unsigned int i,j ;
-
-  for (i=0 ; i < 3 ; i++)
-    for (j=0 ; j < 3; j++)
+  for (unsigned int i=0 ; i < 3 ; i++)
+    for (unsigned int j=0 ; j < 3; j++)
       R[i][j] = (*this)[i][j] ;
 }
 
@@ -545,7 +551,6 @@ vpHomogeneousMatrix::extract(vpTranslationVector &tv) const
 void
 vpHomogeneousMatrix::extract(vpThetaUVector &tu) const
 {
-  
   vpRotationMatrix R;
   (*this).extract(R);
   tu.buildFrom(R);
@@ -568,17 +573,15 @@ vpHomogeneousMatrix::extract(vpQuaternionVector &q) const
 void
 vpHomogeneousMatrix::insert(const vpRotationMatrix &R)
 {
-  unsigned int i,j ;
-
-  for (i=0 ; i < 3 ; i++)
-    for (j=0 ; j < 3; j++)
+  for (unsigned int i=0 ; i < 3 ; i++)
+    for (unsigned int j=0 ; j < 3; j++)
       (*this)[i][j] = R[i][j] ;
 }
 
 /*!  
 
   Insert the rotational component of the homogeneous matrix from a
-  theta u rotation vector.
+  \f$theta {\bf u}\f$ rotation vector.
 
 */
 void
@@ -592,11 +595,11 @@ vpHomogeneousMatrix::insert(const vpThetaUVector &tu)
   Insert the translational component in a homogeneous matrix.
 */
 void
-vpHomogeneousMatrix::insert(const vpTranslationVector &T)
+vpHomogeneousMatrix::insert(const vpTranslationVector &t)
 {
-  (*this)[0][3] = T[0] ;
-  (*this)[1][3] = T[1] ;
-  (*this)[2][3] = T[2] ;
+  (*this)[0][3] = t[0] ;
+  (*this)[1][3] = t[1] ;
+  (*this)[2][3] = t[2] ;
 }
 
 /*!  
@@ -629,7 +632,6 @@ vpHomogeneousMatrix::inverse() const
 {
   vpHomogeneousMatrix Mi ;
 
-
   vpRotationMatrix R ;      extract(R) ;
   vpTranslationVector T ;   extract(T) ;
 
@@ -650,14 +652,12 @@ void vpHomogeneousMatrix::eye()
   (*this)[0][0] = 1 ;
   (*this)[1][1] = 1 ;
   (*this)[2][2] = 1 ;
+  (*this)[3][3] = 1 ;
 
-  (*this)[0][1] = (*this)[0][2] = 0 ;
-  (*this)[1][0] = (*this)[1][2] = 0 ;
-  (*this)[2][0] = (*this)[2][1] = 0 ;
-
-  (*this)[0][3] = 0 ;
-  (*this)[1][3] = 0 ;
-  (*this)[2][3] = 0 ;
+  (*this)[0][1] = (*this)[0][2] = (*this)[0][3] = 0 ;
+  (*this)[1][0] = (*this)[1][2] = (*this)[1][3] = 0 ;
+  (*this)[2][0] = (*this)[2][1] = (*this)[2][3] = 0 ;
+  (*this)[3][0] = (*this)[3][1] = (*this)[3][2] = 0 ;
 }
 
 /*!
@@ -706,14 +706,12 @@ vpHomogeneousMatrix::inverse(vpHomogeneousMatrix &M) const
 void
 vpHomogeneousMatrix::save(std::ofstream &f) const
 {
-  if (! f.fail())
-  {
+  if (! f.fail()) {
     f << *this ;
   }
-  else
-  {
-    vpERROR_TRACE("\t\t file not open " );
-    throw(vpException(vpException::ioError, "\t\t file not open")) ;
+  else {
+    throw(vpException(vpException::ioError,
+                      "Cannot save homogeneous matrix: ostream not open")) ;
   }
 }
 
@@ -739,33 +737,34 @@ vpHomogeneousMatrix::save(std::ofstream &f) const
 void
 vpHomogeneousMatrix::load(std::ifstream &f)
 {
-  if (! f.fail())
-  {
-    for (unsigned int i=0 ; i < 4 ; i++)
-      for (unsigned int j=0 ; j < 4 ; j++)
-      {
+  if (! f.fail()) {
+    for (unsigned int i=0 ; i < 4 ; i++) {
+      for (unsigned int j=0 ; j < 4 ; j++) {
         f >> (*this)[i][j] ;
       }
+    }
   }
-  else
-  {
-    vpERROR_TRACE("\t\t file not open " );
-    throw(vpException(vpException::ioError, "\t\t file not open")) ;
+  else {
+    throw(vpException(vpException::ioError,
+                      "Cannot laad homogeneous matrix: ifstream not open")) ;
   }
 }
 
-//! Print the matrix as a vector [T thetaU]
+//! Print the matrix as a pose vector \f$({\bf t}^T \theta {\bf u}^T)\f$
 void
 vpHomogeneousMatrix::print()
 {
   vpPoseVector r(*this) ;
   std::cout << r.t() ;
 }
-//! Basic initialisation (identity)
+/*!
+   Set homogeneous matrix to identity.
+   \sa eye()
+ */
 void
 vpHomogeneousMatrix::setIdentity()
 {
-  init() ;
+  eye() ;
 }
 
 /*!

--- a/modules/core/src/math/transformation/vpPoseVector.cpp
+++ b/modules/core/src/math/transformation/vpPoseVector.cpp
@@ -44,42 +44,34 @@
 
 */
 
+#include <sstream>
+#include <assert.h>
+
 #include <visp3/core/vpPoseVector.h>
 #include <visp3/core/vpMath.h>
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpMatrixException.h>
 #include <visp3/core/vpException.h>
 
-/*!
-  Set the size of the vector to 6.
-*/
-void 
-vpPoseVector::init()
-{
-  resize(6) ;
-}
 
 /*!
   
-  Default constructor.
-
-  Construct a 6 dimension pose vector \f$ [\bf t, \Theta \bf
-  u]^\top\f$ where \f$ \Theta \bf u\f$ is a rotation vector \f$[\Theta
-  u_x, \Theta u_y, \Theta u_z]^\top\f$ and \f$ \bf t \f$ is a
+  Default constructor that construct a 6 dimension pose vector \f$ [\bf t, \theta \bf
+  u]^\top\f$ where \f$ \theta \bf u\f$ is a rotation vector \f$[\theta
+  u_x, \theta u_y, \theta u_z]^\top\f$ and \f$ \bf t \f$ is a
   translation vector \f$[t_x, t_y, t_z]^\top\f$.
 
   The pose vector is initialized to zero.
 
 */
 vpPoseVector::vpPoseVector()
-{
-  init() ;
-}
+  : vpArray2D<double>(6, 1)
+{}
 
 /*!  
 
-  Construct a 6 dimension pose vector \f$ [\bf{t}, \Theta
-  \bf{u}]^\top\f$ from 3 translations and 3 \f$ \Theta \bf{u}\f$
+  Construct a 6 dimension pose vector \f$ [\bf{t}, \theta
+  \bf{u}]^\top\f$ from 3 translations and 3 \f$ \theta \bf{u}\f$
   angles.
 
   Translations are expressed in meters, while rotations in radians.
@@ -87,7 +79,7 @@ vpPoseVector::vpPoseVector()
   \param tx,ty,tz : Translations \f$[t_x, t_y, t_z]^\top\f$
   respectively along the x, y and z axis (in meters).
 
-  \param tux,tuy,tuz : Rotations \f$[\Theta u_x, \Theta u_y, \Theta
+  \param tux,tuy,tuz : Rotations \f$[\theta u_x, \theta u_y, \theta
   u_z]^\top\f$ respectively around the x, y and z axis (in radians).
 
 */
@@ -97,76 +89,103 @@ vpPoseVector::vpPoseVector(const double tx,
                            const double tux,
                            const double tuy,
                            const double tuz)
+  : vpArray2D<double>(6, 1)
 {
-  init() ;
+  (*this)[0] = tx;
+  (*this)[1] = ty;
+  (*this)[2] = tz;
 
-  (*this)[0] = tx ;
-  (*this)[1] = ty ;
-  (*this)[2] = tz ;
-
-  (*this)[3] = tux ;
-  (*this)[4] = tuy ;
-  (*this)[5] = tuz ;
+  (*this)[3] = tux;
+  (*this)[4] = tuy;
+  (*this)[5] = tuz;
 }
 
 /*! 
 
-  Construct a 6 dimension pose vector \f$ [\bf t, \Theta \bf
-  u]^\top\f$ from a translation vector \f$ \bf t \f$ and a \f$\Theta
+  Construct a 6 dimension pose vector \f$ [\bf t, \theta \bf
+  u]^\top\f$ from a translation vector \f$ \bf t \f$ and a \f$\theta
   \bf u\f$ vector.
 
-  \param tv : Translation vector \f$ \bf t \f$.
-  \param tu : \f$\Theta \bf u\f$ rotation  vector.
+  \param t : Translation vector \f$ \bf t \f$.
+  \param tu : \f$\theta \bf u\f$ rotation  vector.
 
 */
-vpPoseVector::vpPoseVector(const vpTranslationVector& tv,
+vpPoseVector::vpPoseVector(const vpTranslationVector& t,
                            const vpThetaUVector& tu)
+  : vpArray2D<double>(6, 1)
 {
-  init() ;
-  buildFrom(tv,tu) ;
+  buildFrom(t, tu) ;
 }
 
 /*! 
 
-  Construct a 6 dimension pose vector \f$ [\bf t, \Theta \bf
+  Construct a 6 dimension pose vector \f$ [\bf t, \theta \bf
   u]^\top\f$ from a translation vector \f$ \bf t \f$ and a rotation
   matrix \f$ \bf R \f$.
 
-  \param tv : Translation vector \f$ \bf t \f$.
+  \param t : Translation vector \f$ \bf t \f$.
 
-  \param R : Rotation matrix \f$ \bf R \f$ from which \f$\Theta \bf
+  \param R : Rotation matrix \f$ \bf R \f$ from which \f$\theta \bf
   u\f$ vector is extracted to initialise the pose vector.
 
 */
-vpPoseVector::vpPoseVector(const vpTranslationVector& tv,
+vpPoseVector::vpPoseVector(const vpTranslationVector& t,
                            const vpRotationMatrix& R)
+  : vpArray2D<double>(6, 1)
 {
-  init() ;
-  buildFrom(tv,R) ;
+  buildFrom(t, R) ;
 }
 
 /*! 
 
-  Construct a 6 dimension pose vector \f$ [\bf t, \Theta \bf
+  Construct a 6 dimension pose vector \f$ [\bf t, \theta \bf
   u]^\top\f$ from an homogeneous matrix \f$ \bf M \f$.
 
   \param M : Homogeneous matrix \f$ \bf M \f$ from which translation
-  \f$ \bf t \f$ and \f$\Theta \bf u \f$ vectors are extracted to
+  \f$ \bf t \f$ and \f$\theta \bf u \f$ vectors are extracted to
   initialize the pose vector.
 
 */
 vpPoseVector::vpPoseVector(const vpHomogeneousMatrix& M)
+  : vpArray2D<double>(6, 1)
 {
-  init() ;
   buildFrom(M) ;
 }
 
 /*!
-  Build a 6 dimension pose vector \f$ [\bf t, \Theta \bf u]^\top\f$ from
+
+  Set the 6 dimension pose vector \f$ [\bf{t}, \theta
+  \bf{u}]^\top\f$ from 3 translations and 3 \f$ \theta \bf{u}\f$
+  angles.
+
+  Translations are expressed in meters, while rotations in radians.
+
+  \param tx,ty,tz : Translations \f$[t_x, t_y, t_z]^\top\f$
+  respectively along the x, y and z axis (in meters).
+
+  \param tux,tuy,tuz : Rotations \f$[\theta u_x, \theta u_y, \theta
+  u_z]^\top\f$ respectively around the x, y and z axis (in radians).
+
+*/
+void
+vpPoseVector::set(const double tx, const double ty, const double tz,
+                  const double tux, const double tuy, const double tuz)
+{
+  (*this)[0] = tx;
+  (*this)[1] = ty;
+  (*this)[2] = tz;
+
+  (*this)[3] = tux;
+  (*this)[4] = tuy;
+  (*this)[5] = tuz;
+}
+
+/*!
+  Build a 6 dimension pose vector \f$ [\bf t, \theta \bf u]^\top\f$ from
   an homogeneous matrix \f$ \bf M \f$.
 
   \param M : Homogeneous matrix \f$ \bf M \f$ from which translation \f$
-  \bf t \f$ and \f$\Theta \bf u \f$ vectors are extracted to initialize
+  \bf t \f$ and \f$\theta \bf u \f$ vectors are extracted to initialize
   the pose vector.
 
   \return The build pose vector.
@@ -175,7 +194,7 @@ vpPoseVector::vpPoseVector(const vpHomogeneousMatrix& M)
 vpPoseVector
 vpPoseVector::buildFrom(const vpHomogeneousMatrix& M)
 {
-  vpRotationMatrix R ;    M.extract(R) ;
+  vpRotationMatrix R ;     M.extract(R) ;
   vpTranslationVector tv ; M.extract(tv) ;
   buildFrom(tv,R) ;
   return *this ;
@@ -183,58 +202,55 @@ vpPoseVector::buildFrom(const vpHomogeneousMatrix& M)
 
 /*! 
 
-  Build a 6 dimension pose vector \f$ [\bf t, \Theta \bf u]^\top\f$
-  from a translation vector \f$ \bf t \f$ and a \f$\Theta \bf u\f$
+  Build a 6 dimension pose vector \f$ [\bf t, \theta \bf u]^\top\f$
+  from a translation vector \f$ \bf t \f$ and a \f$\theta \bf u\f$
   vector.
 
-  \param tv : Translation vector \f$ \bf t \f$.
-  \param tu : \f$\Theta \bf u\f$ rotation  vector.
+  \param t : Translation vector \f$ \bf t \f$.
+  \param tu : \f$\theta \bf u\f$ rotation  vector.
 
   \return The build pose vector.
 */
 vpPoseVector
-vpPoseVector::buildFrom(const vpTranslationVector& tv,
+vpPoseVector::buildFrom(const vpTranslationVector& t,
                         const vpThetaUVector& tu)
 {
-  for (unsigned int i =0  ; i < 3 ; i++)
-    {
-      (*this)[i] = tv[i] ;
-      (*this)[i+3] = tu[i] ;
-    }
+  for (unsigned int i =0  ; i < 3 ; i++) {
+    (*this)[i]   = t[i] ;
+    (*this)[i+3] = tu[i] ;
+  }
   return *this ;
 }
 
 /*! 
 
-  Build a 6 dimension pose vector \f$ [\bf t, \Theta \bf u]^\top\f$
+  Build a 6 dimension pose vector \f$ [\bf t, \theta \bf u]^\top\f$
   from a translation vector \f$ \bf t \f$ and a rotation matrix \f$
   \bf R \f$.
 
-  \param tv : Translation vector \f$ \bf t \f$.
+  \param t : Translation vector \f$ \bf t \f$.
 
-  \param R : Rotation matrix \f$ \bf R \f$ from which \f$\Theta \bf
+  \param R : Rotation matrix \f$ \bf R \f$ from which \f$\theta \bf
   u\f$ vector is extracted to initialise the pose vector.
 
   \return The build pose vector.
 */
 vpPoseVector
-vpPoseVector::buildFrom(const vpTranslationVector& tv,
+vpPoseVector::buildFrom(const vpTranslationVector& t,
                         const vpRotationMatrix& R)
 {
   vpThetaUVector tu ;
   tu.buildFrom(R) ;
 
-  buildFrom(tv,tu) ;
+  buildFrom(t, tu) ;
   return *this ;
 }
-
-
 
 /*!
 
   Prints to the standart stream the pose vector.
 
-  \warning Values concerning the \f$ \Theta \bf u\f$ rotation are
+  \warning Values concerning the \f$ \theta {\bf u}\f$ rotation are
   converted in degrees.
 
   The following code
@@ -248,6 +264,8 @@ vpPoseVector::buildFrom(const vpTranslationVector& tv,
   \code
   1 2 3 180 -180 0
   \endcode
+
+  \sa std::ostream &operator<<(std::ostream &s, const vpArray2D<Type> &A)
 */
 void
 vpPoseVector::print()
@@ -256,7 +274,6 @@ vpPoseVector::print()
     if (i<3) std::cout << (*this)[i] <<" " ;
     else  std::cout << vpMath::deg((*this)[i]) <<" " ;
   std::cout <<std::endl ;
-
 }
 
 /*!
@@ -272,15 +289,13 @@ vpPoseVector::print()
 void
 vpPoseVector::save(std::ofstream &f) const
 {
-  if (! f.fail())
-    {
-      f << *this ;
-    }
-  else
-    {
-      vpERROR_TRACE("\t\t file not open " );
-      throw(vpException(vpException::ioError, "\t\t file not open")) ;
-    }
+  if (! f.fail()) {
+    f << *this ;
+  }
+  else {
+    throw(vpException(vpException::ioError,
+                      "Cannot save the pose vector: ofstream not openned")) ;
+  }
 }
 
 
@@ -297,23 +312,127 @@ vpPoseVector::save(std::ofstream &f) const
 void
 vpPoseVector::load(std::ifstream &f)
 {
-  if (! f.fail())
-  {
-    for (unsigned int i=0 ; i < 6 ; i++)
-    {
+  if (! f.fail()) {
+    for (unsigned int i=0 ; i < 6 ; i++) {
       f >> (*this)[i] ;
     }
   }
-  else
-  {
-    vpERROR_TRACE("\t\t file not open " );
-    throw(vpException(vpException::ioError, "\t\t file not open")) ;
+  else {
+    throw(vpException(vpException::ioError,
+                      "Cannot read pose vector: ifstream not openned")) ;
   }
 }
 
-
 /*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */
+  Transpose the pose vector. The resulting vector becomes a row vector.
+
+*/
+vpRowVector vpPoseVector::t() const
+{
+  vpRowVector v(rowNum);
+  memcpy(v.data, data, rowNum*sizeof(double)) ;
+  return v;
+}
+
+/*!
+
+  Pretty print a pose vector. The data are tabulated.
+  The common widths before and after the decimal point
+  are set with respect to the parameter maxlen.
+
+  \param s Stream used for the printing.
+
+  \param length The suggested width of each vector element.
+  The actual width grows in order to accomodate the whole integral part,
+  and shrinks if the whole extent is not needed for all the numbers.
+  \param intro The introduction which is printed before the vector.
+  Can be set to zero (or omitted), in which case
+  the introduction is not printed.
+
+  \return Returns the common total width for all vector elements.
+
+  \sa std::ostream &operator<<(std::ostream &s, const vpArray2D<Type> &A)
+*/
+int
+vpPoseVector::print(std::ostream& s, unsigned int length, char const* intro) const
+{
+  typedef std::string::size_type size_type;
+
+  unsigned int m = getRows();
+  unsigned int n = 1;
+
+  std::vector<std::string> values(m*n);
+  std::ostringstream oss;
+  std::ostringstream ossFixed;
+  std::ios_base::fmtflags original_flags = oss.flags();
+
+  // ossFixed <<std::fixed;
+  ossFixed.setf ( std::ios::fixed, std::ios::floatfield );
+
+  size_type maxBefore=0;  // the length of the integral part
+  size_type maxAfter=0;   // number of decimals plus
+  // one place for the decimal point
+  for (unsigned int i=0;i<m;++i) {
+    oss.str("");
+    oss << (*this)[i];
+    if (oss.str().find("e")!=std::string::npos){
+      ossFixed.str("");
+      ossFixed << (*this)[i];
+      oss.str(ossFixed.str());
+    }
+
+    values[i]=oss.str();
+    size_type thislen=values[i].size();
+    size_type p=values[i].find('.');
+
+    if (p==std::string::npos){
+      maxBefore=vpMath::maximum(maxBefore, thislen);
+      // maxAfter remains the same
+    } else{
+      maxBefore=vpMath::maximum(maxBefore, p);
+      maxAfter=vpMath::maximum(maxAfter, thislen-p-1);
+    }
+
+  }
+
+  size_type totalLength=length;
+  // increase totalLength according to maxBefore
+  totalLength=vpMath::maximum(totalLength,maxBefore);
+  // decrease maxAfter according to totalLength
+  maxAfter=std::min(maxAfter, totalLength-maxBefore);
+  if (maxAfter==1) maxAfter=0;
+
+  // the following line is useful for debugging
+  //std::cerr <<totalLength <<" " <<maxBefore <<" " <<maxAfter <<"\n";
+
+  if (intro) s <<intro;
+  s <<"["<<m<<","<<n<<"]=\n";
+
+  for (unsigned int i=0;i<m;i++) {
+    s <<"  ";
+    size_type p=values[i].find('.');
+    s.setf(std::ios::right, std::ios::adjustfield);
+    s.width((std::streamsize)maxBefore);
+    s <<values[i].substr(0,p).c_str();
+
+    if (maxAfter>0){
+      s.setf(std::ios::left, std::ios::adjustfield);
+      if (p!=std::string::npos){
+        s.width((std::streamsize)maxAfter);
+        s <<values[i].substr(p,maxAfter).c_str();
+      } else{
+        assert(maxAfter>1);
+        s.width((std::streamsize)maxAfter);
+        s <<".0";
+      }
+    }
+
+    s <<' ';
+
+    s <<std::endl;
+  }
+
+  s.flags(original_flags); // restore s to standard state
+
+  return (int)(maxBefore+maxAfter);
+}

--- a/modules/core/src/math/transformation/vpRotationVector.cpp
+++ b/modules/core/src/math/transformation/vpRotationVector.cpp
@@ -35,9 +35,12 @@
  *
  *****************************************************************************/
 
-#include <visp3/core/vpRotationVector.h>
 #include <algorithm>
 #include <math.h>
+
+#include <visp3/core/vpRotationVector.h>
+#include <visp3/core/vpRowVector.h>
+
 /*!
   \file vpRotationVector.cpp
   \brief class that consider the case of a generic rotation vector
@@ -123,4 +126,33 @@ void vpRotationVector::init(const unsigned int vector_size){
 vpRotationVector::~vpRotationVector(){
 	delete[] r;
 	r = NULL;
+}
+
+/*!
+  Operator that allows to multiply each element of a rotation vector by a scalar.
+
+  \param x : The scalar.
+
+  \return The rotation vector multiplied by the scalar. The current
+  rotation vector (*this) is unchanged.
+
+*/
+vpRotationVector vpRotationVector::operator*(double x) const
+{
+  vpRotationVector v;
+
+  for (unsigned int i=0;i<_size;i++)
+    v[i] = (*this)[i] * x;
+  return v;
+}
+
+/*!
+  \relates vpRotationVector
+  Allows to multiply a scalar by rotaion vector.
+*/
+vpRotationVector operator*(const double &x,const vpRotationVector &v)
+{
+  vpRotationVector vout ;
+  vout = v*x ;
+  return vout ;
 }

--- a/modules/core/src/math/transformation/vpVelocityTwistMatrix.cpp
+++ b/modules/core/src/math/transformation/vpVelocityTwistMatrix.cpp
@@ -35,14 +35,11 @@
  *
  *****************************************************************************/
 
+#include <sstream>
+#include <assert.h>
+
 #include <visp3/core/vpVelocityTwistMatrix.h>
-
-// Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
-
-// Debug trace
-#include <visp3/core/vpDebug.h>
 
 
 /*!
@@ -55,22 +52,20 @@
 
 
 /*!
-  Copy operator.
+  Copy operator that allow to set a velocity twist matrix from an other one.
 
   \param V : Velocity twist matrix to copy.
 */
 vpVelocityTwistMatrix &
 vpVelocityTwistMatrix::operator=(const vpVelocityTwistMatrix &V)
 {
-  init() ;
-
   for (int i=0; i<6; i++)
+  {
+    for (int j=0; j<6; j++)
     {
-      for (int j=0; j<6; j++)
-	{
-	  rowPtrs[i][j] = V.rowPtrs[i][j];
-	}
+      rowPtrs[i][j] = V.rowPtrs[i][j];
     }
+  }
 
   return *this;
 }
@@ -79,35 +74,24 @@ vpVelocityTwistMatrix::operator=(const vpVelocityTwistMatrix &V)
 /*!
   Initialize a 6x6 velocity twist matrix as identity. 
 */
-
 void
-vpVelocityTwistMatrix::init()
-{
-  unsigned int i,j ;
-
-  try {
-    resize(6,6) ;
-  }
-  catch(vpException me)
-    {
-      vpERROR_TRACE("Error caught") ;
-      throw ;
-    }
-
-  for (i=0 ; i < 6 ; i++)
-    for (j=0 ; j < 6; j++)
+vpVelocityTwistMatrix::eye()
+{  
+  for (unsigned int i=0 ; i < 6 ; i++)
+    for (unsigned int j=0 ; j < 6; j++)
       if (i==j)
-	(*this)[i][j] = 1.0 ;
+        (*this)[i][j] = 1.0 ;
       else
-	(*this)[i][j] = 0.0;
+        (*this)[i][j] = 0.0;
 }
 
 /*!
   Initialize a velocity twist transformation matrix as identity.
 */
-vpVelocityTwistMatrix::vpVelocityTwistMatrix() : vpMatrix()
+vpVelocityTwistMatrix::vpVelocityTwistMatrix()
+  : vpArray2D<double>(6, 6)
 {
-  init() ;
+  eye() ;
 }
 
 /*!
@@ -115,9 +99,9 @@ vpVelocityTwistMatrix::vpVelocityTwistMatrix() : vpMatrix()
 
   \param V : Velocity twist matrix used as initializer.
 */
-vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpVelocityTwistMatrix &V) : vpMatrix()
+vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpVelocityTwistMatrix &V)
+  : vpArray2D<double>(6, 6)
 {
-  init() ;
   *this = V;
 }
 
@@ -131,9 +115,9 @@ vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpVelocityTwistMatrix &V) : v
   transformation matrix.
 
 */
-vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpHomogeneousMatrix &M) : vpMatrix()
+vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpHomogeneousMatrix &M)
+  : vpArray2D<double>(6, 6)
 {
-  init() ;
   buildFrom(M);
 }
 
@@ -142,16 +126,16 @@ vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpHomogeneousMatrix &M) : vpM
   Initialize a velocity twist transformation matrix from a translation vector
   \e t and a rotation vector with \f$\theta u \f$ parametrization.
 
-  \param tv : Translation vector.
+  \param t : Translation vector.
   
   \param thetau : \f$\theta u\f$ rotation vector.
 
 */
-vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpTranslationVector &tv,
-					     const vpThetaUVector &thetau) : vpMatrix()
+vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpTranslationVector &t,
+                                             const vpThetaUVector &thetau)
+  : vpArray2D<double>(6, 6)
 {
-  init() ;
-  buildFrom(tv, thetau) ;
+  buildFrom(t, thetau) ;
 }
 
 /*!
@@ -159,35 +143,36 @@ vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpTranslationVector &tv,
   Initialize a velocity twist transformation matrix from a translation vector
   \e t and a rotation matrix M.
 
-  \param tv : Translation vector.
+  \param t : Translation vector.
   
   \param R : Rotation matrix.
 
 */
-vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpTranslationVector &tv,
-					     const vpRotationMatrix &R)
+vpVelocityTwistMatrix::vpVelocityTwistMatrix(const vpTranslationVector &t,
+                                             const vpRotationMatrix &R)
+  : vpArray2D<double>(6, 6)
 {
-  init() ;
-  buildFrom(tv,R) ;
+  buildFrom(t,R) ;
 }
 
 /*!
 
   Initialize a velocity twist transformation matrix from a translation vector
-  \e t and a rotation vector with \f$\theta u \f$ parametrization.
+  \f${\bf t}=(t_x, t_y, t_z)^T\f$ and a rotation vector with \f$\theta {\bf u}=(\theta u_x, \theta u_y, \theta u_z)^T \f$
+  parametrization.
 
   \param tx,ty,tz : Translation vector in meters.
 
-  \param tux,tuy,tuz : \f$\theta u\f$ rotation vector expressed in radians.
+  \param tux,tuy,tuz : \f$\theta {\bf u}\f$ rotation vector expressed in radians.
 */
 vpVelocityTwistMatrix::vpVelocityTwistMatrix(const double tx,
 					     const double ty,
 					     const double tz,
 					     const double tux,
 					     const double tuy,
-					     const double tuz) : vpMatrix()
+               const double tuz)
+  : vpArray2D<double>(6, 6)
 {
-  init() ;
   vpTranslationVector T(tx,ty,tz) ;
   vpThetaUVector tu(tux,tuy,tuz) ;
   buildFrom(T,tu) ;  
@@ -201,7 +186,7 @@ vpVelocityTwistMatrix::vpVelocityTwistMatrix(const double tx,
 void
 vpVelocityTwistMatrix::setIdentity()
 {
-  init() ;
+  eye() ;
 }
 
 
@@ -218,12 +203,12 @@ vpVelocityTwistMatrix::operator*(const vpVelocityTwistMatrix &V) const
 
   for (unsigned int i=0;i<6;i++)
     for (unsigned int j=0;j<6;j++)
-      {
-	double s =0 ;
-	for (int k=0;k<6;k++)
-	  s +=rowPtrs[i][k] * V.rowPtrs[k][j];
-	p[i][j] = s ;
-      }
+    {
+      double s =0 ;
+      for (int k=0;k<6;k++)
+        s +=rowPtrs[i][k] * V.rowPtrs[k][j];
+      p[i][j] = s ;
+    }
   return p;
 }
 
@@ -234,16 +219,14 @@ vpVelocityTwistMatrix::operator*(const vpVelocityTwistMatrix &V) const
   camera velocity skew from the joint velocities knowing the robot jacobian.
 
   \code
-  #include <visp3/core/vpConfig.h>
-  #include <visp3/robot/vpRobotAfma6.h>
-  #include <visp3/core/vpColVector.h>
-  #include <visp3/core/vpVelocityTwistMatrix.h>
+#include <visp3/core/vpConfig.h>
+#include <visp3/robot/vpSimulatorCamera.h>
+#include <visp3/core/vpColVector.h>
+#include <visp3/core/vpVelocityTwistMatrix.h>
 
-  #ifdef VISP_HAVE_AFMA6
-
-  int main()
-  {
-  vpRobotAfma6 robot;
+int main()
+{
+  vpSimulatorCamera robot;
 
   vpColVector q_vel(6); // Joint velocity on the 6 joints
   // ... q_vel need here to be initialized
@@ -260,22 +243,19 @@ vpVelocityTwistMatrix::operator*(const vpVelocityTwistMatrix &V) const
   c_v = cVe * eJe * q_vel;
 
   return 0;
-  }
-  #endif  
+}
   \endcode
 
-  \exception vpMatrixException::incorrectMatrixSizeError If M is not a 6 rows
-  dimension matrix.
+  \exception vpException::dimensionError If M is not a 6 rows dimension matrix.
 */
 vpMatrix
 vpVelocityTwistMatrix::operator*(const vpMatrix &M) const
 {
-
-  if (6 != M.getRows())
-    {
-      vpERROR_TRACE("vpVelocityTwistMatrix mismatch in vpVelocityTwistMatrix/vpMatrix multiply") ;
-      throw(vpMatrixException::incorrectMatrixSizeError) ;
-    }
+  if (6 != M.getRows()) {
+    throw(vpException(vpException::dimensionError,
+                      "Cannot multiply a (6x6) velocity twist matrix by a (%dx%d) matrix",
+                      M.getRows(), M.getCols()));
+  }
 
   vpMatrix p(6, M.getCols()) ;
   for (unsigned int i=0;i<6;i++)
@@ -292,15 +272,11 @@ vpVelocityTwistMatrix::operator*(const vpMatrix &M) const
 /*!
 
   Operator that allows to multiply a twist transformation matrix by a
-  column vector.
-
-  Operation c = V * v (V, the velocity skew transformation matrix is unchanged,
-  c and v are 6 dimension vectors).
+  6-dimension column vector.
 
   \param v : Velocity skew vector.
 
-  \exception vpMatrixException::incorrectMatrixSizeError If v is not a 6
-  dimension vector.
+  \exception vpException::dimensionError If v is not a 6 dimension column vector.
 
 */
 vpColVector
@@ -310,9 +286,9 @@ vpVelocityTwistMatrix::operator*(const vpColVector &v) const
 
   if (6 != v.getRows())
   {
-    vpERROR_TRACE("vpVelocityTwistMatrix mismatch in vpVelocityTwistMatrix/vector multiply") ;
-    throw(vpMatrixException(vpMatrixException::incorrectMatrixSizeError,
-                            "Mismatch in vpVelocityTwistMatrix/vector multiply")) ;
+    throw(vpException(vpException::dimensionError,
+                      "Cannot multiply a (6x6) velocity twist matrix by a (%d) column vector",
+                      v.getRows()));
   }
 
   c = 0.0;
@@ -334,17 +310,17 @@ vpVelocityTwistMatrix::operator*(const vpColVector &v) const
   Build a velocity twist transformation matrix from a translation vector
   \e t and a rotation matrix M.
 
-  \param tv : Translation vector.
+  \param t : Translation vector.
   
   \param R : Rotation matrix.
 
 */
 vpVelocityTwistMatrix
-vpVelocityTwistMatrix::buildFrom(const vpTranslationVector &tv,
-				 const vpRotationMatrix &R)
+vpVelocityTwistMatrix::buildFrom(const vpTranslationVector &t,
+                                 const vpRotationMatrix &R)
 {
   unsigned int i, j;
-  vpMatrix skewaR = tv.skew(tv)*R ;
+  vpMatrix skewaR = t.skew(t)*R ;
 
   for (i=0 ; i < 3 ; i++)
     for (j=0 ; j < 3 ; j++)
@@ -362,20 +338,19 @@ vpVelocityTwistMatrix::buildFrom(const vpTranslationVector &tv,
   Initialize a velocity twist transformation matrix from a translation vector
   \e t and a rotation vector with \f$\theta u \f$ parametrization.
 
-  \param tv : Translation vector.
+  \param t : Translation vector.
   
-  \param thetau : \f$\theta u\f$ rotation vector.
+  \param thetau : \f$\theta {\bf u}\f$ rotation vector.
 
 */
 vpVelocityTwistMatrix
-vpVelocityTwistMatrix::buildFrom(const vpTranslationVector &tv,
-				 const vpThetaUVector &thetau)
+vpVelocityTwistMatrix::buildFrom(const vpTranslationVector &t,
+                                 const vpThetaUVector &thetau)
 {
   vpRotationMatrix R ;
   R.buildFrom(thetau) ;
-  buildFrom(tv,R) ;
+  buildFrom(t,R) ;
   return (*this) ;
-
 }
 
 
@@ -402,7 +377,7 @@ vpVelocityTwistMatrix::buildFrom(const vpHomogeneousMatrix &M)
 }
 
 
-//! invert the twist matrix
+//! Invert the velocity twist matrix.
 vpVelocityTwistMatrix
 vpVelocityTwistMatrix::inverse() const
 {
@@ -417,14 +392,14 @@ vpVelocityTwistMatrix::inverse() const
 }
 
 
-//! invert the twist matrix
+//! Invert the velocity twist matrix.
 void
-vpVelocityTwistMatrix::inverse(vpVelocityTwistMatrix &Wi) const
+vpVelocityTwistMatrix::inverse(vpVelocityTwistMatrix &V) const
 {
-	Wi = inverse();
+  V = inverse();
 }
 
-//! extract the rotational matrix from the twist matrix
+//! Extract the rotation matrix from the velocity twist matrix.
 void
 vpVelocityTwistMatrix::extract( vpRotationMatrix &R) const
 {
@@ -433,7 +408,7 @@ vpVelocityTwistMatrix::extract( vpRotationMatrix &R) const
 	      R[i][j] = (*this)[i][j];
 }
 
-//! extract the translation vector from the twist matrix
+//! Extract the translation vector from the velocity twist matrix.
 void
 vpVelocityTwistMatrix::extract(vpTranslationVector &tv) const
 {
@@ -449,8 +424,107 @@ vpVelocityTwistMatrix::extract(vpTranslationVector &tv) const
   tv[2] = skT[1][0];
 }
 
-/*
- * Local variables:
- * c-basic-offset: 2
- * End:
- */
+/*!
+
+  Pretty print a velocity twist matrix. The data are tabulated.
+  The common widths before and after the decimal point
+  are set with respect to the parameter maxlen.
+
+  \param s Stream used for the printing.
+
+  \param length The suggested width of each matrix element.
+  The actual width grows in order to accomodate the whole integral part,
+  and shrinks if the whole extent is not needed for all the numbers.
+  \param intro The introduction which is printed before the matrix.
+  Can be set to zero (or omitted), in which case
+  the introduction is not printed.
+
+  \return Returns the common total width for all matrix elements
+
+  \sa std::ostream &operator<<(std::ostream &s, const vpArray2D<Type> &A)
+*/
+int
+vpVelocityTwistMatrix::print(std::ostream& s, unsigned int length, char const* intro) const
+{
+  typedef std::string::size_type size_type;
+
+  unsigned int m = getRows();
+  unsigned int n = getCols();
+
+  std::vector<std::string> values(m*n);
+  std::ostringstream oss;
+  std::ostringstream ossFixed;
+  std::ios_base::fmtflags original_flags = oss.flags();
+
+  // ossFixed <<std::fixed;
+  ossFixed.setf ( std::ios::fixed, std::ios::floatfield );
+
+  size_type maxBefore=0;  // the length of the integral part
+  size_type maxAfter=0;   // number of decimals plus
+  // one place for the decimal point
+  for (unsigned int i=0;i<m;++i) {
+    for (unsigned int j=0;j<n;++j){
+      oss.str("");
+      oss << (*this)[i][j];
+      if (oss.str().find("e")!=std::string::npos){
+        ossFixed.str("");
+        ossFixed << (*this)[i][j];
+        oss.str(ossFixed.str());
+      }
+
+      values[i*n+j]=oss.str();
+      size_type thislen=values[i*n+j].size();
+      size_type p=values[i*n+j].find('.');
+
+      if (p==std::string::npos){
+        maxBefore=vpMath::maximum(maxBefore, thislen);
+        // maxAfter remains the same
+      } else{
+        maxBefore=vpMath::maximum(maxBefore, p);
+        maxAfter=vpMath::maximum(maxAfter, thislen-p-1);
+      }
+    }
+  }
+
+  size_type totalLength=length;
+  // increase totalLength according to maxBefore
+  totalLength=vpMath::maximum(totalLength,maxBefore);
+  // decrease maxAfter according to totalLength
+  maxAfter=std::min(maxAfter, totalLength-maxBefore);
+  if (maxAfter==1) maxAfter=0;
+
+  // the following line is useful for debugging
+  //std::cerr <<totalLength <<" " <<maxBefore <<" " <<maxAfter <<"\n";
+
+  if (intro) s <<intro;
+  s <<"["<<m<<","<<n<<"]=\n";
+
+  for (unsigned int i=0;i<m;i++) {
+    s <<"  ";
+    for (unsigned int j=0;j<n;j++){
+      size_type p=values[i*n+j].find('.');
+      s.setf(std::ios::right, std::ios::adjustfield);
+      s.width((std::streamsize)maxBefore);
+      s <<values[i*n+j].substr(0,p).c_str();
+
+      if (maxAfter>0){
+        s.setf(std::ios::left, std::ios::adjustfield);
+        if (p!=std::string::npos){
+          s.width((std::streamsize)maxAfter);
+          s <<values[i*n+j].substr(p,maxAfter).c_str();
+        } else{
+          assert(maxAfter>1);
+          s.width((std::streamsize)maxAfter);
+          s <<".0";
+        }
+      }
+
+      s <<' ';
+    }
+    s <<std::endl;
+  }
+
+  s.flags(original_flags); // restore s to standard state
+
+  return (int)(maxBefore+maxAfter);
+}

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -969,36 +969,36 @@ bool vpIoTools::readConfigVar(const std::string &var, std::string &value)
 
   \return true if the parameter could be read.
 */
-bool vpIoTools::readConfigVar(const std::string &var, vpMatrix &value, const unsigned int &nCols, const unsigned int &nRows)
+bool vpIoTools::readConfigVar(const std::string &var, vpArray2D<double> &value, const unsigned int &nCols, const unsigned int &nRows)
 {
   bool found = false;
   std::string nb;
   for(unsigned int k=0;k<configVars.size() && found==false;++k)
+  {
+    if(configVars[k] == var)
     {
-      if(configVars[k] == var)
-	{
       found = true;
-	  // resize or not
-	  if(nCols != 0 && nRows != 0)
-	    value.resize(nRows, nCols);
-	  size_t ind=0,ind2;
-	  for(unsigned int i=0;i<value.getRows();++i)
+      // resize or not
+      if(nCols != 0 && nRows != 0)
+        value.resize(nRows, nCols);
+      size_t ind=0,ind2;
+      for(unsigned int i=0;i<value.getRows();++i)
         for(unsigned int j=0;j<value.getCols();++j)
-          {
-            ind2 = configValues[k].find(",",ind);
-            nb = configValues[k].substr(ind,ind2-ind);
-            if(nb.compare("PI") == 0)
-                value[i][j] = M_PI;
-            else if(nb.compare("PI/2") == 0)
-                value[i][j] = M_PI/2;
-            else if(nb.compare("-PI/2") == 0)
-                value[i][j] = -M_PI/2;
-            else
-                value[i][j] = atof(nb.c_str());
-            ind = ind2+1;
-          }
-	}
+        {
+          ind2 = configValues[k].find(",",ind);
+          nb = configValues[k].substr(ind,ind2-ind);
+          if(nb.compare("PI") == 0)
+            value[i][j] = M_PI;
+          else if(nb.compare("PI/2") == 0)
+            value[i][j] = M_PI/2;
+          else if(nb.compare("-PI/2") == 0)
+            value[i][j] = -M_PI/2;
+          else
+            value[i][j] = atof(nb.c_str());
+          ind = ind2+1;
+        }
     }
+  }
   if(found == false)
     std::cout << var << " not found in config file" << std::endl;
   return found;

--- a/modules/core/test/math/testColVector.cpp
+++ b/modules/core/test/math/testColVector.cpp
@@ -41,103 +41,247 @@
   Test some vpColVector functionalities.
 */
 
-#include <visp3/core/vpColVector.h>
-#include <visp3/core/vpDebug.h>
-
 #include <stdlib.h>
 #include <stdio.h>
+
+#include <visp3/core/vpMath.h>
+#include <visp3/core/vpColVector.h>
+
+
+bool test(const std::string &s, const vpColVector &v, const std::vector<double> &bench)
+{
+  static unsigned int cpt = 0;
+  std::cout << "** Test " << ++cpt << std::endl;
+  std::cout << s << "(" << v.getRows() << "," << v.getCols() << ") = [" << v.t() << "]^T" << std::endl;
+  if(bench.size() != v.size()) {
+    std::cout << "Test fails: bad size wrt bench" << std::endl;
+    return false;
+  }
+  for (unsigned int i=0; i<v.size(); i++) {
+    if (std::fabs(v[i]-bench[i]) > std::fabs(v[i])*std::numeric_limits<double>::epsilon()) {
+      std::cout << "Test fails: bad content" << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
 
 
 int main()
 {
-  try {
-    vpColVector V(4) ;
-    V = 1.0;
+  int err = 1;
 
-    vpTRACE("------------------------");
-    vpTRACE("call std::cout << V;");
-    std::cout << V << std::endl;
+  {
+    vpColVector v;
 
-    vpTRACE("------------------------");
-    vpTRACE("call V.normalize();");
-    V.normalize();
+    v.resize(4);
+    v = 3;
+    std::vector<double> bench1(4, 3);
+    if (test("v", v, bench1) == false)
+      return err;
+    std::vector<double> bench2(4, 3./6);
+    v.normalize();
+    if (test("v", v, bench2) == false)
+      return err;
+  }
 
-    vpTRACE("------------------------");
-    vpTRACE("call std::cout << V;");
-    std::cout << V << std::endl;
+  {
+    vpColVector v(4);
+    std::vector<double> bench1(4);
+    for(size_t i=0; i<v.size(); i++) {
+      v[i] = i;
+      bench1[i] = i;
+    }
+    if (test("v", v, bench1) == false)
+      return err;
 
+    vpColVector w;
+    w.init(v, 0, 2);
+    std::vector<double> bench2;
+    bench2.push_back(0);
+    bench2.push_back(1);
+    if (test("w", w, bench2) == false)
+      return err;
 
-    //Test stack
-    vpColVector col_vector1(4);
-    col_vector1 = 1.0;
-    col_vector1.stack(2.0);
-    std::cout << "col_vector1.stack(2.0)=\n" << col_vector1 << std::endl;
+    std::vector<double> bench3;
+    bench3.push_back(1);
+    bench3.push_back(2);
+    bench3.push_back(3);
 
-    vpColVector col_vector2(3);
-    col_vector2 = 5.0;
+    vpColVector r1;
+    for(size_t i=0; i<4; i++)
+      r1.stack(i);
 
-    vpColVector col_vector3;
-    col_vector3 = vpColVector::stack(col_vector1, col_vector2);
-    std::cout << "vpColVector::stack(col_vector1, col_vector2)=\n" << col_vector3 << std::endl;
+    vpColVector r2 = r1.extract(1, 3);
+    if (test("r2", r2, bench3) == false)
+      return err;
+  }
+  {
+    vpMatrix M(4, 1);
+    std::vector<double> bench(4);
+    for(unsigned int i=0; i<M.getRows(); i++) {
+      M[i][0] = i;
+      bench[i] = i;
+    }
+    if (test("M", M, bench) == false)
+      return err;
+    vpColVector v;
+    v = M;
+    if (test("v", v, bench) == false)
+      return err;
+    vpColVector w(M);
+    if (test("w", w, bench) == false)
+      return err;
+    vpColVector z1(bench);
+    if (test("z1", z1, bench) == false)
+      return err;
+    vpColVector z2 = bench;
+    if (test("z2", z2, bench) == false)
+      return err;
+  }
+  {
+    vpColVector v(3);
+    v[0] = 1;
+    v[1] = 2;
+    v[2] = 3;
+    std::vector<double> bench1;
+    bench1.push_back(3);
+    bench1.push_back(6);
+    bench1.push_back(9);
 
-    col_vector1.stack(col_vector2);
-    std::cout << "col_vector1.stack(col_vector2)=\n" << col_vector1 << std::endl;
+    vpColVector w = v * 3;
+    // v is unchanged
+    // w is now equal to : [3 6 9]
+    if (test("w", w, bench1) == false)
+      return err;
 
+    vpColVector x(w);
+    if (test("x", x, bench1) == false)
+      return err;
 
-    //Test mean, median and standard deviation against Matlab with rng(0) and rand(10,1)*10
-    vpColVector colVector(10);
-    colVector[0] = 8.1472;
-    colVector[1] = 9.0579;
-    colVector[2] = 1.2699;
-    colVector[3] = 9.1338;
-    colVector[4] = 6.3236;
-    colVector[5] = 0.9754;
-    colVector[6] = 2.7850;
-    colVector[7] = 5.4688;
-    colVector[8] = 9.5751;
-    colVector[9] = 9.6489;
+    std::vector<float> bench2;
+    bench2.push_back(3);
+    bench2.push_back(6);
+    bench2.push_back(9);
+    vpColVector y1(bench2);
+    if (test("y1", y1, bench1) == false)
+      return err;
+    vpColVector y2 = bench2;
+    if (test("y2", y2, bench1) == false)
+      return err;
+  }
+  {
+    vpColVector r1(3, 1);
+    vpColVector r2 = -r1;
+    std::vector<double> bench(3,-1);
+    // v contains [-1 -1 -1]
+    if (test("r2", r2, bench) == false)
+      return err;
+    r2.stack(-2);
+    bench.push_back(-2);
+    if (test("r2", r2, bench) == false)
+      return err;
+    vpColVector r3 = vpColVector::stack(r1, r2);
+    std::vector<double> bench3(7, 1);
+    bench3[3] = bench3[4] = bench3[5] = -1;
+    bench3[6] = -2;
+    if (test("r3", r3, bench3) == false)
+      return err;
 
+    r1.stack(r2);
+    if (test("r1", r1, bench3) == false)
+      return err;
+  }
+  {
+    vpColVector r1(3, 2);
+    vpColVector r2(3, 4);
+    std::cout << "test r1: " << r1 << std::endl;
+    std::cout << "test r2: " << r2 << std::endl;
+    vpColVector r = r1 + r2;
+    std::cout << "test r1+r2: " << r1+r2 << std::endl;
+    std::cout << "test r: " << r << std::endl;
+    std::vector<double> bench(3, 6);
+    if (test("r", r, bench) == false)
+      return err;
+    r1 += r2;
+    if (test("r1", r1, bench) == false)
+      return err;
+  }
+  {
+    vpColVector r1(3, 2);
+    vpColVector r2(3, 4);
+    vpColVector r = r1 - r2;
+    std::vector<double> bench(3, -2);
+    if (test("r", r, bench) == false)
+      return err;
+    r1 -= r2;
+    if (test("r1", r1, bench) == false)
+      return err;
+  }
+  {
+    vpColVector r(5, 1);
+    r.clear();
+    r.resize(5);
+    r = 5;
+    std::vector<double> bench(5, 5);
+    if (test("r", r, bench) == false)
+      return err;
+  }
+  {
+    // Test mean, median and standard deviation against Matlab with rng(0) and rand(10,1)*10
+    vpColVector r(10);
+    r[0] = 8.1472;
+    r[1] = 9.0579;
+    r[2] = 1.2699;
+    r[3] = 9.1338;
+    r[4] = 6.3236;
+    r[5] = 0.9754;
+    r[6] = 2.7850;
+    r[7] = 5.4688;
+    r[8] = 9.5751;
+    r[9] = 9.6489;
 
-    double res = vpColVector::mean(colVector);
+    std::cout << "** Test mean" << std::endl;
+    double res = vpColVector::mean(r);
     if(!vpMath::equal(res, 6.2386, 0.001)) {
-      std::cerr << "Problem with vpColVector::mean()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad mean " << res << std::endl;
+      return err;
     }
-    std::cout << "vpColVector::mean() is Ok !" << std::endl;
 
-    res = vpColVector::stdev(colVector);
+    std::cout << "** Test stdev" << std::endl;
+    res = vpColVector::stdev(r);
     if(!vpMath::equal(res, 3.2810, 0.001)) {
-      std::cerr << "Problem with vpColVector::stdev()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad stdev " << res << std::endl;
+      return err;
     }
 
-    res = vpColVector::stdev(colVector, true);
+    std::cout << "** Test stdev(bessel)" << std::endl;
+    res = vpColVector::stdev(r, true);
     if(!vpMath::equal(res, 3.4585, 0.001)) {
-      std::cerr << "Problem with vpColVector::stdev() with Bessel correction=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad stdev(bessel) " << res << std::endl;
+      return err;
     }
-    std::cout << "vpColVector::stdev() is Ok !" << std::endl;
 
-    res = vpColVector::median(colVector);
+    std::cout << "** Test median" << std::endl;
+    res = vpColVector::median(r);
     if(!vpMath::equal(res, 7.2354, 0.001)) {
-      std::cerr << "Problem with vpColVector::median()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad median " << res << std::endl;
+      return err;
     }
 
-    //Test median with odd number of elements
-    colVector.stack(1.5761);
-    res = vpColVector::median(colVector);
+    // Test median with odd number of elements
+    std::cout << "** Test median (odd)" << std::endl;
+    r.stack(1.5761);
+    res = vpColVector::median(r);
     if(!vpMath::equal(res, 6.3236, 0.001)) {
-      std::cerr << "Problem with vpColVector::median()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad median (odd) " << res << std::endl;
+      return err;
     }
-    std::cout << "vpColVector::median() is Ok !" << std::endl;
-
-    std::cout << "OK !" << std::endl;
-    return (0);
+    std::cout << "r: [" << r << "]^T" << std::endl;
+    r.print(std::cout, 8, "r");
   }
-  catch(vpException &e) {
-    std::cout << "Catch an exception: " << e << std::endl;
-    return (1);
-  }
+  std::cout << "All tests succeed" << std::endl;
+  return 0;
 }

--- a/modules/core/test/math/testColVector.cpp
+++ b/modules/core/test/math/testColVector.cpp
@@ -90,9 +90,9 @@ int main()
   {
     vpColVector v(4);
     std::vector<double> bench1(4);
-    for(size_t i=0; i<v.size(); i++) {
-      v[i] = i;
-      bench1[i] = i;
+    for(unsigned int i=0; i<v.size(); i++) {
+      v[i] = (double)i;
+	  bench1[i] = (double)i;
     }
     if (test("v", v, bench1) == false)
       return err;
@@ -112,7 +112,7 @@ int main()
 
     vpColVector r1;
     for(size_t i=0; i<4; i++)
-      r1.stack(i);
+      r1.stack((double)i);
 
     vpColVector r2 = r1.extract(1, 3);
     if (test("r2", r2, bench3) == false)

--- a/modules/core/test/math/testMatrix.cpp
+++ b/modules/core/test/math/testMatrix.cpp
@@ -55,6 +55,7 @@ int
 main()
 {
   try {
+    int err = 1;
     {
       vpMatrix M(4,5);
       int val = 0;
@@ -70,6 +71,40 @@ main()
       N.init(M, 0, 1, 2, 3);
       std::cout <<"N ";
       N.print (std::cout, 4);
+
+      if (vpMatrix::saveMatrix("matrix.mat", M, false, "My 4-by-5 matrix"))
+        std::cout << "Matrix saved in matrix.mat file" << std::endl;
+      else
+        return err;
+
+      vpMatrix M1;
+      if (vpMatrix::loadMatrix("matrix.mat", M1, false))
+        std::cout << "Matrix loaded from matrix.mat file: \n" << M1 << std::endl;
+      else
+        return err;
+
+      if (vpMatrix::saveMatrixYAML("matrix.yml", M, "My 4-by-5 matrix"))
+        std::cout << "Matrix saved in matrix.yml file" << std::endl;
+      else
+        return err;
+
+      vpMatrix M2;
+      if (vpMatrix::loadMatrixYAML("matrix.yml", M2))
+        std::cout << "Matrix loaded from matrix.yml file: \n" << M2 << std::endl;
+      else
+        return err;
+    }
+    {
+      vpRotationMatrix R(vpMath::rad(10), vpMath::rad(20), vpMath::rad(30));
+      std::cout << "R: \n" << R << std::endl;
+      vpMatrix M1(R);
+      std::cout << "M1: \n" << M1 << std::endl;
+      vpMatrix M2(M1);
+      std::cout << "M2: \n" << M2 << std::endl;
+      vpMatrix M3 = R;
+      std::cout << "M3: \n" << M3 << std::endl;
+      vpMatrix M4 = M1;
+      std::cout << "M4: \n" << M4 << std::endl;
     }
     {
 

--- a/modules/core/test/math/testMatrixException.cpp
+++ b/modules/core/test/math/testMatrixException.cpp
@@ -41,48 +41,33 @@
   \brief Tests matrix exception
 */
 
-#include <visp3/core/vpMath.h>
-#include <visp3/core/vpMatrix.h>
-#include <visp3/core/vpMatrixException.h>
-#include <visp3/core/vpDebug.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <visp3/core/vpMatrix.h>
 
 int main()
 {
+  vpMatrix M ;
+  vpMatrix M1(2,3) ;
+  vpMatrix M2(3,3) ;
+  vpMatrix M3(2,2) ;
+
+  std::cout << "** test matrix exception during multiplication" << std::endl;
+
   try {
-    vpMatrix M ;
-    vpMatrix M1(2,3) ;
-    vpMatrix M2(3,3) ;
-    vpMatrix M3(2,2) ;
-
-    vpTRACE("test matrix size in multiply") ;
-
-    try
-    {
-      M = M1*M3 ;
-    }
-    catch (vpMatrixException me)
-    {
-      std::cout << me << std::endl ;
-    }
-
-
-    vpTRACE("test matrix size in addition") ;
-
-    try
-    {
-      M = M1+M3 ;
-    }
-    catch (vpMatrixException me)
-    {
-      std::cout << me << std::endl ;
-    }
+    M = M1*M3 ;
   }
-  catch(vpException e) {
+  catch (vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
-    return 1;
+  }
+
+  std::cout << "** test matrix exception during addition" << std::endl;
+
+  try {
+    M = M1+M3 ;
+  }
+  catch (vpException &e)  {
+    std::cout << "Catch an exception: " << e << std::endl;
   }
 }

--- a/modules/core/test/math/testRowVector.cpp
+++ b/modules/core/test/math/testRowVector.cpp
@@ -88,9 +88,9 @@ int main()
   {
     vpRowVector v(4);
     std::vector<double> bench1(4);
-    for(size_t i=0; i<v.size(); i++) {
-      v[i] = i;
-      bench1[i] = i;
+    for(unsigned int i=0; i<v.size(); i++) {
+      v[i] = (double)i;
+	  bench1[i] = (double)i;
     }
     if (test("v", v, bench1) == false)
       return err;
@@ -110,7 +110,7 @@ int main()
 
     vpRowVector r1;
     for(size_t i=0; i<4; i++)
-      r1.stack(i);
+      r1.stack((double)i);
 
     vpRowVector r2 = r1.extract(1, 3);
     if (test("r2", r2, bench3) == false)

--- a/modules/core/test/math/testRowVector.cpp
+++ b/modules/core/test/math/testRowVector.cpp
@@ -41,104 +41,241 @@
   Test some vpRowVector functionalities.
 */
 
-#include <visp3/core/vpRowVector.h>
-#include <visp3/core/vpDebug.h>
-#include <visp3/core/vpMath.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 
+#include <visp3/core/vpMath.h>
+#include <visp3/core/vpRowVector.h>
+
+
+bool test(const std::string &s, const vpRowVector &v, const std::vector<double> &bench)
+{
+  static unsigned int cpt = 0;
+  std::cout << "** Test " << ++cpt << std::endl;
+  std::cout << s << "(" << v.getRows() << "," << v.getCols() << ") = [" << v << "]" << std::endl;
+  if(bench.size() != v.size()) {
+    std::cout << "Test fails: bad size wrt bench" << std::endl;
+    return false;
+  }
+  for (unsigned int i=0; i<v.size(); i++) {
+    if (std::fabs(v[i]-bench[i]) > std::fabs(v[i])*std::numeric_limits<double>::epsilon()) {
+      std::cout << "Test fails: bad content" << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
 
 int main()
 {
-  try {
-    vpRowVector V(4) ;
-    V = 1.0;
+  int err = 1;
 
-    vpTRACE("------------------------");
-    vpTRACE("call std::cout << V;");
-    std::cout << V << std::endl;
+  {
+    vpRowVector v;
 
-    vpTRACE("------------------------");
-    vpTRACE("call V.normalize();");
-    V.normalize();
+    v.resize(4);
+    v = 3;
+    std::vector<double> bench1(4, 3);
+    if (test("v", v, bench1) == false)
+      return err;
+    std::vector<double> bench2(4, 3./6);
+    v.normalize();
+    if (test("v", v, bench2) == false)
+      return err;
+  }
 
-    vpTRACE("------------------------");
-    vpTRACE("call std::cout << V;");
-    std::cout << V << std::endl;
+  {
+    vpRowVector v(4);
+    std::vector<double> bench1(4);
+    for(size_t i=0; i<v.size(); i++) {
+      v[i] = i;
+      bench1[i] = i;
+    }
+    if (test("v", v, bench1) == false)
+      return err;
 
+    vpRowVector w;
+    w.init(v, 0, 2);
+    std::vector<double> bench2;
+    bench2.push_back(0);
+    bench2.push_back(1);
+    if (test("w", w, bench2) == false)
+      return err;
 
-    //Test stack
-    vpRowVector row_vector1(4);
-    row_vector1 = 1.0;
-    row_vector1.stack(2.0);
-    std::cout << "row_vector1.stack(2.0)=" << row_vector1 << std::endl;
+    std::vector<double> bench3;
+    bench3.push_back(1);
+    bench3.push_back(2);
+    bench3.push_back(3);
 
-    vpRowVector row_vector2(3);
-    row_vector2 = 5.0;
+    vpRowVector r1;
+    for(size_t i=0; i<4; i++)
+      r1.stack(i);
 
-    vpRowVector row_vector3;
-    row_vector3 = vpRowVector::stack(row_vector1, row_vector2);
-    std::cout << "vpRowVector::stack(row_vector1, row_vector2)=" << row_vector3 << std::endl;
+    vpRowVector r2 = r1.extract(1, 3);
+    if (test("r2", r2, bench3) == false)
+      return err;
+  }
+  {
+    vpMatrix M(1, 4);
+    std::vector<double> bench(4);
+    for(unsigned int i=0; i<M.getCols(); i++) {
+      M[0][i] = i;
+      bench[i] = i;
+    }
+    if (test("M", M, bench) == false)
+      return err;
+    vpRowVector v;
+    v = M;
+    if (test("v", v, bench) == false)
+      return err;
+    vpRowVector w(M);
+    if (test("w", w, bench) == false)
+      return err;
+    vpRowVector z1(bench);
+    if (test("z1", z1, bench) == false)
+      return err;
+    vpRowVector z2 = bench;
+    if (test("z2", z2, bench) == false)
+      return err;
+  }
+  {
+    vpRowVector v(3);
+    v[0] = 1;
+    v[1] = 2;
+    v[2] = 3;
+    std::vector<double> bench1;
+    bench1.push_back(3);
+    bench1.push_back(6);
+    bench1.push_back(9);
 
-    row_vector1.stack(row_vector2);
-    std::cout << "row_vector1.stack(row_vector2)=" << row_vector1 << std::endl;
+    vpRowVector w = v * 3;
+    // v is unchanged
+    // w is now equal to : [3 6 9]
+    if (test("w", w, bench1) == false)
+      return err;
 
+    vpRowVector x(w);
+    if (test("x", x, bench1) == false)
+      return err;
 
-    //Test mean, median and standard deviation against Matlab with rng(0) and rand(10,1)*10
-    vpRowVector rowVector(10);
-    rowVector[0] = 8.1472;
-    rowVector[1] = 9.0579;
-    rowVector[2] = 1.2699;
-    rowVector[3] = 9.1338;
-    rowVector[4] = 6.3236;
-    rowVector[5] = 0.9754;
-    rowVector[6] = 2.7850;
-    rowVector[7] = 5.4688;
-    rowVector[8] = 9.5751;
-    rowVector[9] = 9.6489;
+    std::vector<float> bench2;
+    bench2.push_back(3);
+    bench2.push_back(6);
+    bench2.push_back(9);
+    vpRowVector y1(bench2);
+    if (test("y1", y1, bench1) == false)
+      return err;
+    vpRowVector y2 = bench2;
+    if (test("y2", y2, bench1) == false)
+      return err;
+  }
+  {
+    vpRowVector r1(3, 1);
+    vpRowVector r2 = -r1;
+    std::vector<double> bench(3,-1);
+    // v contains [-1 -1 -1]
+    if (test("r2", r2, bench) == false)
+      return err;
+    r2.stack(-2);
+    bench.push_back(-2);
+    if (test("r2", r2, bench) == false)
+      return err;
+    vpRowVector r3 = vpRowVector::stack(r1, r2);
+    std::vector<double> bench3(7, 1);
+    bench3[3] = bench3[4] = bench3[5] = -1;
+    bench3[6] = -2;
+    if (test("r3", r3, bench3) == false)
+      return err;
 
+    r1.stack(r2);
+    if (test("r1", r1, bench3) == false)
+      return err;
+  }
+  {
+    vpRowVector r1(3, 2);
+    vpRowVector r2(3, 4);
+    vpRowVector r = r1 + r2;
+    std::vector<double> bench(3, 6);
+    if (test("r", r, bench) == false)
+      return err;
+    r1 += r2;
+    if (test("r1", r1, bench) == false)
+      return err;
+  }
+  {
+    vpRowVector r1(3, 2);
+    vpRowVector r2(3, 4);
+    vpRowVector r = r1 - r2;
+    std::vector<double> bench(3, -2);
+    if (test("r", r, bench) == false)
+      return err;
+    r1 -= r2;
+    if (test("r1", r1, bench) == false)
+      return err;
+  }
+  {
+    vpRowVector r(5, 1);
+    r.clear();
+    r.resize(5);
+    r = 5;
+    std::vector<double> bench(5, 5);
+    if (test("r", r, bench) == false)
+      return err;
+  }
+  {
+    // Test mean, median and standard deviation against Matlab with rng(0) and rand(10,1)*10
+    vpRowVector r(10);
+    r[0] = 8.1472;
+    r[1] = 9.0579;
+    r[2] = 1.2699;
+    r[3] = 9.1338;
+    r[4] = 6.3236;
+    r[5] = 0.9754;
+    r[6] = 2.7850;
+    r[7] = 5.4688;
+    r[8] = 9.5751;
+    r[9] = 9.6489;
 
-    double res = vpRowVector::mean(rowVector);
+    std::cout << "** Test mean" << std::endl;
+    double res = vpRowVector::mean(r);
     if(!vpMath::equal(res, 6.2386, 0.001)) {
-      std::cerr << "Problem with vpRowVector::mean()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad mean " << res << std::endl;
+      return err;
     }
-    std::cout << "vpRowVector::mean() is Ok !" << std::endl;
 
-    res = vpRowVector::stdev(rowVector);
+    std::cout << "** Test stdev" << std::endl;
+    res = vpRowVector::stdev(r);
     if(!vpMath::equal(res, 3.2810, 0.001)) {
-      std::cerr << "Problem with vpRowVector::stdev()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad stdev " << res << std::endl;
+      return err;
     }
 
-    res = vpRowVector::stdev(rowVector, true);
+    std::cout << "** Test stdev(bessel)" << std::endl;
+    res = vpRowVector::stdev(r, true);
     if(!vpMath::equal(res, 3.4585, 0.001)) {
-      std::cerr << "Problem with vpRowVector::stdev() with Bessel correction=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad stdev(bessel) " << res << std::endl;
+      return err;
     }
-    std::cout << "vpRowVector::stdev() is Ok !" << std::endl;
 
-    res = vpRowVector::median(rowVector);
+    std::cout << "** Test median" << std::endl;
+    res = vpRowVector::median(r);
     if(!vpMath::equal(res, 7.2354, 0.001)) {
-      std::cerr << "Problem with vpColVector::median()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad median " << res << std::endl;
+      return err;
     }
 
-    //Test median with odd number of elements
-    rowVector.stack(1.5761);
-    res = vpRowVector::median(rowVector);
+    // Test median with odd number of elements
+    std::cout << "** Test median (odd)" << std::endl;
+    r.stack(1.5761);
+    res = vpRowVector::median(r);
     if(!vpMath::equal(res, 6.3236, 0.001)) {
-      std::cerr << "Problem with vpRowVector::median()=" << res << std::endl;
-      return -1;
+      std::cout << "Test fails: bad median (odd) " << res << std::endl;
+      return err;
     }
-    std::cout << "vpRowVector::median() is Ok !" << std::endl;
-
-    std::cout << "OK !" << std::endl;
-    return (0);
+    std::cout << "r: [" << r << "]" << std::endl;
+    r.print(std::cout, 8, "r");
   }
-  catch(vpException &e) {
-    std::cout << "Catch an exception: " << e << std::endl;
-    return (1);
-  }
+  std::cout << "All tests succeed" << std::endl;
+  return 0;
 }

--- a/modules/core/test/math/testTwistMatrix.cpp
+++ b/modules/core/test/math/testTwistMatrix.cpp
@@ -86,7 +86,6 @@ main()
     vpTRACE("cVe twist matrix:");
     cVe.print (std::cout, 6);
 
-
     // Set a speed skew
     vpColVector ev(6);
 

--- a/modules/gui/include/visp3/gui/vpPlot.h
+++ b/modules/gui/include/visp3/gui/vpPlot.h
@@ -147,6 +147,10 @@ class VISP_EXPORT vpPlot
 
     void plot (const unsigned int graphNum, const unsigned int curveNum, const double x, const double y);
     void plot(const unsigned int graphNum, const double x, const vpColVector &v_y);
+    void plot(const unsigned int graphNum, const double x, const vpRowVector &v_y);
+    void plot(const unsigned int graphNum, const double x, const vpPoseVector &v_y);
+    void plot(const unsigned int graphNum, const double x, const vpTranslationVector &v_y);
+    void plot(const unsigned int graphNum, const double x, const vpRotationVector &v_y);
     vpMouseButton::vpMouseButtonType plot (const unsigned int graphNum, const unsigned int curveNum, const double x, const double y, const double z);
     vpMouseButton::vpMouseButtonType plot(const unsigned int graphNum, const double x, const vpColVector &v_y, const vpColVector &v_z);
 

--- a/modules/gui/src/plot/vpPlot.cpp
+++ b/modules/gui/src/plot/vpPlot.cpp
@@ -295,16 +295,90 @@ vpPlot::plot (const unsigned int graphNum, const unsigned int curveNum, const do
   \param x : The coordinate of the new points along the x axis and given in the user unit system.
   \param v_y : y coordinates vector. The coordinates of the new points along the y axis and given in the user unit system.
 */
-void vpPlot::plot(const unsigned int graphNum, 
-      const double x, const vpColVector &v_y)
+void vpPlot::plot(const unsigned int graphNum,
+                  const double x, const vpColVector &v_y)
 {
-	if((graphList+graphNum)->curveNbr == v_y.getRows())
-	{
-		for(unsigned int i = 0;i < v_y.getRows();++i)
-			this->plot(graphNum, i, x, v_y[i]);
-	}
-	else
-		vpTRACE("error in plot vector : not the right dimension");
+  if((graphList+graphNum)->curveNbr == v_y.getRows())
+  {
+    for(unsigned int i = 0;i < v_y.getRows();++i)
+      this->plot(graphNum, i, x, v_y[i]);
+  }
+  else
+    vpTRACE("error in plot vector : not the right dimension");
+}
+/*!
+  This function enables you to add new points in all curves of a plot. These points are drawn with the parameters of the curves.
+
+  \param graphNum : The index of the graph in the window. As the number of graphic in a window is less or equal to 4, this parameter is between 0 and 3.
+  \param x : The coordinate of the new points along the x axis and given in the user unit system.
+  \param v_y : y coordinates vector. The coordinates of the new points along the y axis and given in the user unit system.
+*/
+void vpPlot::plot(const unsigned int graphNum,
+                  const double x, const vpRowVector &v_y)
+{
+  if((graphList+graphNum)->curveNbr == v_y.getRows())
+  {
+    for(unsigned int i = 0;i < v_y.getRows();++i)
+      this->plot(graphNum, i, x, v_y[i]);
+  }
+  else
+    vpTRACE("error in plot vector : not the right dimension");
+}
+
+/*!
+  This function enables you to add new points in all curves of a plot. These points are drawn with the parameters of the curves.
+
+  \param graphNum : The index of the graph in the window. As the number of graphic in a window is less or equal to 4, this parameter is between 0 and 3.
+  \param x : The coordinate of the new points along the x axis and given in the user unit system.
+  \param v_y : y coordinates vector. The coordinates of the new points along the y axis and given in the user unit system.
+*/
+void vpPlot::plot(const unsigned int graphNum,
+                  const double x, const vpPoseVector &v_y)
+{
+  if((graphList+graphNum)->curveNbr == v_y.getRows())
+  {
+    for(unsigned int i = 0;i < v_y.getRows();++i)
+      this->plot(graphNum, i, x, v_y[i]);
+  }
+  else
+    vpTRACE("error in plot vector : not the right dimension");
+}
+/*!
+  This function enables you to add new points in all curves of a plot. These points are drawn with the parameters of the curves.
+
+  \param graphNum : The index of the graph in the window. As the number of graphic in a window is less or equal to 4, this parameter is between 0 and 3.
+  \param x : The coordinate of the new points along the x axis and given in the user unit system.
+  \param v_y : y coordinates vector. The coordinates of the new points along the y axis and given in the user unit system.
+*/
+void vpPlot::plot(const unsigned int graphNum,
+                  const double x, const vpTranslationVector &v_y)
+{
+  if((graphList+graphNum)->curveNbr == v_y.getRows())
+  {
+    for(unsigned int i = 0;i < v_y.getRows();++i)
+      this->plot(graphNum, i, x, v_y[i]);
+  }
+  else
+    vpTRACE("error in plot vector : not the right dimension");
+}
+
+/*!
+  This function enables you to add new points in all curves of a plot. These points are drawn with the parameters of the curves.
+
+  \param graphNum : The index of the graph in the window. As the number of graphic in a window is less or equal to 4, this parameter is between 0 and 3.
+  \param x : The coordinate of the new points along the x axis and given in the user unit system.
+  \param v_y : y coordinates vector. The coordinates of the new points along the y axis and given in the user unit system.
+*/
+void vpPlot::plot(const unsigned int graphNum,
+                  const double x, const vpRotationVector &v_y)
+{
+  if((graphList+graphNum)->curveNbr == v_y.size())
+  {
+    for(unsigned int i = 0;i < v_y.size();++i)
+      this->plot(graphNum, i, x, v_y[i]);
+  }
+  else
+    vpTRACE("error in plot vector : not the right dimension");
 }
 
 

--- a/modules/robot/src/real-robot/afma6/vpAfma6.cpp
+++ b/modules/robot/src/real-robot/afma6/vpAfma6.cpp
@@ -165,7 +165,7 @@ vpAfma6::vpAfma6()
   // distance between join 5 and 6
   this->_long_56  = -0.06924;
   // Camera extrinsic parameters: effector to camera frame
-  this->_eMc.setIdentity(); // Default values are initialized ...
+  this->_eMc.eye(); // Default values are initialized ...
   //  ... in init (vpAfma6::vpAfma6ToolType tool,
   //               vpCameraParameters::vpCameraParametersProjType projModel)
   // Maximal value of the joints

--- a/modules/robot/src/real-robot/viper/vpViper.cpp
+++ b/modules/robot/src/real-robot/viper/vpViper.cpp
@@ -94,7 +94,7 @@ vpViper::vpViper()
   joint_max[5] = vpMath::rad(360);
 
   // End effector to camera transformation
-  eMc.setIdentity(); 
+  eMc.eye();
 }
 
 
@@ -889,7 +889,7 @@ void
 vpViper::get_wMe(vpHomogeneousMatrix & wMe) const
 {
   // Set the rotation as identity
-  wMe.setIdentity();
+  wMe.eye();
 
   // Set the translation
   wMe[2][3] = d6;

--- a/modules/robot/src/robot-simulator/vpRobotCamera.cpp
+++ b/modules/robot/src/robot-simulator/vpRobotCamera.cpp
@@ -85,8 +85,7 @@ vpRobotCamera::vpRobotCamera()
 void vpRobotCamera::init()
 {
   nDof = 6;
-  eJe.resize(6,6) ;
-  eJe.setIdentity() ;
+  eJe.eye(6,6) ;
   eJeAvailable = true;
   fJeAvailable = false;
   areJointLimitsAvailable = false;

--- a/modules/robot/src/robot-simulator/vpSimulatorAfma6.cpp
+++ b/modules/robot/src/robot-simulator/vpSimulatorAfma6.cpp
@@ -2594,8 +2594,8 @@ vpSimulatorAfma6::setPosition(const vpHomogeneousMatrix &cdMo_, vpImage<unsigned
 		cdTUc.buildFrom(cdRc);
 
 		// compute v,w and velocity
-		v = -lambda*cdRc.t()*cdTc;
-		w = -lambda*cdTUc;
+    v = -lambda*cdRc.t()*cdTc;
+    w = -lambda*cdTUc;
 		for(i=0;i<3;++i)
 		{
 			vel[i] = v[i];

--- a/modules/robot/src/robot-simulator/vpSimulatorCamera.cpp
+++ b/modules/robot/src/robot-simulator/vpSimulatorCamera.cpp
@@ -68,8 +68,7 @@ vpSimulatorCamera::vpSimulatorCamera() : wMc_()
 void vpSimulatorCamera::init()
 {
   nDof = 6;
-  eJe.resize(6,6) ;
-  eJe.setIdentity() ;
+  eJe.eye(6,6) ;
   eJeAvailable = true;
   fJeAvailable = false;
   areJointLimitsAvailable = false;

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
@@ -573,7 +573,7 @@ protected:
 
   void createCylinderBBox(const vpPoint& p1, const vpPoint &p2, const double &radius, std::vector<std::vector<vpPoint> > &listFaces);
 
-  void computeJTR(const vpMatrix& J, const vpColVector& R, vpMatrix& JTR);
+  void computeJTR(const vpMatrix& J, const vpColVector& R, vpColVector& JTR);
   
 #ifdef VISP_HAVE_COIN3D
   virtual void extractGroup(SoVRMLGroup *sceneGraphVRML2, vpHomogeneousMatrix &transform, int &idFace);

--- a/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
@@ -599,7 +599,7 @@ vpMbEdgeTracker::computeVVS(const vpImage<unsigned char>& _I)
         cVo.buildFrom(cMo);
         vpMatrix LVJ = (L*cVo*oJo);
         vpMatrix LVJTLVJ = (LVJ).AtA();
-        vpMatrix LVJTR;
+        vpColVector LVJTR;
         computeJTR(LVJ, weighted_error, LVJTR);
         v = -0.7*LVJTLVJ.pseudoInverse(LVJTLVJ.getRows()*std::numeric_limits<double>::epsilon())*LVJTR;
         v = cVo * v;
@@ -801,7 +801,7 @@ vpMbEdgeTracker::computeVVS(const vpImage<unsigned char>& _I)
         case vpMbTracker::LEVENBERG_MARQUARDT_OPT:
         {
           vpMatrix LMA(LTL.getRows(), LTL.getCols());
-          LMA.setIdentity();
+          LMA.eye();
           vpMatrix LTLmuI = LTL + (LMA*mu);
           v = -lambda*LTLmuI.pseudoInverse(LTLmuI.getRows()*std::numeric_limits<double>::epsilon())*LTR;
 
@@ -821,14 +821,14 @@ vpMbEdgeTracker::computeVVS(const vpImage<unsigned char>& _I)
         cVo.buildFrom(cMo);
         vpMatrix LVJ = (L*cVo*oJo);
         vpMatrix LVJTLVJ = (LVJ).AtA();
-        vpMatrix LVJTR;
+        vpColVector LVJTR;
         computeJTR(LVJ, weighted_error, LVJTR);
 
         switch(m_optimizationMethod){
         case vpMbTracker::LEVENBERG_MARQUARDT_OPT:
         {
           vpMatrix LMA(LVJTLVJ.getRows(), LVJTLVJ.getCols());
-          LMA.setIdentity();
+          LMA.eye();
           vpMatrix LTLmuI = LVJTLVJ + (LMA*mu);
           v = -lambda*LTLmuI.pseudoInverse(LTLmuI.getRows()*std::numeric_limits<double>::epsilon())*LVJTR;
           v = cVo * v;
@@ -2273,7 +2273,7 @@ vpMbEdgeTracker::initCylinder(const vpPoint& p1, const vpPoint &p2, const double
 void
 vpMbEdgeTracker::resetTracker()
 {
-  this->cMo.setIdentity();
+  this->cMo.eye();
   vpMbtDistanceLine *l;
   vpMbtDistanceCylinder *cy;
   vpMbtDistanceCircle *ci;
@@ -2357,7 +2357,7 @@ void
 vpMbEdgeTracker::reInitModel(const vpImage<unsigned char>& I, const char* cad_name,
                              const vpHomogeneousMatrix& cMo_, const bool verbose)
 {
-  this->cMo.setIdentity();
+  this->cMo.eye();
   vpMbtDistanceLine *l;
   vpMbtDistanceCylinder *cy;
   vpMbtDistanceCircle *ci;

--- a/modules/tracker/mbt/src/hybrid/vpMbEdgeKltTracker.cpp
+++ b/modules/tracker/mbt/src/hybrid/vpMbEdgeKltTracker.cpp
@@ -620,7 +620,8 @@ vpMbEdgeKltTracker::computeVVS(const vpImage<unsigned char>& I, const unsigned i
   vpRobust robust_mbt(0), robust_klt(0);
   vpHomography H;
 
-  vpMatrix LTL, LTR;
+  vpMatrix LTL;
+  vpColVector LTR;
   
   double factorMBT = 1.0;
   double factorKLT = 1.0;
@@ -732,8 +733,8 @@ vpMbEdgeKltTracker::computeVVS(const vpImage<unsigned char>& I, const unsigned i
         robust_mbt.setIteration(iter);
         robust_mbt.setThreshold(thresholdMBT/cam.get_px());
         robust_mbt.MEstimator( vpRobust::TUKEY, R_mbt, w_mbt);
-        L->stackMatrices(L_mbt);
-        R->stackMatrices(R_mbt);
+        L->stack(L_mbt);
+        R->stack(R_mbt);
       }
 
       if(nbInfos > 3){
@@ -746,8 +747,8 @@ vpMbEdgeKltTracker::computeVVS(const vpImage<unsigned char>& I, const unsigned i
         robust_klt.setThreshold(thresholdKLT/cam.get_px());
         robust_klt.MEstimator( vpRobust::TUKEY, R_klt, w_klt);
 
-        L->stackMatrices(L_klt);
-        R->stackMatrices(R_klt);
+        L->stack(L_klt);
+        R->stack(R_klt);
       }
 
       unsigned int cpt = 0;
@@ -797,7 +798,7 @@ vpMbEdgeKltTracker::computeVVS(const vpImage<unsigned char>& I, const unsigned i
           case vpMbTracker::LEVENBERG_MARQUARDT_OPT:
           {
             vpMatrix LMA(LTL.getRows(), LTL.getCols());
-            LMA.setIdentity();
+            LMA.eye();
             vpMatrix LTLmuI = LTL + (LMA*mu);
             v = -lambda*LTLmuI.pseudoInverse(LTLmuI.getRows()*std::numeric_limits<double>::epsilon())*LTR;
 
@@ -818,14 +819,14 @@ vpMbEdgeKltTracker::computeVVS(const vpImage<unsigned char>& I, const unsigned i
           cVo.buildFrom(cMo);
           vpMatrix LVJ = ((*L)*cVo*oJo);
           vpMatrix LVJTLVJ = (LVJ).AtA();
-          vpMatrix LVJTR;
+          vpColVector LVJTR;
           computeJTR(LVJ, *R, LVJTR);
 
           switch(m_optimizationMethod){
           case vpMbTracker::LEVENBERG_MARQUARDT_OPT:
           {
             vpMatrix LMA(LVJTLVJ.getRows(), LVJTLVJ.getCols());
-            LMA.setIdentity();
+            LMA.eye();
             vpMatrix LTLmuI = LVJTLVJ + (LMA*mu);
             v = -lambda*LTLmuI.pseudoInverse(LTLmuI.getRows()*std::numeric_limits<double>::epsilon())*LVJTR;
             v = cVo * v;

--- a/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
@@ -154,7 +154,7 @@ void
 vpMbKltTracker::reinit(const vpImage<unsigned char>& I)
 {
   c0Mo = cMo;
-  ctTc0.setIdentity();
+  ctTc0.eye();
 
   vpImageConvert::convert(I, cur);
 
@@ -236,7 +236,7 @@ vpMbKltTracker::reinit(const vpImage<unsigned char>& I)
 void            
 vpMbKltTracker::resetTracker()
 {
-  cMo.setIdentity();
+  cMo.eye();
   
 #if (VISP_HAVE_OPENCV_VERSION < 0x020408)
   if(cur != NULL){
@@ -564,7 +564,7 @@ vpMbKltTracker::setPose(const vpImage<unsigned char> &I, const vpHomogeneousMatr
 
     cMo = cdMo;
     c0Mo = cMo;
-    ctTc0.setIdentity();
+    ctTc0.eye();
   }
 }
 
@@ -737,7 +737,8 @@ vpMbKltTracker::computeVVS(const unsigned int &nbInfos, vpColVector &w)
   vpColVector w_true;
   vpRobust robust(2*nbInfos);
 
-  vpMatrix LTL, LTR;
+  vpMatrix LTL;
+  vpColVector LTR;
   vpHomogeneousMatrix cMoPrev;
   vpHomogeneousMatrix ctTc0_Prev;
   vpColVector m_error_prev(2*nbInfos);
@@ -850,7 +851,7 @@ vpMbKltTracker::computeVVS(const unsigned int &nbInfos, vpColVector &w)
           case vpMbTracker::LEVENBERG_MARQUARDT_OPT:
           {
             vpMatrix LMA(LTL.getRows(), LTL.getCols());
-            LMA.setIdentity();
+            LMA.eye();
             vpMatrix LTLmuI = LTL + (LMA*mu);
             v = -lambda*LTLmuI.pseudoInverse(LTLmuI.getRows()*std::numeric_limits<double>::epsilon())*LTR;
 
@@ -870,14 +871,14 @@ vpMbKltTracker::computeVVS(const unsigned int &nbInfos, vpColVector &w)
           cVo.buildFrom(cMo);
           vpMatrix LVJ = (L*cVo*oJo);
           vpMatrix LVJTLVJ = (LVJ).AtA();
-          vpMatrix LVJTR;
+          vpColVector LVJTR;
           computeJTR(LVJ, R, LVJTR);
 
           switch(m_optimizationMethod){
           case vpMbTracker::LEVENBERG_MARQUARDT_OPT:
           {
             vpMatrix LMA(LVJTLVJ.getRows(), LVJTLVJ.getCols());
-            LMA.setIdentity();
+            LMA.eye();
             vpMatrix LTLmuI = LVJTLVJ + (LMA*mu);
             v = -lambda*LTLmuI.pseudoInverse(LTLmuI.getRows()*std::numeric_limits<double>::epsilon())*LVJTR;
             v = cVo * v;
@@ -1356,7 +1357,7 @@ void
 vpMbKltTracker::reInitModel(const vpImage<unsigned char>& I, const char* cad_name,
                             const vpHomogeneousMatrix& cMo_, const bool verbose)
 {
-  this->cMo.setIdentity();
+  this->cMo.eye();
 
 #if (VISP_HAVE_OPENCV_VERSION < 0x020408)
   if(cur != NULL){

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -136,7 +136,7 @@ vpMbTracker::vpMbTracker()
   useLodGeneral(false), applyLodSettingInConfig(false), minLineLengthThresholdGeneral(50.0),
   minPolygonAreaThresholdGeneral(2500.0), mapOfParameterNames()
 {
-    oJo.setIdentity();
+    oJo.eye();
     //Map used to parse additional information in CAO model files,
     //like name of faces or LOD setting
     mapOfParameterNames["name"] = "string";
@@ -205,7 +205,7 @@ vpMbTracker::initClick(const vpImage<unsigned char>& I, const std::string& initF
   }
   if(finitpos.fail() ){
   	std::cout << "cannot read " << s << std::endl << "cMo set to identity" << std::endl;
-  	last_cMo.setIdentity();
+    last_cMo.eye();
   }
   else{
     for (unsigned int i = 0; i < 6; i += 1){
@@ -2364,18 +2364,18 @@ vpMbTracker::setClipping(const unsigned int &flags)
   
   \param interaction : The interaction matrix (size Nx6).
   \param error : The residu vector (size Nx1).
-  \param JTR : The resulting JTR matrix (size 6x1).
+  \param JTR : The resulting JTR column vector (size 6x1).
   
 */
 void 
-vpMbTracker::computeJTR(const vpMatrix& interaction, const vpColVector& error, vpMatrix& JTR)
+vpMbTracker::computeJTR(const vpMatrix& interaction, const vpColVector& error, vpColVector& JTR)
 {
   if(interaction.getRows() != error.getRows() || interaction.getCols() != 6 ){
     throw vpMatrixException(vpMatrixException::incorrectMatrixSizeError, 
               "Incorrect matrices size in computeJTR.");
   }
 
-  JTR.resize(6, 1);
+  JTR.resize(6);
   const unsigned int N = interaction.getRows();
 
   for (unsigned int i = 0; i < 6; i += 1){
@@ -2383,7 +2383,7 @@ vpMbTracker::computeJTR(const vpMatrix& interaction, const vpColVector& error, v
     for (unsigned int j = 0; j < N; j += 1){
       ssum += interaction[j][i] * error[j];
     }
-    JTR[i][0] = ssum;
+    JTR[i] = ssum;
   }
 }
 

--- a/modules/tracker/me/src/moving-edges/vpMeEllipse.cpp
+++ b/modules/tracker/me/src/moving-edges/vpMeEllipse.cpp
@@ -635,7 +635,7 @@ vpMeEllipse::leastSquare()
   r.setThreshold(2);
   r.setIteration(0) ;
   vpMatrix D(numberOfSignal(),numberOfSignal()) ;
-  D.setIdentity() ;
+  D.eye() ;
   vpMatrix DA, DAmemory ;
   vpColVector DAx ;
   vpColVector w(numberOfSignal()) ;

--- a/modules/tracker/me/src/moving-edges/vpMeLine.cpp
+++ b/modules/tracker/me/src/moving-edges/vpMeLine.cpp
@@ -297,7 +297,7 @@ vpMeLine::leastSquare()
   r.setThreshold(2);
   r.setIteration(0) ;
   vpMatrix D(numberOfSignal(),numberOfSignal()) ;
-  D.setIdentity() ;
+  D.eye() ;
   vpMatrix DA, DAmemory ;
   vpColVector DAx ;
   vpColVector w(numberOfSignal()) ;

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardAdditional.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardAdditional.cpp
@@ -159,7 +159,7 @@ void vpTemplateTrackerSSDForwardAdditional::trackNoPyr(const vpImage<unsigned ch
         computeOptimalBrentGain(I,p,erreur,dp,alpha);
         dp=alpha*dp;
       }
-      p+=1.*dp;
+      p += 1. * dp;
       break;
     }
 

--- a/modules/tracker/tt/src/warp/vpTemplateTrackerWarp.cpp
+++ b/modules/tracker/tt/src/warp/vpTemplateTrackerWarp.cpp
@@ -149,7 +149,7 @@ void vpTemplateTrackerWarp::findWarp(const double *ut0,const double *vt0,const d
 
     vpMatrix::computeHLM(H, lambda, HLM);
     try{
-      p+=HLM.inverseByLU()*G;
+      p+=(vpColVector)(HLM.inverseByLU()*G, 0);
     }
     catch(vpException &e) {
       //std::cout<<"Cannot inverse the matrix by LU " << std::endl;

--- a/modules/tracker/tt/src/warp/vpTemplateTrackerWarpHomographySL3.cpp
+++ b/modules/tracker/tt/src/warp/vpTemplateTrackerWarpHomographySL3.cpp
@@ -289,7 +289,7 @@ void vpTemplateTrackerWarpHomographySL3::getdW0(const int &i,const int &j,const 
   vpMatrix dhdx(1,3);
   dhdx=0;
   dhdx[0][0]=dx;dhdx[0][1]=dy;dhdx[0][2]=-j*dx-i*dy;
-  G.setIdentity();
+  G.eye();
 
   dGx=0;
   for(unsigned int par=0;par<3;par++)
@@ -321,7 +321,7 @@ void vpTemplateTrackerWarpHomographySL3::getdWdp0(const int &i,const int &j,doub
   vpMatrix dhdx(2,3);
   dhdx=0;
   dhdx[0][0]=1.;dhdx[1][1]=1.;dhdx[0][2]=-j;dhdx[1][2]=-i;
-  G.setIdentity();
+  G.eye();
 
   dGx=0;
   for(unsigned int par=0;par<3;par++)
@@ -350,7 +350,7 @@ void vpTemplateTrackerWarpHomographySL3::getdWdp0(const double &i,const double &
   vpMatrix dhdx(2,3);
   dhdx=0;
   dhdx[0][0]=1.;dhdx[1][1]=1.;dhdx[0][2]=-j;dhdx[1][2]=-i;
-  G.setIdentity();
+  G.eye();
 
   dGx=0;
   for(unsigned int par=0;par<3;par++)

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
@@ -37,7 +37,6 @@
  *
  *****************************************************************************/
 #include <visp3/tt_mi/vpTemplateTrackerMIInverseCompositional.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/core/vpTrackingException.h>
 
 #ifdef VISP_HAVE_OPENMP
@@ -632,7 +631,6 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
         MI_postEstimation = -1;
         NMI_postEstimation = -1;
         deletePosEvalRMS();
-        //            throw(vpMatrixException(vpMatrixException::matrixError, "Covariance not inversible")) ;
       }
     }
   }

--- a/modules/vision/src/calibration/vpCalibrationTools.cpp
+++ b/modules/vision/src/calibration/vpCalibrationTools.cpp
@@ -1192,8 +1192,8 @@ void vpCalibration::calibrationTsai(std::vector<vpHomogeneousMatrix>& cMo,
           }
           else
           {
-            A = vpMatrix::stackMatrices(A,As) ;
-            B = vpMatrix::stackMatrices(B,b) ;
+            A = vpMatrix::stack(A,As) ;
+            B = vpColVector::stack(B,b) ;
           }
           k++ ;
         }
@@ -1246,7 +1246,7 @@ void vpCalibration::calibrationTsai(std::vector<vpHomogeneousMatrix>& cMo,
     // Building of the system for the translation estimation
     // for all couples ij
     vpRotationMatrix I3 ;
-    I3.setIdentity() ;
+    I3.eye() ;
     int k = 0 ;
     for (unsigned int i=0 ; i < nbPose ; i++)
     {
@@ -1277,11 +1277,10 @@ void vpCalibration::calibrationTsai(std::vector<vpHomogeneousMatrix>& cMo,
 
           rTeij = rRej.t()*rTeij ;
 
-          vpMatrix a ;
-          a = (vpMatrix)rReij - (vpMatrix)I3 ;
+          vpMatrix a = vpMatrix(rReij) - vpMatrix(I3);
 
           vpTranslationVector b ;
-          b =  eRc*cjTo - rReij*eRc*ciTo + rTeij ;
+          b = eRc*cjTo - rReij*eRc*ciTo + rTeij ;
 
           if (k==0)
           {
@@ -1290,8 +1289,8 @@ void vpCalibration::calibrationTsai(std::vector<vpHomogeneousMatrix>& cMo,
           }
           else
           {
-            A = vpMatrix::stackMatrices(A,a) ;
-            B = vpMatrix::stackMatrices(B,b) ;
+            A = vpMatrix::stack(A,a) ;
+            B = vpColVector::stack(B,b) ;
           }
           k++ ;
         }

--- a/modules/vision/src/homography-estimation/vpHomographyDLT.cpp
+++ b/modules/vision/src/homography-estimation/vpHomographyDLT.cpp
@@ -169,9 +169,9 @@ vpHomography::HartleyDenormalization(vpHomography &aHbn,
   vpMatrix T2(3,3);
   vpMatrix T2T(3,3);
 
-  T1.setIdentity();
-  T2.setIdentity();
-  T2T.setIdentity();
+  T1.eye();
+  T2.eye();
+  T2T.eye();
 
   T1[0][0]=T1[1][1]=coef1;
   T1[0][2]=-coef1*xg1 ;

--- a/modules/vision/src/homography-estimation/vpHomographyExtract.cpp
+++ b/modules/vision/src/homography-estimation/vpHomographyExtract.cpp
@@ -1051,7 +1051,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
 
       if (norm1ok)
       {
-        Rprim1.setIdentity();
+        Rprim1.eye();
 
         Tprim1 = Nprim1[0];
         Tprim1*= (sv[2] - sv[0]);
@@ -1059,7 +1059,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
 
       if (norm2ok)
       {
-        Rprim2.setIdentity();
+        Rprim2.eye();
 
         Tprim2 = Nprim2[1];
         Tprim2*= (sv[2] - sv[0]);
@@ -1069,7 +1069,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
     {
       if (norm1ok)
       {
-        Rprim1.setIdentity();
+        Rprim1.eye();
 
         Tprim1 = Nprim1[0];
         Tprim1*= (sv[0] - sv[1]);
@@ -1077,7 +1077,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
 
       if (norm2ok)
       {
-        Rprim2.setIdentity();
+        Rprim2.eye();
 
         Tprim2 = Nprim2[1];
         Tprim2*= (sv[0] - sv[1]);
@@ -1086,7 +1086,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
     if (cas == cas4)
     {
       // on ne connait pas la normale dans ce cas la
-      Rprim1.setIdentity();
+      Rprim1.eye();
       Tprim1 = 0.0;
     }
   }
@@ -1204,7 +1204,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
 
       if (norm1ok)
       {
-        Rprim1.setIdentity();
+        Rprim1.eye();
         Rprim1[0][0] = -1;
         Rprim1[1][1] = -1;
 
@@ -1214,7 +1214,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
 
       if (norm2ok)
       {
-        Rprim2.setIdentity();
+        Rprim2.eye();
         Rprim2[0][0] = -1;
         Rprim2[1][1] = -1;
 
@@ -1226,7 +1226,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
     {
       if (norm1ok)
       {
-        Rprim1.setIdentity();
+        Rprim1.eye();
         Rprim1[2][2] = -1;
         Rprim1[1][1] = -1;
 
@@ -1236,7 +1236,7 @@ void vpHomography::computeDisplacement(const vpHomography &H,
 
       if (norm2ok)
       {
-        Rprim2.setIdentity();
+        Rprim2.eye();
         Rprim2[2][2] = -1;
         Rprim2[1][1] = -1;
 

--- a/modules/vision/src/homography-estimation/vpHomographyVVS.cpp
+++ b/modules/vision/src/homography-estimation/vpHomographyVVS.cpp
@@ -206,8 +206,8 @@ vpHomography::computeRotation(unsigned int nbpoint,
           if (k == 0) { L = H2 ; e = e2 ; }
           else
           {
-            L = vpMatrix::stackMatrices(L,H2) ;
-            e = vpMatrix::stackMatrices(e,e2) ;
+            L = vpMatrix::stack(L,H2) ;
+            e = vpColVector::stack(e,e2) ;
           }
         }
         else
@@ -216,8 +216,8 @@ vpHomography::computeRotation(unsigned int nbpoint,
             if (k == 0) { L = H1 ; e= e1 ; }
             else
             {
-              L =  vpMatrix::stackMatrices(L,H1) ;
-              e = vpMatrix::stackMatrices(e,e1) ;
+              L =  vpMatrix::stack(L,H1) ;
+              e = vpColVector::stack(e,e1) ;
             }
           }
           else
@@ -225,11 +225,11 @@ vpHomography::computeRotation(unsigned int nbpoint,
             if (k == 0) {L = H2 ; e = e2 ; }
             else
             {
-              L =  vpMatrix::stackMatrices(L,H2) ;
-              e =  vpMatrix::stackMatrices(e,e2) ;
+              L =  vpMatrix::stack(L,H2) ;
+              e =  vpColVector::stack(e,e2) ;
             }
-            L =  vpMatrix::stackMatrices(L,H1) ;
-            e =  vpMatrix::stackMatrices(e,e1) ;
+            L =  vpMatrix::stack(L,H1) ;
+            e =  vpColVector::stack(e,e1) ;
           }
 
         k++ ;
@@ -378,8 +378,8 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
 
       vpMatrix H(3,3) ;
 
-      Hp2 = ((vpMatrix)c1Rc2 + ((vpMatrix)c1Tc2*N2.t())/d2)*p2 ;  // p2 = Hp1
-      Hp1 = ((vpMatrix)c2Rc1 + ((vpMatrix)c2Tc1*N1.t())/d1)*p1 ;  // p1 = Hp2
+      Hp2 = ((vpMatrix)c1Rc2 + (c1Tc2*N2.t())/d2)*p2 ;  // p2 = Hp1
+      Hp1 = ((vpMatrix)c2Rc1 + (c2Tc1*N1.t())/d1)*p1 ;  // p1 = Hp2
 
       Hp2 /= Hp2[2] ;  // normalisation
       Hp1 /= Hp1[2] ;
@@ -435,8 +435,8 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
         if (k == 0) { L = H2 ; e = e2 ; }
         else
         {
-          L = vpMatrix::stackMatrices(L,H2) ;
-          e = vpMatrix::stackMatrices(e,e2) ;
+          L = vpMatrix::stack(L,H2) ;
+          e = vpColVector::stack(e,e2) ;
         }
       }
       else
@@ -445,8 +445,8 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
           if (k == 0) { L = H1 ; e= e1 ; }
           else
           {
-            L = vpMatrix::stackMatrices(L,H1) ;
-            e = vpMatrix::stackMatrices(e,e1) ;
+            L = vpMatrix::stack(L,H1) ;
+            e = vpColVector::stack(e,e1) ;
           }
         }
         else
@@ -454,11 +454,11 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
           if (k == 0) {L = H2 ; e = e2 ; }
           else
           {
-            L = vpMatrix::stackMatrices(L,H2) ;
-            e = vpMatrix::stackMatrices(e,e2) ;
+            L = vpMatrix::stack(L,H2) ;
+            e = vpColVector::stack(e,e2) ;
           }
-          L = vpMatrix::stackMatrices(L,H1) ;
-          e = vpMatrix::stackMatrices(e,e1) ;
+          L = vpMatrix::stack(L,H1) ;
+          e = vpColVector::stack(e,e1) ;
         }
 
 
@@ -595,8 +595,8 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
 
       vpMatrix H(3,3) ;
 
-      Hp2 = ((vpMatrix)c1Rc2 + ((vpMatrix)c1Tc2*N2.t())/d2)*p2 ;  // p2 = Hp1
-      Hp1 = ((vpMatrix)c2Rc1 + ((vpMatrix)c2Tc1*N1.t())/d1)*p1 ;  // p1 = Hp2
+      Hp2 = ((vpMatrix)c1Rc2 + (c1Tc2*N2.t())/d2)*p2 ;  // p2 = Hp1
+      Hp1 = ((vpMatrix)c2Rc1 + (c2Tc1*N1.t())/d1)*p1 ;  // p1 = Hp2
 
       Hp2 /= Hp2[2] ;  // normalisation
       Hp1 /= Hp1[2] ;
@@ -653,8 +653,8 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
         if (k == 0) { L = H2 ; e = e2 ; }
         else
         {
-          L = vpMatrix::stackMatrices(L,H2) ;
-          e = vpMatrix::stackMatrices(e,e2) ;
+          L = vpMatrix::stack(L,H2) ;
+          e = vpColVector::stack(e,e2) ;
         }
       }
       else
@@ -663,8 +663,8 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
           if (k == 0) { L = H1 ; e= e1 ; }
           else
           {
-            L = vpMatrix::stackMatrices(L,H1) ;
-            e = vpMatrix::stackMatrices(e,e1) ;
+            L = vpMatrix::stack(L,H1) ;
+            e = vpColVector::stack(e,e1) ;
           }
         }
         else
@@ -672,11 +672,11 @@ vpHomography::computeDisplacement(unsigned int nbpoint,
           if (k == 0) {L = H2 ; e = e2 ; }
           else
           {
-            L = vpMatrix::stackMatrices(L,H2) ;
-            e = vpMatrix::stackMatrices(e,e2) ;
+            L = vpMatrix::stack(L,H2) ;
+            e = vpColVector::stack(e,e2) ;
           }
-          L = vpMatrix::stackMatrices(L,H1) ;
-          e = vpMatrix::stackMatrices(e,e1) ;
+          L = vpMatrix::stack(L,H1) ;
+          e = vpColVector::stack(e,e1) ;
         }
 
 

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -710,7 +710,7 @@ vpPose::poseFromRectangle(vpPoint &p1,vpPoint &p2,
   vpColVector kh2(3);
   vpMatrix K(3,3);
   K = cam.get_K();
-  K.setIdentity();
+  K.eye();
   vpMatrix Kinv =K.pseudoInverse();
 
   vpMatrix KinvH =Kinv*H;
@@ -720,7 +720,7 @@ vpPose::poseFromRectangle(vpPoint &p1,vpPoint &p2,
   double s= sqrt(kh1.sumSquare())/sqrt(kh2.sumSquare());
 
   vpMatrix D(3,3);
-  D.setIdentity();
+  D.eye();
   D[1][1]=1/s;
   vpMatrix cHo=H*D;
 

--- a/modules/vision/src/pose-estimation/vpPoseFeatures.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseFeatures.cpp
@@ -289,8 +289,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpPoint p(featurePoint_Point_list[i].firstParam);
       p.track(cMo);
       vpFeatureBuilder::create(fp, p);
-      err.stackMatrices(fp.error(*(featurePoint_Point_list[i].desiredFeature)));
-      L.stackMatrices(fp.interaction());
+      err.stack(fp.error(*(featurePoint_Point_list[i].desiredFeature)));
+      L.stack(fp.interaction());
     }
     
     //--------------vpFeaturePoint3D--------------
@@ -300,8 +300,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpPoint p(featurePoint3D_Point_list[i].firstParam);
       p.track(cMo);
       vpFeatureBuilder::create(fp3D, p);
-      err.stackMatrices(fp3D.error(*(featurePoint3D_Point_list[i].desiredFeature)));
-      L.stackMatrices(fp3D.interaction());
+      err.stack(fp3D.error(*(featurePoint3D_Point_list[i].desiredFeature)));
+      L.stack(fp3D.interaction());
     }
     
     //--------------vpFeatureVanishingPoint--------------
@@ -311,8 +311,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpPoint p(featureVanishingPoint_Point_list[i].firstParam);
       p.track(cMo);
       vpFeatureBuilder::create(fvp, p);
-      err.stackMatrices(fvp.error(*(featureVanishingPoint_Point_list[i].desiredFeature)));
-      L.stackMatrices(fvp.interaction());
+      err.stack(fvp.error(*(featureVanishingPoint_Point_list[i].desiredFeature)));
+      L.stack(fvp.interaction());
     }
       //From Duo of vpLines
     if( i < featureVanishingPoint_DuoLine_list.size() ){
@@ -322,8 +322,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       l1.track(cMo);
       l2.track(cMo);
       vpFeatureBuilder::create(fvp, l1, l2);
-      err.stackMatrices(fvp.error(*(featureVanishingPoint_DuoLine_list[i].desiredFeature)));
-      L.stackMatrices(fvp.interaction());
+      err.stack(fvp.error(*(featureVanishingPoint_DuoLine_list[i].desiredFeature)));
+      L.stack(fvp.interaction());
     }
     
     //--------------vpFeatureEllipse--------------
@@ -333,8 +333,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpSphere s(featureEllipse_Sphere_list[i].firstParam);
       s.track(cMo);
       vpFeatureBuilder::create(fe, s);
-      err.stackMatrices(fe.error(*(featureEllipse_Sphere_list[i].desiredFeature)));
-      L.stackMatrices(fe.interaction());
+      err.stack(fe.error(*(featureEllipse_Sphere_list[i].desiredFeature)));
+      L.stack(fe.interaction());
     }
       //From vpCircle
     if( i < featureEllipse_Circle_list.size() ){
@@ -342,8 +342,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpCircle c(featureEllipse_Circle_list[i].firstParam);
       c.track(cMo);
       vpFeatureBuilder::create(fe, c);
-      err.stackMatrices(fe.error(*(featureEllipse_Circle_list[i].desiredFeature)));
-      L.stackMatrices(fe.interaction());
+      err.stack(fe.error(*(featureEllipse_Circle_list[i].desiredFeature)));
+      L.stack(fe.interaction());
     }
     
     //--------------vpFeatureLine--------------
@@ -353,8 +353,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpLine l(featureLine_Line_list[i].firstParam);
       l.track(cMo);
       vpFeatureBuilder::create(fl, l);
-      err.stackMatrices(fl.error(*(featureLine_Line_list[i].desiredFeature)));
-      L.stackMatrices(fl.interaction());
+      err.stack(fl.error(*(featureLine_Line_list[i].desiredFeature)));
+      L.stack(fl.interaction());
     }
       //From Duo of vpCylinder / Integer
     if( i < featureLine_DuoLineInt_List.size() ){
@@ -362,8 +362,8 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       vpCylinder c(featureLine_DuoLineInt_List[i].firstParam);
       c.track(cMo);
       vpFeatureBuilder::create(fl, c, featureLine_DuoLineInt_List[i].secondParam);
-      err.stackMatrices(fl.error(*(featureLine_DuoLineInt_List[i].desiredFeature)));
-      L.stackMatrices(fl.interaction());
+      err.stack(fl.error(*(featureLine_DuoLineInt_List[i].desiredFeature)));
+      L.stack(fl.interaction());
     }
     
     //--------------vpFeatureSegment--------------
@@ -375,15 +375,15 @@ void vpPoseFeatures::error_and_interaction(vpHomogeneousMatrix & cMo, vpColVecto
       p1.track(cMo);
       p2.track(cMo);
       vpFeatureBuilder::create(fs, p1, p2);
-      err.stackMatrices(fs.error(*(featureSegment_DuoPoints_list[i].desiredFeature)));
-      L.stackMatrices(fs.interaction());
+      err.stack(fs.error(*(featureSegment_DuoPoints_list[i].desiredFeature)));
+      L.stack(fs.interaction());
     }
 
 #ifdef VISP_HAVE_CPP11_COMPATIBILITY
     //--------------Specific Feature--------------
     if( i < featureSpecific_list.size() ){
       featureSpecific_list[i]->createCurrent(cMo);
-      err.stackMatrices(featureSpecific_list[i]->error());
+      err.stack(featureSpecific_list[i]->error());
       L.stackMatrices(featureSpecific_list[i]->currentInteraction());
     }
 #endif

--- a/modules/visual_features/src/visual-feature/vpBasicFeature.cpp
+++ b/modules/visual_features/src/visual-feature/vpBasicFeature.cpp
@@ -127,22 +127,22 @@ vpBasicFeature::getDimension(unsigned int select) const
 
 //! Get the feature vector  \f$\bf s\f$.
 vpColVector
- vpBasicFeature::get_s(const unsigned int select) const
+vpBasicFeature::get_s(const unsigned int select) const
 {
-    vpColVector state(0),stateLine(1);
-    // if s is higher than the possible selections (photometry), send back the whole vector
-    if(dim_s > 31)
-    	return s;
+  vpColVector state(0), stateLine(1);
+  // if s is higher than the possible selections (photometry), send back the whole vector
+  if(dim_s > 31)
+    return s;
 
-	for(unsigned int i=0;i<dim_s;++i)
-	{
-		if(FEATURE_LINE[i] & select)
-		{
-			stateLine[0] = s[i];
-			state.stackMatrices(stateLine);
-    	}
-	}
-    return state ;
+  for(unsigned int i=0;i<dim_s;++i)
+  {
+    if(FEATURE_LINE[i] & select)
+    {
+      stateLine[0] = s[i];
+      state.stack(stateLine);
+    }
+  }
+  return state ;
 }
 
 void vpBasicFeature::resetFlags()
@@ -175,7 +175,7 @@ vpColVector vpBasicFeature::error(const vpBasicFeature &s_star,
 			if(FEATURE_LINE[i] & select)
 			{
 				eLine[0] = s[i] - s_star[i];
-				e.stackMatrices(eLine);
+        e.stack(eLine);
 				//std::cout << "dim_s <= 31"<<std::endl;
 			}
 		}

--- a/modules/visual_features/src/visual-feature/vpFeatureDepth.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureDepth.cpp
@@ -47,7 +47,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace

--- a/modules/visual_features/src/visual-feature/vpFeatureEllipse.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureEllipse.cpp
@@ -47,7 +47,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -171,7 +170,7 @@ vpFeatureEllipse::interaction(const unsigned int select)
     H[0][5] = yc;
 
 
-    L = vpMatrix::stackMatrices(L,H) ;
+    L = vpMatrix::stack(L,H) ;
   }
 
   if (vpFeatureEllipse::selectY() & select )
@@ -186,7 +185,7 @@ vpFeatureEllipse::interaction(const unsigned int select)
     H[0][4] = -xc*yc - mu11;
     H[0][5] = -xc;
 
-    L = vpMatrix::stackMatrices(L,H) ;
+    L = vpMatrix::stack(L,H) ;
   }
 
   if (vpFeatureEllipse::selectMu20() & select )
@@ -200,7 +199,7 @@ vpFeatureEllipse::interaction(const unsigned int select)
     H[0][4] = -4*mu20*xc;
     H[0][5] = 2*mu11;
 
-    L = vpMatrix::stackMatrices(L,H) ;
+    L = vpMatrix::stack(L,H) ;
   }
 
   if (vpFeatureEllipse::selectMu11() & select )
@@ -214,7 +213,7 @@ vpFeatureEllipse::interaction(const unsigned int select)
     H[0][4] = -yc*mu20-3*xc*mu11;
     H[0][5] = mu02-mu20;
 
-    L = vpMatrix::stackMatrices(L,H) ;
+    L = vpMatrix::stack(L,H) ;
   }
 
   if (vpFeatureEllipse::selectMu02() & select )
@@ -227,7 +226,7 @@ vpFeatureEllipse::interaction(const unsigned int select)
     H[0][3] = 4*yc*mu02;
     H[0][4] = -2*(yc*mu11 +xc*mu02) ;
     H[0][5] = -2*mu11 ;
-    L = vpMatrix::stackMatrices(L,H) ;
+    L = vpMatrix::stack(L,H) ;
   }
 
 
@@ -248,14 +247,14 @@ vpFeatureEllipse::error(const vpBasicFeature &s_star,
       vpColVector ex(1) ;
       ex[0] = s[0] - s_star[0] ;
 
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
     if (vpFeatureEllipse::selectY() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[1] - s_star[1] ;
-      e =  vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
 
      if (vpFeatureEllipse::selectMu20() & select )
@@ -263,37 +262,27 @@ vpFeatureEllipse::error(const vpBasicFeature &s_star,
       vpColVector ex(1) ;
       ex[0] = s[2] - s_star[2] ;
 
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
     if (vpFeatureEllipse::selectMu11() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[3] - s_star[3] ;
-      e =  vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
 
     if (vpFeatureEllipse::selectMu02() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[4] - s_star[4] ;
-      e =  vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
 
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matrix related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw;
   }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-
 
   return e ;
 

--- a/modules/visual_features/src/visual-feature/vpFeatureLine.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureLine.cpp
@@ -47,7 +47,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -269,7 +268,7 @@ vpFeatureLine::interaction(const unsigned int select)
     Lrho[0][4]= -co*(1.0 + rho*rho);
     Lrho[0][5]= 0.0;
 
-    L = vpMatrix::stackMatrices(L,Lrho) ;
+    L = vpMatrix::stack(L,Lrho) ;
   }
 
   if (vpFeatureLine::selectTheta() & select )
@@ -283,7 +282,7 @@ vpFeatureLine::interaction(const unsigned int select)
     Ltheta[0][4] = -rho*si;
     Ltheta[0][5] = -1.0;
 
-    L = vpMatrix::stackMatrices(L,Ltheta) ;
+    L = vpMatrix::stack(L,Ltheta) ;
   }
   return L ;
 }
@@ -339,9 +338,7 @@ vpFeatureLine::error(const vpBasicFeature &s_star,
       vpColVector erho(1) ;
       erho[0] = s[0] - s_star[0] ;
 
-
-
-      e = vpMatrix::stackMatrices(e,erho) ;
+      e = vpColVector::stack(e,erho) ;
     }
 
     if (vpFeatureLine::selectTheta() & select )
@@ -353,25 +350,14 @@ vpFeatureLine::error(const vpBasicFeature &s_star,
 
       vpColVector etheta(1) ;
       etheta[0] = err ;
-      e =  vpMatrix::stackMatrices(e,etheta) ;
+      e = vpColVector::stack(e,etheta) ;
     }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matric related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw ;
   }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-
 
   return e ;
-
 }
 
 

--- a/modules/visual_features/src/visual-feature/vpFeatureMoment.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureMoment.cpp
@@ -42,7 +42,6 @@
 #include <visp3/core/vpMath.h>
 
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 #include <visp3/core/vpDebug.h>
@@ -191,7 +190,7 @@ vpMatrix vpFeatureMoment::interaction (unsigned int select){
 
     for(unsigned int i=0;i<dim_s;++i){
         if(vpBasicFeature::FEATURE_LINE[i] & select){
-            L.stackMatrices(interaction_matrices[i]);
+            L.stack(interaction_matrices[i]);
         }
     }
 

--- a/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
@@ -145,16 +145,16 @@ void vpFeatureMomentAlpha::compute_interaction(){
 }
 
 vpColVector vpFeatureMomentAlpha::error (const vpBasicFeature &s_star, const unsigned int /* select */){
-	vpColVector e(0) ;
-	double err = s[0] - s_star[0] ;
+  vpColVector e(0) ;
+  double err = s[0] - s_star[0] ;
 
-    if (err < -M_PI) err += 2*M_PI ;
-    if (err > M_PI) err -= 2*M_PI ;
+  if (err < -M_PI) err += 2*M_PI ;
+  if (err > M_PI) err -= 2*M_PI ;
 
-	vpColVector ecv(1) ;
-    ecv[0] = err ;
-    e =  vpMatrix::stackMatrices(e,ecv) ;
+  vpColVector ecv(1) ;
+  ecv[0] = err ;
+  e = vpColVector::stack(e,ecv) ;
 
-	return e;
+  return e;
 }
 #endif

--- a/modules/visual_features/src/visual-feature/vpFeaturePoint.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeaturePoint.cpp
@@ -47,7 +47,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -303,7 +302,7 @@ vpFeaturePoint::interaction(const unsigned int select)
     Lx[0][4] = -(1+x_*x_) ;
     Lx[0][5] = y_ ;
 
-    L = vpMatrix::stackMatrices(L,Lx) ;
+    L = vpMatrix::stack(L,Lx) ;
   }
 
   if (vpFeaturePoint::selectY() & select )
@@ -317,7 +316,7 @@ vpFeaturePoint::interaction(const unsigned int select)
     Ly[0][4] = -x_*y_ ;
     Ly[0][5] = -x_ ;
 
-    L = vpMatrix::stackMatrices(L,Ly) ;
+    L = vpMatrix::stack(L,Ly) ;
   }
   return L ;
 }
@@ -365,27 +364,18 @@ vpFeaturePoint::error(const vpBasicFeature &s_star,
       vpColVector ex(1) ;
       ex[0] = s[0] - s_star[0] ;
 
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
     if (vpFeaturePoint::selectY() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[1] - s_star[1] ;
-      e =  vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matrix related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw ;
   }
 
 

--- a/modules/visual_features/src/visual-feature/vpFeaturePoint3D.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeaturePoint3D.cpp
@@ -42,7 +42,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -300,7 +299,7 @@ vpFeaturePoint3D::interaction(const unsigned int select)
     Lx[0][4] = -Z ;
     Lx[0][5] = Y ;
 
-    L = vpMatrix::stackMatrices(L,Lx) ;
+    L = vpMatrix::stack(L,Lx) ;
   }
 
   if (vpFeaturePoint3D::selectY() & select )
@@ -314,7 +313,7 @@ vpFeaturePoint3D::interaction(const unsigned int select)
     Ly[0][4] = 0 ;
     Ly[0][5] = -X ;
 
-    L = vpMatrix::stackMatrices(L,Ly) ;
+    L = vpMatrix::stack(L,Ly) ;
   }
   if (vpFeaturePoint3D::selectZ() & select )
   {
@@ -327,7 +326,7 @@ vpFeaturePoint3D::interaction(const unsigned int select)
     Lz[0][4] = X ;
     Lz[0][5] = 0 ;
 
-    L = vpMatrix::stackMatrices(L,Lz) ;
+    L = vpMatrix::stack(L,Lz) ;
   }
   return L ;
 }
@@ -393,34 +392,25 @@ vpFeaturePoint3D::error(const vpBasicFeature &s_star,
       vpColVector ex(1) ;
       ex[0] = s[0] - s_star[0] ;
 
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
     if (vpFeaturePoint3D::selectY() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[1] - s_star[1] ;
-      e =  vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
 
     if (vpFeaturePoint3D::selectZ() & select )
     {
       vpColVector ez(1) ;
       ez[0] = s[2] - s_star[2] ;
-      e =  vpMatrix::stackMatrices(e,ez) ;
+      e = vpColVector::stack(e,ez) ;
     }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matrix related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw ;
   }
 
   return e ;

--- a/modules/visual_features/src/visual-feature/vpFeaturePointPolar.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeaturePointPolar.cpp
@@ -47,7 +47,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -354,7 +353,7 @@ vpFeaturePointPolar::interaction(const unsigned int select)
 //     printf("Lrho: rho %f theta %f Z %f\n", rho, theta, Z);
 //     std::cout << "Lrho: " << Lrho << std::endl;
 
-    L = vpMatrix::stackMatrices(L,Lrho) ;
+    L = vpMatrix::stack(L,Lrho) ;
   }
 
   if (vpFeaturePointPolar::selectTheta() & select )
@@ -370,7 +369,7 @@ vpFeaturePointPolar::interaction(const unsigned int select)
 
 //     printf("Ltheta: rho %f theta %f Z %f\n", rho, theta, Z);
 //     std::cout << "Ltheta: " << Ltheta << std::endl;
-    L = vpMatrix::stackMatrices(L,Ltheta) ;
+    L = vpMatrix::stack(L,Ltheta) ;
   }
   return L ;
 }
@@ -429,7 +428,7 @@ vpFeaturePointPolar::error(const vpBasicFeature &s_star,
       vpColVector erho(1) ;
       erho[0] = s[0] - s_star[0] ;
 
-      e = vpMatrix::stackMatrices(e,erho) ;
+      e = vpColVector::stack(e,erho) ;
     }
 
     if (vpFeaturePointPolar::selectTheta() & select )
@@ -445,20 +444,11 @@ vpFeaturePointPolar::error(const vpBasicFeature &s_star,
  
       vpColVector etheta(1) ;
       etheta[0] = err ;
-      e =  vpMatrix::stackMatrices(e,etheta) ;
+      e =  vpColVector::stack(e,etheta) ;
     }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matrix related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw ;
   }
 
 

--- a/modules/visual_features/src/visual-feature/vpFeatureSegment.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureSegment.cpp
@@ -47,7 +47,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 
 // Debug trace
 #include <visp3/core/vpDebug.h>
@@ -251,7 +250,7 @@ vpFeatureSegment::interaction( const unsigned int select )
       Lxn[0][3] = sin_a_*cos_a_/4/ln - xn*xnalpha*sin_a_/ln;
       Lxn[0][4] = -ln*(1.+lc*lc/4.) + xn*xnalpha*cos_a_/ln ;
       Lxn[0][5] = yn ;
-      L = vpMatrix::stackMatrices(L, Lxn) ;
+      L = vpMatrix::stack(L, Lxn) ;
     }
 
     if (vpFeatureSegment::selectYc() & select ){
@@ -262,7 +261,7 @@ vpFeatureSegment::interaction( const unsigned int select )
       Lyn[0][3] = ln*(1+ls*ls/4.)-yn*xnalpha*sin_a_/ln ;
       Lyn[0][4] = -sin_a_*cos_a_/4/ln + yn*xnalpha*cos_a_/ln;
       Lyn[0][5] = -xn ;
-      L = vpMatrix::stackMatrices(L, Lyn) ;
+      L = vpMatrix::stack(L, Lyn) ;
     }
 
     if (vpFeatureSegment::selectL() & select ){
@@ -273,7 +272,7 @@ vpFeatureSegment::interaction( const unsigned int select )
       Lln[0][3] = -yn-xnalpha*sin_a_ ;
       Lln[0][4] = xn + xnalpha*cos_a_ ;
       Lln[0][5] = 0 ;
-      L = vpMatrix::stackMatrices(L, Lln) ;
+      L = vpMatrix::stack(L, Lln) ;
     }
     if (vpFeatureSegment::selectAlpha() & select ){
       // We recall that xc_ contains xc/l, yc_ contains yc/l and l_ contains 1/l
@@ -284,7 +283,7 @@ vpFeatureSegment::interaction( const unsigned int select )
         Lalpha[0][3] = (-xc_*sin_a_*sin_a_+yc_*cos_a_*sin_a_)/l_;
         Lalpha[0][4] = (xc_*cos_a_*sin_a_ - yc_*cos_a_*cos_a_)/l_ ;
         Lalpha[0][5] = -1 ;
-      L = vpMatrix::stackMatrices(L,Lalpha) ;
+      L = vpMatrix::stack(L,Lalpha) ;
     }
   }
   else
@@ -297,7 +296,7 @@ vpFeatureSegment::interaction( const unsigned int select )
       Lxc[0][3] = xc_*yc_ + l_*l_*cos_a_*sin_a_/4. ;
       Lxc[0][4] = -(1+xc_*xc_+l_*l_*cos_a_*cos_a_/4.) ;
       Lxc[0][5] = yc_ ;
-      L = vpMatrix::stackMatrices(L,Lxc) ;
+      L = vpMatrix::stack(L,Lxc) ;
     }
 
     if (vpFeatureSegment::selectYc() & select ){
@@ -308,7 +307,7 @@ vpFeatureSegment::interaction( const unsigned int select )
       Lyc[0][3] = 1+yc_*yc_+l_*l_*sin_a_*sin_a_/4. ;
       Lyc[0][4] = -xc_*yc_-l_*l_*cos_a_*sin_a_/4. ;
       Lyc[0][5] = -xc_ ;
-      L = vpMatrix::stackMatrices(L,Lyc) ;
+      L = vpMatrix::stack(L,Lyc) ;
     }
 
     if (vpFeatureSegment::selectL() & select ){
@@ -319,7 +318,7 @@ vpFeatureSegment::interaction( const unsigned int select )
       Ll[0][3] = l_*(xc_*cos_a_*sin_a_ + yc_*(1+sin_a_*sin_a_)) ;
       Ll[0][4] = -l_*(xc_*(1+cos_a_*cos_a_)+yc_*cos_a_*sin_a_) ;
       Ll[0][5] = 0 ;
-      L = vpMatrix::stackMatrices(L,Ll) ;
+      L = vpMatrix::stack(L,Ll) ;
     }
     if (vpFeatureSegment::selectAlpha() & select ){
       vpMatrix Lalpha(1,6);
@@ -329,7 +328,7 @@ vpFeatureSegment::interaction( const unsigned int select )
         Lalpha[0][3] = -xc_*sin_a_*sin_a_+yc_*cos_a_*sin_a_;
         Lalpha[0][4] = xc_*cos_a_*sin_a_ - yc_*cos_a_*cos_a_ ;
         Lalpha[0][5] = -1 ;
-      L = vpMatrix::stackMatrices(L,Lalpha) ;
+      L = vpMatrix::stack(L,Lalpha) ;
     }
   }
 
@@ -368,19 +367,19 @@ vpFeatureSegment::error( const vpBasicFeature &s_star, const unsigned int select
   if (vpFeatureSegment::selectXc() & select ){
     vpColVector exc(1) ;
     exc[0] = xc_-s_star[0];
-    e = vpMatrix::stackMatrices(e,exc) ;
+    e = vpColVector::stack(e,exc) ;
   }
 
   if (vpFeatureSegment::selectYc() & select ){
     vpColVector eyc(1) ;
     eyc[0] = yc_ - s_star[1];
-    e = vpMatrix::stackMatrices(e,eyc) ;
+    e = vpColVector::stack(e,eyc) ;
   }
 
   if (vpFeatureSegment::selectL() & select ){
     vpColVector eL(1) ;
     eL[0] = l_ - s_star[2];
-    e = vpMatrix::stackMatrices(e,eL) ;
+    e = vpColVector::stack(e,eL) ;
   }
 
   if (vpFeatureSegment::selectAlpha() & select ){
@@ -388,7 +387,7 @@ vpFeatureSegment::error( const vpBasicFeature &s_star, const unsigned int select
     eAlpha[0] = alpha_ - s_star[3];
     while (eAlpha[0] < -M_PI) eAlpha[0] += 2*M_PI ;
     while (eAlpha[0] > M_PI) eAlpha[0] -= 2*M_PI ;
-    e = vpMatrix::stackMatrices(e,eAlpha) ;
+    e = vpColVector::stack(e,eAlpha) ;
   }
   return e ;
 }

--- a/modules/visual_features/src/visual-feature/vpFeatureThetaU.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureThetaU.cpp
@@ -43,7 +43,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -475,7 +474,7 @@ vpFeatureThetaU::interaction(const unsigned int select)
   Lw = vpColVector::skew(u) ;  /* [theta/2  u]_x */
 
   vpMatrix U2(3,3) ;
-  U2.setIdentity() ;
+  U2.eye() ;
   
   double  theta = sqrt(s.sumSquare()) ;
   if (theta >= 1e-6) {
@@ -503,7 +502,7 @@ vpFeatureThetaU::interaction(const unsigned int select)
       for (int i=0 ; i < 3 ; i++) Lx[0][i+3] = Lw[0][i] ;
 
 
-      L = vpMatrix::stackMatrices(L,Lx) ;
+      L = vpMatrix::stack(L,Lx) ;
     }
 
   if (vpFeatureThetaU::selectTUy() & select )
@@ -513,7 +512,7 @@ vpFeatureThetaU::interaction(const unsigned int select)
       Ly[0][0] = 0 ;    Ly[0][1] = 0 ;    Ly[0][2] = 0 ;
       for (int i=0 ; i < 3 ; i++) Ly[0][i+3] = Lw[1][i] ;
 
-      L = vpMatrix::stackMatrices(L,Ly) ;
+      L = vpMatrix::stack(L,Ly) ;
     }
 
   if (vpFeatureThetaU::selectTUz() & select )
@@ -523,7 +522,7 @@ vpFeatureThetaU::interaction(const unsigned int select)
       Lz[0][0] = 0 ;    Lz[0][1] = 0 ;    Lz[0][2] = 0 ;
       for (int i=0 ; i < 3 ; i++) Lz[0][i+3] = Lw[2][i] ;
 
-      L = vpMatrix::stackMatrices(L,Lz) ;
+      L = vpMatrix::stack(L,Lz) ;
     }
 
   return L ;
@@ -608,21 +607,21 @@ vpFeatureThetaU::error(const vpBasicFeature &s_star,
     {
       vpColVector ex(1) ;
       ex[0] = s[0]  ;
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
   if (vpFeatureThetaU::selectTUy() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[1] ;
-      e = vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
 
   if (vpFeatureThetaU::selectTUz() & select )
     {
       vpColVector ez(1) ;
       ez[0] = s[2] ;
-      e = vpMatrix::stackMatrices(e,ez) ;
+      e = vpColVector::stack(e,ez) ;
     }
   return e ;
 }

--- a/modules/visual_features/src/visual-feature/vpFeatureTranslation.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureTranslation.cpp
@@ -44,7 +44,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -360,7 +359,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
 	Lx[0][i] = f2Mf1[0][i] ;
       Lx[0][3] = 0 ;    Lx[0][4] = 0 ;    Lx[0][5] = 0 ;
 
-      L = vpMatrix::stackMatrices(L,Lx) ;
+      L = vpMatrix::stack(L,Lx) ;
     }
 
     if (vpFeatureTranslation::selectTy() & select ) {
@@ -370,7 +369,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
 	Ly[0][i] = f2Mf1[1][i] ;
       Ly[0][3] = 0 ;    Ly[0][4] = 0 ;    Ly[0][5] = 0 ;
 
-      L = vpMatrix::stackMatrices(L,Ly) ;
+      L = vpMatrix::stack(L,Ly) ;
     }
 
     if (vpFeatureTranslation::selectTz() & select ) {
@@ -380,7 +379,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
 	Lz[0][i] = f2Mf1[2][i] ;
       Lz[0][3] = 0 ;    Lz[0][4] = 0 ;    Lz[0][5] = 0 ;
 
-      L = vpMatrix::stackMatrices(L,Lz) ;
+      L = vpMatrix::stack(L,Lz) ;
     }
   }
   if (translation == cMcd) {
@@ -390,7 +389,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
       Lx[0][0] = -1 ;    Lx[0][1] = 0 ;    Lx[0][2] = 0 ;
       Lx[0][3] = 0 ;    Lx[0][4] = -s[2] ;    Lx[0][5] = s[1] ;
 
-      L = vpMatrix::stackMatrices(L,Lx) ;
+      L = vpMatrix::stack(L,Lx) ;
     }
 
     if (vpFeatureTranslation::selectTy() & select ) {
@@ -398,7 +397,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
       Ly[0][0] = 0 ;    Ly[0][1] = -1 ;    Ly[0][2] = 0 ;
       Ly[0][3] = s[2] ;    Ly[0][4] = 0 ;    Ly[0][5] = -s[0] ;
 
-      L = vpMatrix::stackMatrices(L,Ly) ;
+      L = vpMatrix::stack(L,Ly) ;
     }
 
     if (vpFeatureTranslation::selectTz() & select ) {
@@ -406,7 +405,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
       Lz[0][0] = 0 ;    Lz[0][1] = 0 ;    Lz[0][2] = -1 ;
       Lz[0][3] = -s[1] ;    Lz[0][4] = s[0] ;    Lz[0][5] = 0 ;
 
-      L = vpMatrix::stackMatrices(L,Lz) ;
+      L = vpMatrix::stack(L,Lz) ;
     }
   }
 
@@ -417,7 +416,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
       Lx[0][0] = -1 ;    Lx[0][1] = 0 ;    Lx[0][2] = 0 ;
       Lx[0][3] = 0 ;    Lx[0][4] = -s[2] ;    Lx[0][5] = s[1] ;
 
-      L = vpMatrix::stackMatrices(L,Lx) ;
+      L = vpMatrix::stack(L,Lx) ;
     }
 
     if (vpFeatureTranslation::selectTy() & select ) {
@@ -425,7 +424,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
       Ly[0][0] = 0 ;    Ly[0][1] = -1 ;    Ly[0][2] = 0 ;
       Ly[0][3] = s[2] ;    Ly[0][4] = 0 ;    Ly[0][5] = -s[0] ;
 
-      L = vpMatrix::stackMatrices(L,Ly) ;
+      L = vpMatrix::stack(L,Ly) ;
     }
 
     if (vpFeatureTranslation::selectTz() & select ) {
@@ -433,7 +432,7 @@ vpFeatureTranslation::interaction(const unsigned int select)
       Lz[0][0] = 0 ;    Lz[0][1] = 0 ;    Lz[0][2] = -1 ;
       Lz[0][3] = -s[1] ;    Lz[0][4] = s[0] ;    Lz[0][5] = 0 ;
 
-      L = vpMatrix::stackMatrices(L,Lz) ;
+      L = vpMatrix::stack(L,Lz) ;
     }
   }
 
@@ -522,21 +521,21 @@ vpFeatureTranslation::error(const vpBasicFeature &s_star,
     {
       vpColVector ex(1) ;
       ex[0] = s[0]-s_star[0]  ;
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
   if (vpFeatureTranslation::selectTy() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[1]-s_star[1] ;
-      e = vpMatrix::stackMatrices(e,ey) ;
+      e = vpColVector::stack(e,ey) ;
     }
 
   if (vpFeatureTranslation::selectTz() & select )
     {
       vpColVector ez(1) ;
       ez[0] = s[2]-s_star[2] ;
-      e = vpMatrix::stackMatrices(e,ez) ;
+      e = vpColVector::stack(e,ez) ;
     }
 
   return e ;

--- a/modules/visual_features/src/visual-feature/vpFeatureVanishingPoint.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureVanishingPoint.cpp
@@ -45,7 +45,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -161,7 +160,7 @@ vpFeatureVanishingPoint::interaction(const unsigned int select)
     Lx[0][4] = -(1+x*x) ;
     Lx[0][5] = y ;
 
-    L = vpMatrix::stackMatrices(L,Lx) ;
+    L = vpMatrix::stack(L,Lx) ;
   }
 
   if (vpFeatureVanishingPoint::selectY() & select )
@@ -175,7 +174,7 @@ vpFeatureVanishingPoint::interaction(const unsigned int select)
     Ly[0][4] = -x*y ;
     Ly[0][5] = -x ;
 
-    L = vpMatrix::stackMatrices(L,Ly) ;
+    L = vpMatrix::stack(L,Ly) ;
   }
   return L ;
 }
@@ -196,27 +195,18 @@ vpFeatureVanishingPoint::error(const vpBasicFeature &s_star,
       vpColVector ex(1) ;
       ex[0] = s[0] - s_star[0] ;
 
-      e = vpMatrix::stackMatrices(e,ex) ;
+      e = vpColVector::stack(e,ex) ;
     }
 
     if (vpFeatureVanishingPoint::selectY() & select )
     {
       vpColVector ey(1) ;
       ey[0] = s[1] - s_star[1] ;
-      e =  vpMatrix::stackMatrices(e,ey) ;
+      e =  vpColVector::stack(e,ey) ;
     }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matrix related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw ;
   }
   return e ;
 }

--- a/modules/visual_features/src/visual-feature/vpGenericFeature.cpp
+++ b/modules/visual_features/src/visual-feature/vpGenericFeature.cpp
@@ -41,7 +41,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 #include <visp3/visual_features/vpFeatureException.h>
 
 // Debug trace
@@ -51,8 +50,8 @@
 
 /*!
   \file vpGenericFeature.cpp
-  \brief class that defines what is a generic feature (used to create new
-  feature not implemented in ViSP2
+  Class that defines what is a generic feature. This class could be used to create new
+  features not implemented in ViSP.
 */
 
 vpGenericFeature::~vpGenericFeature()
@@ -220,7 +219,7 @@ vpGenericFeature::error(const vpBasicFeature &s_star,
 	    vpColVector ex(1) ;
 	    ex[i] = err[i] ;
 
-	    e = vpMatrix::stackMatrices(e,ex) ;
+	    e = vpColVector::stack(e,ex) ;
 	  }
       }
       else
@@ -233,22 +232,13 @@ vpGenericFeature::error(const vpBasicFeature &s_star,
 	    vpColVector ex(1) ;
 	    ex[0] = s[i] - s_star[i] ;
 
-	    e = vpMatrix::stackMatrices(e,ex) ;
+	    e = vpColVector::stack(e,ex) ;
 	  }
 
       }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matric related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw;
   }
   return e ;
 
@@ -321,7 +311,7 @@ vpGenericFeature::error( const unsigned int select)
 	    vpColVector ex(1) ;
 	    ex[i] = err[i] ;
 
-	    e = vpMatrix::stackMatrices(e,ex) ;
+	    e = vpColVector::stack(e,ex) ;
 	  }
       }
       else
@@ -333,22 +323,13 @@ vpGenericFeature::error( const unsigned int select)
 	    vpColVector ex(1) ;
 	    ex[i] = s[i]  ;
 
-	    e = vpMatrix::stackMatrices(e,ex) ;
+	    e = vpColVector::stack(e,ex) ;
 	  }
 
       }
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("caught a Matric related error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("caught another error") ;
-    std::cout <<std::endl << me << std::endl ;
-    throw(me) ;
+  catch(...) {
+    throw;
   }
 
   return e ;
@@ -435,7 +416,7 @@ vpGenericFeature::interaction(const unsigned int select)
       for (int j=0 ; j < 6 ; j++)
 	Lx[0][j] = L[i][j] ;
 
-      Ls = vpMatrix::stackMatrices(Ls,Lx) ;
+      Ls = vpMatrix::stack(Ls,Lx) ;
     }
 
   return Ls ;

--- a/modules/vs/src/vpServo.cpp
+++ b/modules/vs/src/vpServo.cpp
@@ -44,7 +44,6 @@
 
 // Exception
 #include <visp3/core/vpException.h>
-#include <visp3/core/vpMatrixException.h>
 
 // Debug trace
 #include <visp3/core/vpDebug.h>
@@ -983,8 +982,7 @@ vpColVector vpServo::computeControlLaw()
     */
       e1 = J1p*error ;// primary task
 
-      WpW.resize(J1.getCols(), J1.getCols()) ;
-      WpW.setIdentity() ;
+      WpW.eye(J1.getCols(), J1.getCols()) ;
     }
     else
     {
@@ -1013,23 +1011,13 @@ vpColVector vpServo::computeControlLaw()
 
     vpMatrix I ;
 
-    I.resize(J1.getCols(),J1.getCols()) ;
-    I.setIdentity() ;
+    I.eye(J1.getCols(),J1.getCols()) ;
 
     computeProjectionOperators();
 
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("Caught a matrix related error") ;
-    std::cout << me << std::endl ;
-    throw me;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("Error caught") ;
-    std::cout << me << std::endl ;
-    throw me ;
+  catch(...) {
+    throw;
   }
 
   iteration++ ;
@@ -1151,8 +1139,7 @@ vpColVector vpServo::computeControlLaw(double t)
     */
       e1 = J1p*error ;// primary task
 
-      WpW.resize(J1.getCols(), J1.getCols()) ;
-      WpW.setIdentity() ;
+      WpW.eye(J1.getCols(), J1.getCols()) ;
     }
     else
     {
@@ -1190,22 +1177,12 @@ vpColVector vpServo::computeControlLaw(double t)
 
     vpMatrix I ;
 
-    I.resize(J1.getCols(), J1.getCols()) ;
-    I.setIdentity() ;
+    I.eye(J1.getCols(), J1.getCols()) ;
 
     computeProjectionOperators() ;
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("Caught a matrix related error") ;
-    std::cout << me << std::endl ;
-    throw me;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("Error caught") ;
-    std::cout << me << std::endl ;
-    throw me ;
+  catch(...) {
+    throw;
   }
 
   iteration++ ;
@@ -1326,8 +1303,7 @@ vpColVector vpServo::computeControlLaw(double t, const vpColVector &e_dot_init)
     */
       e1 = J1p*error ;// primary task
 
-      WpW.resize(J1.getCols(), J1.getCols()) ;
-      WpW.setIdentity() ;
+      WpW.eye(J1.getCols(), J1.getCols()) ;
     }
     else
     {
@@ -1365,22 +1341,12 @@ vpColVector vpServo::computeControlLaw(double t, const vpColVector &e_dot_init)
 
     vpMatrix I ;
 
-    I.resize(J1.getCols(), J1.getCols()) ;
-    I.setIdentity() ;
+    I.eye(J1.getCols(), J1.getCols()) ;
 
     computeProjectionOperators();
   }
-  catch(vpMatrixException me)
-  {
-    vpERROR_TRACE("Caught a matrix related error") ;
-    std::cout << me << std::endl ;
-    throw me;
-  }
-  catch(vpException me)
-  {
-    vpERROR_TRACE("Error caught") ;
-    std::cout << me << std::endl ;
-    throw me ;
+  catch(...) {
+    throw;
   }
 
   iteration++ ;


### PR DESCRIPTION
Previously it was possible to call operator+() on vpHomogeneousMatrix, vpRotationMatrix or vpPoseVector classes. This shouldn't be allowed. Other examples could be found with operations that could be possible but that have no sense.

That's why we introduce an new vpArray2D template class with all the common functionalities that could be applied on matrices and vectors (allocation, element getter and setter, getting size).

The following containers now inherit from vpArray<double>:
- matrices: vpMatrix, vpRotationMatrix, vpHomogeneousMatrix, vpVelocityTwistMatrix, vpForceTwistMatrix
- vectors: vpColVector, vpRowVector, vpPoseVector
