### PR TITLE
Fix vpPoseVector::getThetaUVector() to return the adequate vector

### DIFF
--- a/modules/core/src/math/transformation/vpPoseVector.cpp
+++ b/modules/core/src/math/transformation/vpPoseVector.cpp
@@ -340,7 +340,7 @@ vpRotationMatrix vpPoseVector::getRotationMatrix() const
  */
 vpThetaUVector vpPoseVector::getThetaUVector() const
 {
-  vpThetaUVector tu((*this)[0], (*this)[1], (*this)[2]);
+  vpThetaUVector tu((*this)[3], (*this)[4], (*this)[5]);
   return tu;
 }
 


### PR DESCRIPTION
vpPoseVector::getThetaUVector() was returning a vpThetaUVector with the values corresponding to the translation instead of the angle/axis representation.