### PR TITLE
Add possibility to read images with whitespaces in pathname.

### DIFF
--- a/cmake/FindIsInf.cmake
+++ b/cmake/FindIsInf.cmake
@@ -63,7 +63,7 @@ int main(int argc, char ** argv)
     (void)_finite(1.0);
     return 0;
 }
-" HAVE_FUNC__ISINF)
+" HAVE_FUNC__FINITE)
 else()
     set(HAVE_FUNC__FINITE FALSE)
 endif()

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -726,10 +726,19 @@ vpIoTools::path(const char *pathname)
 #elif defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
   for(unsigned int i=0 ; i<path.length() ; i++)
     if( path[i] == '\\')	path[i] = '/';
-#  if TARGET_OS_IOS == 0 // The above code is not working on iOS since wordexp() is not available
+#  if TARGET_OS_IOS == 0 // The following code is not working on iOS since wordexp() is not available
   wordexp_t exp_result;
+
   wordexp(path.c_str(), &exp_result, 0);
-  path = std::string(exp_result.we_wordv[0]);
+  path = "";
+  //If path contains whitespace, wordexp_t will try to expand each word separated by whitespaces
+  //This is why we need to concatenate the results
+  for(size_t i = 0; i < exp_result.we_wordc; i++) {
+    path += exp_result.we_wordv[i];
+    if(i < exp_result.we_wordc-1) {
+      path += " ";
+    }
+  }
   wordfree(&exp_result);
 #  endif
 #endif

--- a/modules/io/src/image/vpImageIo.cpp
+++ b/modules/io/src/image/vpImageIo.cpp
@@ -278,23 +278,27 @@ vpImageIo::read(vpImage<unsigned char> &I, const char *filename)
     std::string message = "Cannot read file: \"" + std::string(filename) + "\" doesn't exist";
     throw (vpImageException(vpImageException::ioError, message));
   }
+
+  //Allows to use ~ symbol or env variables in path
+  std::string final_filename = vpIoTools::path(filename);
+
   bool try_opencv_reader = false;
 
-  switch(getFormat(filename)){
+  switch(getFormat(final_filename.c_str())){
   case FORMAT_PGM :
-    readPGM(I,filename); break;
+    readPGM(I,final_filename); break;
   case FORMAT_PPM :
-    readPPM(I,filename); break;
+    readPPM(I,final_filename); break;
   case FORMAT_JPEG :
 #ifdef VISP_HAVE_JPEG
-    readJPEG(I,filename);
+    readJPEG(I,final_filename);
 #else
     try_opencv_reader = true;
 #endif
     break;
   case FORMAT_PNG :
 #if defined(VISP_HAVE_PNG)
-    readPNG(I,filename);
+    readPNG(I,final_filename);
 #else
     try_opencv_reader = true;
 #endif
@@ -313,22 +317,22 @@ vpImageIo::read(vpImage<unsigned char> &I, const char *filename)
   if (try_opencv_reader) {
 #if VISP_HAVE_OPENCV_VERSION >= 0x030000
     //std::cout << "Use opencv to read the image" << std::endl;
-    cv::Mat cvI = cv::imread(filename, cv::IMREAD_GRAYSCALE);
+    cv::Mat cvI = cv::imread(final_filename, cv::IMREAD_GRAYSCALE);
     if (cvI.cols == 0 && cvI.rows == 0) {
-      std::string message = "Cannot read file \"" + std::string(filename) + "\": Image format not supported";
+      std::string message = "Cannot read file \"" + std::string(final_filename) + "\": Image format not supported";
       throw (vpImageException(vpImageException::ioError, message)) ;
     }
     vpImageConvert::convert(cvI, I);
 #elif VISP_HAVE_OPENCV_VERSION >= 0x020100
     //std::cout << "Use opencv to read the image" << std::endl;
-    cv::Mat cvI = cv::imread(filename, CV_LOAD_IMAGE_GRAYSCALE);
+    cv::Mat cvI = cv::imread(final_filename, CV_LOAD_IMAGE_GRAYSCALE);
     if (cvI.cols == 0 && cvI.rows == 0) {
-      std::string message = "Cannot read file \"" + std::string(filename) + "\": Image format not supported";
+      std::string message = "Cannot read file \"" + std::string(final_filename) + "\": Image format not supported";
       throw (vpImageException(vpImageException::ioError, message)) ;
     }
     vpImageConvert::convert(cvI, I);
 #else
-    std::string message = "Cannot read file \"" + std::string(filename) + "\": Image format not supported";
+    std::string message = "Cannot read file \"" + std::string(final_filename) + "\": Image format not supported";
     throw (vpImageException(vpImageException::ioError, message)) ;
 #endif
   }
@@ -378,24 +382,26 @@ vpImageIo::read(vpImage<vpRGBa> &I, const char *filename)
     std::string message = "Cannot read file: \"" + std::string(filename) + "\" doesn't exist";
     throw (vpImageException(vpImageException::ioError, message));
   }
+  //Allows to use ~ symbol or env variables in path
+  std::string final_filename = vpIoTools::path(filename);
 
   bool try_opencv_reader = false;
 
-  switch(getFormat(filename)){
+  switch(getFormat(final_filename.c_str())){
   case FORMAT_PGM :
-    readPGM(I,filename); break;
+    readPGM(I,final_filename); break;
   case FORMAT_PPM :
-    readPPM(I,filename); break;
+    readPPM(I,final_filename); break;
   case FORMAT_JPEG :
 #ifdef VISP_HAVE_JPEG
-    readJPEG(I,filename);
+    readJPEG(I,final_filename);
 #else
     try_opencv_reader = true;
 #endif
     break;
   case FORMAT_PNG :
 #if defined(VISP_HAVE_PNG)
-    readPNG(I,filename);
+    readPNG(I,final_filename);
 #else
     try_opencv_reader = true;
 #endif
@@ -414,22 +420,22 @@ vpImageIo::read(vpImage<vpRGBa> &I, const char *filename)
   if (try_opencv_reader) {
 #if VISP_HAVE_OPENCV_VERSION >= 0x030000
     // std::cout << "Use opencv to read the image" << std::endl;
-    cv::Mat cvI = cv::imread(filename, cv::IMREAD_COLOR);
+    cv::Mat cvI = cv::imread(final_filename, cv::IMREAD_COLOR);
     if (cvI.cols == 0 && cvI.rows == 0) {
-      std::string message = "Cannot read file \"" + std::string(filename) + "\": Image format not supported";
+      std::string message = "Cannot read file \"" + std::string(final_filename) + "\": Image format not supported";
       throw (vpImageException(vpImageException::ioError, message)) ;
     }
     vpImageConvert::convert(cvI, I);
 #elif VISP_HAVE_OPENCV_VERSION >= 0x020100
     // std::cout << "Use opencv to read the image" << std::endl;
-    cv::Mat cvI = cv::imread(filename, CV_LOAD_IMAGE_COLOR);
+    cv::Mat cvI = cv::imread(final_filename, CV_LOAD_IMAGE_COLOR);
     if (cvI.cols == 0 && cvI.rows == 0) {
-      std::string message = "Cannot read file \"" + std::string(filename) + "\": Image format not supported";
+      std::string message = "Cannot read file \"" + std::string(final_filename) + "\": Image format not supported";
       throw (vpImageException(vpImageException::ioError, message)) ;
     }
     vpImageConvert::convert(cvI, I);
 #else
-    std::string message = "Cannot read file \"" + std::string(filename) + "\": Image format not supported";
+    std::string message = "Cannot read file \"" + std::string(final_filename) + "\": Image format not supported";
     throw (vpImageException(vpImageException::ioError, message)) ;
 #endif
   }


### PR DESCRIPTION
Add possibility to read images with:
- whitespaces in pathname
- on Unix, word expansion is done so `vpImageIo::read(I, "~/Pictures/img space.jpg")` or `vpImageIo::read(I, "$VISP_INPUT_IMAGE_PATH/ViSP-images/Klimt/Klimt.png")` should work

Fix macro name when finding _finite function on MSVC.