### PR TITLE
Fix Z < 0 and fix index calculation in vpMbKltTracker::postTracking().

### DIFF
--- a/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
@@ -664,8 +664,8 @@ vpMbKltTracker::postTracking(const vpImage<unsigned char>& I, vpColVector &w)
       initialNumber += kltpoly->getInitialNumberPoint();
       if(kltpoly->hasEnoughPoints()){
         vpSubColVector sub_w(w, shift, 2*kltpoly->getCurrentNumberPoints());
-        kltpoly->removeOutliers(sub_w, threshold_outlier);
         shift += 2*kltpoly->getCurrentNumberPoints();
+        kltpoly->removeOutliers(sub_w, threshold_outlier);
         
         currentNumber += kltpoly->getCurrentNumberPoints();
       }
@@ -685,8 +685,8 @@ vpMbKltTracker::postTracking(const vpImage<unsigned char>& I, vpColVector &w)
       initialNumber += kltPolyCylinder->getInitialNumberPoint();
       if(kltPolyCylinder->hasEnoughPoints()){
         vpSubColVector sub_w(w, shift, 2*kltPolyCylinder->getCurrentNumberPoints());
-        kltPolyCylinder->removeOutliers(sub_w, threshold_outlier);
         shift += 2*kltPolyCylinder->getCurrentNumberPoints();
+        kltPolyCylinder->removeOutliers(sub_w, threshold_outlier);
 
         currentNumber += kltPolyCylinder->getCurrentNumberPoints();
       }

--- a/modules/tracker/mbt/src/klt/vpMbtDistanceKltCylinder.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbtDistanceKltCylinder.cpp
@@ -283,10 +283,7 @@ vpMbtDistanceKltCylinder::computeInteractionMatrixAndResidu(const vpHomogeneousM
 
     double Z = computeZ(x_cur, y_cur);
 
-    if(Z < std::numeric_limits<double>::epsilon())
-      throw vpException(vpException::divideByZeroError, "Error while estimating cylinder point of interest depth");
-
-    if(vpMath::isNaN(Z)){
+    if(vpMath::isNaN(Z) || Z < std::numeric_limits<double>::epsilon()){
 //      std::cout << "Z is Nan : " << A << " , " << B << " , " << C << " | " << Z << " | " << x_cur << " , " << y_cur << std::endl;
 //      std::cout << std::sqrt(B*B - A*C) << " , " << B*B - A*C << std::endl;
 


### PR DESCRIPTION
Correct vpMbtDistanceKltCylinder.cpp to not throw an exception when a KLT point have a calculated Z < 0 but rather set the interaction matrix to zero. Fix index calculation in vpMbKltTracker::postTracking().