### PR TITLE
Fix isinf and NAN identifier with MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,8 @@ VP_SET(VISP_HAVE_FUNC__ISNAN TRUE IF HAVE_FUNC__ISNAN) # for header vpConfig.h
 VP_SET(VISP_HAVE_FUNC_ISINF TRUE IF HAVE_FUNC_ISINF) # for header vpConfig.h
 # Find std::isinf function (cmath)
 VP_SET(VISP_HAVE_FUNC_STD_ISINF TRUE IF HAVE_FUNC_STD_ISINF) # for header vpConfig.h
+# Find _finite function for MSVC
+VP_SET(VISP_HAVE_FUNC__FINITE TRUE IF HAVE_FUNC__FINITE) # for header vpConfig.h
 # Find round function (math.h)
 VP_SET(VISP_HAVE_FUNC_ROUND TRUE IF HAVE_FUNC_ROUND) # for header vpConfig.h
 # Find std::round function (cmath)

--- a/cmake/FindIsInf.cmake
+++ b/cmake/FindIsInf.cmake
@@ -60,11 +60,11 @@ if(HAVE_FLOAT_H)
 #include <float.h>
 int main(int argc, char ** argv)
 {
-    (void)_isinf(1.0);
+    (void)_finite(1.0);
     return 0;
 }
 " HAVE_FUNC__ISINF)
 else()
-    set(HAVE_FUNC__ISINF FALSE)
+    set(HAVE_FUNC__FINITE FALSE)
 endif()
 

--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -339,6 +339,9 @@
 // Defined if std::isinf function is available
 #cmakedefine VISP_HAVE_FUNC_STD_ISINF
 
+// Defined if _finite (Microsoft version) function is available
+#cmakedefine VISP_HAVE_FUNC__FINITE
+
 // Defined if round function is available
 #cmakedefine VISP_HAVE_FUNC_ROUND
 

--- a/modules/core/src/math/misc/vpMath.cpp
+++ b/modules/core/src/math/misc/vpMath.cpp
@@ -114,6 +114,8 @@ bool vpMath::isInf(const double value)
   return isinf(value);
 #elif defined(VISP_HAVE_FUNC_STD_ISINF)
   return std::isinf(value);
+#elif defined(VISP_HAVE_FUNC__FINITE)
+  return !_finite(value);
 #else
   //Taken from OpenCV source code CvIsInf()
   Cv64suf ieee754;

--- a/modules/core/test/math/testMath.cpp
+++ b/modules/core/test/math/testMath.cpp
@@ -53,6 +53,15 @@
 // 4723 : potential divide by 0
 #endif
 
+#ifdef WIN32
+  #ifndef NAN
+    //https://msdn.microsoft.com/en-us/library/w22adx1s%28v=vs.120%29.aspx
+    //http://tdistler.com/2011/03/24/how-to-define-nan-not-a-number-on-windows
+    static const unsigned long __nan[2] = {0xffffffff, 0x7fffffff};
+    #define NAN (*(const float *) __nan)
+  #endif
+#endif
+
 int main() {
   //Test isNaN
   if(vpMath::isNaN(0.0)) {
@@ -116,10 +125,13 @@ int main() {
 
 
   //Test isInf
+#if !defined(VISP_HAVE_FUNC__FINITE)
+  //Disable this test if using _finite as (!_finite(NAN)) returns true whereas isinf(NAN) returns false
   if(vpMath::isInf(NAN)) {
     std::cerr << "Fail: vpMath::isInf(NAN)=" << vpMath::isInf(NAN) << " / should be false" << std::endl;
     return -1;
   }
+#endif
 
   if(!vpMath::isInf(1.0/a)) {
     std::cerr << "Fail: vpMath::isInf(1.0/0.0)=" << vpMath::isInf(1.0/a) << " / should be true" << std::endl;


### PR DESCRIPTION
- Correct the macro to find isinf on MSVC. 
- Fix NAN identifier that is missing with MSVC.