### PR TITLE
Fix covariance computation for the edge trackers.

### DIFF
--- a/example/tracking/mbtEdgeKltMultiTracking.cpp
+++ b/example/tracking/mbtEdgeKltMultiTracking.cpp
@@ -61,7 +61,7 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/mbt/vpMbEdgeKltMultiTracker.h>
 
-#define GETOPTARGS  "x:m:i:n:dchtfColw"
+#define GETOPTARGS  "x:m:i:n:dchtfColwvp"
 
 
 void usage(const char *name, const char *badparam)
@@ -72,7 +72,7 @@ Example of tracking based on the 3D model.\n\
 SYNOPSIS\n\
   %s [-i <test image path>] [-x <config file>]\n\
   [-m <model name>] [-n <initialisation file base name>]\n\
-  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l]",
+  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l] [-v] [-p]",
   name );
 
   fprintf(stdout, "\n\
@@ -128,7 +128,13 @@ OPTIONS:                                               \n\
      When Ogre3D is enable [-o] show Ogre3D configuration dialog that allows to set the renderer.\n\
 \n\
   -l\n\
-     Use the scanline for visibility tests\n\
+     Use the scanline for visibility tests.\n\
+\n\
+  -v\n\
+     Compute covariance matrix.\n\
+\n\
+  -v\n\
+     Compute gradient projection error.\n\
 \n\
   -h \n\
      Print the help.\n\n");
@@ -140,7 +146,8 @@ OPTIONS:                                               \n\
 
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
                 std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog, bool &useScanline)
+                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog,
+                bool &useScanline, bool &computeCovariance, bool &projectionError)
 {
   const char *optarg_;
   int   c;
@@ -159,6 +166,8 @@ bool getOptions(int argc, const char **argv, std::string &ipath, std::string &co
     case 'o': useOgre = true; break;
     case 'l': useScanline = true; break;
     case 'w': showOgreConfigDialog  = true; break;
+    case 'v': computeCovariance  = true; break;
+    case 'p': projectionError  = true; break;
     case 'h': usage(argv[0], NULL); return false; break;
 
     default:
@@ -199,6 +208,8 @@ main(int argc, const char ** argv)
     bool useOgre = false;
     bool showOgreConfigDialog = false;
     bool useScanline = false;
+    bool computeCovariance = false;
+    bool projectionError = false;
     bool quit = false;
 
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
@@ -211,7 +222,7 @@ main(int argc, const char ** argv)
     // Read the command line options
     if (!getOptions(argc, argv, opt_ipath, opt_configFile, opt_modelFile, opt_initFile, displayFeatures,
                     opt_click_allowed, opt_display, cao3DModel, trackCylinder, useOgre, showOgreConfigDialog,
-                    useScanline)) {
+                    useScanline, computeCovariance, projectionError)) {
       return (-1);
     }
 
@@ -387,6 +398,12 @@ main(int argc, const char ** argv)
     // Tells if the tracker has to use the scanline visibility tests
     tracker.setScanLineVisibilityTest(useScanline);
 
+    // Tells if the tracker has to compute the covariance matrix
+    tracker.setCovarianceComputation(computeCovariance);
+
+    // Tells if the tracker has to compute the projection error
+    tracker.setProjectionErrorComputation(projectionError);
+
     // Retrieve the camera parameters from the tracker
     tracker.getCameraParameters(cam1, cam2);
 
@@ -429,9 +446,6 @@ main(int argc, const char ** argv)
       vpDisplay::flush(I1);
       vpDisplay::flush(I2);
     }
-
-    // Uncomment if you want to compute the covariance matrix.
-    // tracker.setCovarianceComputation(true); //Important if you want tracker.getCovarianceMatrix() to work.
 
     while (!reader.end())
     {
@@ -494,6 +508,8 @@ main(int argc, const char ** argv)
         tracker.setCameraParameters(cam1, cam2);
         tracker.setOgreVisibilityTest(useOgre);
         tracker.setScanLineVisibilityTest(useScanline);
+        tracker.setCovarianceComputation(computeCovariance);
+        tracker.setProjectionErrorComputation(projectionError);
         tracker.initFromPose(I1, I2, c1Mo, c2Mo);
       }
 
@@ -526,9 +542,13 @@ main(int argc, const char ** argv)
         }
       }
 
-      // Uncomment if you want to print the covariance matrix.
-      // Make sure tracker.setCovarianceComputation(true) has been called (uncomment below).
-      // std::cout << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      if(computeCovariance) {
+        std::cout << "Covariance matrix: \n" << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      }
+
+      if(projectionError) {
+        std::cout << "Projection error: " << tracker.getProjectionError() << std::endl << std::endl;
+      }
 
       vpDisplay::flush(I1);
       vpDisplay::flush(I2);

--- a/example/tracking/mbtEdgeKltTracking.cpp
+++ b/example/tracking/mbtEdgeKltTracking.cpp
@@ -60,12 +60,13 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/mbt/vpMbEdgeKltTracker.h>
 
-#define GETOPTARGS  "x:m:i:n:dchtfColw"
+#define GETOPTARGS  "x:m:i:n:dchtfColwvp"
 
 void usage(const char *name, const char *badparam);
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
-                std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &useScanline);
+    std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
+    bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog,
+    bool &useScanline, bool &computeCovariance, bool &projectionError);
 
 void usage(const char *name, const char *badparam)
 {
@@ -75,7 +76,7 @@ Example of tracking based on the 3D model.\n\
 SYNOPSIS\n\
   %s [-i <test image path>] [-x <config file>]\n\
   [-m <model name>] [-n <initialisation file base name>]\n\
-  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l]",
+  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l] [-v] [-p]",
   name );
 
   fprintf(stdout, "\n\
@@ -131,7 +132,13 @@ OPTIONS:                                               \n\
      When Ogre3D is enable [-o] show Ogre3D configuration dialog thatallows to set the renderer.\n\
 \n\
   -l\n\
-     Use the scanline for visibility tests\n\
+     Use the scanline for visibility tests.\n\
+\n\
+  -v\n\
+     Compute covariance matrix.\n\
+\n\
+  -v\n\
+     Compute gradient projection error.\n\
 \n\
   -h \n\
      Print the help.\n\n");
@@ -143,7 +150,8 @@ OPTIONS:                                               \n\
 
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
                 std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog, bool &useScanline)
+                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog,
+                bool &useScanline, bool &computeCovariance, bool &projectionError)
 {
   const char *optarg_;
   int   c;
@@ -162,6 +170,8 @@ bool getOptions(int argc, const char **argv, std::string &ipath, std::string &co
     case 'o': useOgre = true; break;
     case 'l': useScanline = true; break;
     case 'w': showOgreConfigDialog  = true; break;
+    case 'v': computeCovariance  = true; break;
+    case 'p': projectionError  = true; break;
     case 'h': usage(argv[0], NULL); return false; break;
 
     default:
@@ -202,6 +212,8 @@ main(int argc, const char ** argv)
     bool useOgre = false;
     bool showOgreConfigDialog = false;
     bool useScanline = false;
+    bool computeCovariance = false;
+    bool projectionError = false;
     bool quit = false;
 
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
@@ -214,7 +226,7 @@ main(int argc, const char ** argv)
     // Read the command line options
     if (!getOptions(argc, argv, opt_ipath, opt_configFile, opt_modelFile, opt_initFile, displayFeatures,
                     opt_click_allowed, opt_display, cao3DModel, trackCylinder, useOgre, showOgreConfigDialog,
-                    useScanline)) {
+                    useScanline, computeCovariance, projectionError)) {
       return (-1);
     }
 
@@ -384,6 +396,12 @@ main(int argc, const char ** argv)
     // Tells if the tracker has to use the scanline visibility tests
     tracker.setScanLineVisibilityTest(useScanline);
 
+    // Tells if the tracker has to compute the covariance matrix
+    tracker.setCovarianceComputation(computeCovariance);
+
+    // Tells if the tracker has to compute the projection error
+    tracker.setProjectionErrorComputation(projectionError);
+
     // Retrieve the camera parameters from the tracker
     tracker.getCameraParameters(cam);
 
@@ -423,9 +441,6 @@ main(int argc, const char ** argv)
 
     if (opt_display)
       vpDisplay::flush(I);
-
-    // Uncomment if you want to compute the covariance matrix.
-    // tracker.setCovarianceComputation(true); //Important if you want tracker.getCovarianceMatrix() to work.
 
     while (!reader.end())
     {
@@ -482,6 +497,8 @@ main(int argc, const char ** argv)
         tracker.setCameraParameters(cam);
         tracker.setOgreVisibilityTest(useOgre);
         tracker.setScanLineVisibilityTest(useScanline);
+        tracker.setCovarianceComputation(computeCovariance);
+        tracker.setProjectionErrorComputation(projectionError);
         tracker.initFromPose(I, cMo);
       }
 
@@ -522,9 +539,13 @@ main(int argc, const char ** argv)
         }
       }
 
-      // Uncomment if you want to print the covariance matrix.
-      // Make sure tracker.setCovarianceComputation(true) has been called (uncomment below).
-      // std::cout << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      if(computeCovariance) {
+        std::cout << "Covariance matrix: \n" << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      }
+
+      if(projectionError) {
+        std::cout << "Projection error: " << tracker.getProjectionError() << std::endl << std::endl;
+      }
 
       vpDisplay::flush(I) ;
     }
@@ -547,7 +568,7 @@ main(int argc, const char ** argv)
 
     return 0;
   }
-  catch(vpException e) {
+  catch(vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
     return 1;
   }

--- a/example/tracking/mbtEdgeMultiTracking.cpp
+++ b/example/tracking/mbtEdgeMultiTracking.cpp
@@ -63,7 +63,7 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/mbt/vpMbEdgeMultiTracker.h>
 
-#define GETOPTARGS  "x:m:i:n:dchtfColw"
+#define GETOPTARGS  "x:m:i:n:dchtfColwvp"
 
 
 void usage(const char *name, const char *badparam)
@@ -74,7 +74,7 @@ Example of tracking based on the 3D model.\n\
 SYNOPSIS\n\
   %s [-i <test image path>] [-x <config file>]\n\
   [-m <model name>] [-n <initialisation file base name>]\n\
-  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l]",
+  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l] [-v] [-p]",
   name );
 
   fprintf(stdout, "\n\
@@ -130,7 +130,13 @@ OPTIONS:                                               \n\
      When Ogre3D is enable [-o] show Ogre3D configuration dialog that allows to set the renderer.\n\
 \n\
   -l\n\
-     Use the scanline for visibility tests\n\
+     Use the scanline for visibility tests.\n\
+\n\
+  -v\n\
+     Compute covariance matrix.\n\
+\n\
+  -v\n\
+     Compute gradient projection error.\n\
 \n\
   -h \n\
      Print the help.\n\n");
@@ -142,7 +148,8 @@ OPTIONS:                                               \n\
 
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
                 std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog, bool &useScanline)
+                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog,
+                bool &useScanline, bool &computeCovariance, bool &projectionError)
 {
   const char *optarg_;
   int   c;
@@ -161,6 +168,8 @@ bool getOptions(int argc, const char **argv, std::string &ipath, std::string &co
     case 'o': useOgre = true; break;
     case 'l': useScanline = true; break;
     case 'w': showOgreConfigDialog  = true; break;
+    case 'v': computeCovariance  = true; break;
+    case 'p': projectionError  = true; break;
     case 'h': usage(argv[0], NULL); return false; break;
 
     default:
@@ -201,6 +210,8 @@ main(int argc, const char ** argv)
     bool useOgre = false;
     bool showOgreConfigDialog = false;
     bool useScanline = false;
+    bool computeCovariance = false;
+    bool projectionError = false;
     bool quit = false;
 
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
@@ -214,7 +225,7 @@ main(int argc, const char ** argv)
     // Read the command line options
     if (!getOptions(argc, argv, opt_ipath, opt_configFile, opt_modelFile, opt_initFile, displayFeatures,
                     opt_click_allowed, opt_display, cao3DModel, trackCylinder, useOgre, showOgreConfigDialog,
-                    useScanline)) {
+                    useScanline, computeCovariance, projectionError)) {
       return (-1);
     }
 
@@ -377,6 +388,12 @@ main(int argc, const char ** argv)
     // Tells if the tracker has to use the scanline visibility tests
     tracker.setScanLineVisibilityTest(useScanline);
 
+    // Tells if the tracker has to compute the covariance matrix
+    tracker.setCovarianceComputation(computeCovariance);
+
+    // Tells if the tracker has to compute the projection error
+    tracker.setProjectionErrorComputation(projectionError);
+
     // Retrieve the camera parameters from the tracker
     tracker.getCameraParameters(cam1, cam2);
 
@@ -425,9 +442,6 @@ main(int argc, const char ** argv)
       vpDisplay::flush(I1);
       vpDisplay::flush(I2);
     }
-
-    // Uncomment if you want to compute the covariance matrix.
-    // tracker.setCovarianceComputation(true); //Important if you want tracker.getCovarianceMatrix() to work.
 
     while (!reader.end())
     {
@@ -478,6 +492,8 @@ main(int argc, const char ** argv)
         tracker.setCameraParameters(cam1, cam2);
         tracker.setOgreVisibilityTest(useOgre);
         tracker.setScanLineVisibilityTest(useScanline);
+        tracker.setCovarianceComputation(computeCovariance);
+        tracker.setProjectionErrorComputation(projectionError);
         tracker.initFromPose(I1, I2, c1Mo, c2Mo);
       }
 
@@ -510,9 +526,13 @@ main(int argc, const char ** argv)
         }
       }
 
-      // Uncomment if you want to print the covariance matrix.
-      // Make sure tracker.setCovarianceComputation(true) has been called (uncomment below).
-      // std::cout << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      if(computeCovariance) {
+        std::cout << "Covariance matrix: \n" << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      }
+
+      if(projectionError) {
+        std::cout << "Projection error: " << tracker.getProjectionError() << std::endl << std::endl;
+      }
 
       vpDisplay::flush(I1);
       vpDisplay::flush(I2);

--- a/example/tracking/mbtEdgeTracking.cpp
+++ b/example/tracking/mbtEdgeTracking.cpp
@@ -62,12 +62,13 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/mbt/vpMbEdgeTracker.h>
 
-#define GETOPTARGS  "x:m:i:n:dchtfColw"
+#define GETOPTARGS  "x:m:i:n:dchtfColwvp"
 
 void usage(const char *name, const char *badparam);
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
-                std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &useScanline);
+    std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
+    bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog,
+    bool &useScanline, bool &computeCovariance, bool &projectionError);
 
 void usage(const char *name, const char *badparam)
 {
@@ -77,7 +78,7 @@ Example of tracking based on the 3D model.\n\
 SYNOPSIS\n\
   %s [-i <test image path>] [-x <config file>]\n\
   [-m <model name>] [-n <initialisation file base name>]\n\
-  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l]",
+  [-t] [-c] [-d] [-h] [-f] [-C] [-o] [-w] [-l] [-v] [-p]",
   name );
 
   fprintf(stdout, "\n\
@@ -133,7 +134,13 @@ OPTIONS:                                               \n\
      When Ogre3D is enable [-o] show Ogre3D configuration dialog thatallows to set the renderer.\n\
 \n\
   -l\n\
-     Use the scanline for visibility tests\n\
+     Use the scanline for visibility tests.\n\
+\n\
+  -v\n\
+     Compute covariance matrix.\n\
+\n\
+  -v\n\
+     Compute gradient projection error.\n\
 \n\
   -h \n\
      Print the help.\n\n");
@@ -145,7 +152,8 @@ OPTIONS:                                               \n\
 
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
                 std::string &initFile, bool &displayFeatures, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog, bool &useScanline)
+                bool& cao3DModel, bool& trackCylinder, bool &useOgre, bool &showOgreConfigDialog,
+                bool &useScanline, bool &computeCovariance, bool &projectionError)
 {
   const char *optarg_;
   int   c;
@@ -164,6 +172,8 @@ bool getOptions(int argc, const char **argv, std::string &ipath, std::string &co
     case 'o': useOgre = true; break;
     case 'l': useScanline = true; break;
     case 'w': showOgreConfigDialog  = true; break;
+    case 'v': computeCovariance  = true; break;
+    case 'p': projectionError  = true; break;
     case 'h': usage(argv[0], NULL); return false; break;
 
     default:
@@ -204,6 +214,8 @@ main(int argc, const char ** argv)
     bool useOgre = false;
     bool showOgreConfigDialog = false;
     bool useScanline = false;
+    bool computeCovariance = false;
+    bool projectionError = false;
     bool quit = false;
 
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
@@ -217,7 +229,7 @@ main(int argc, const char ** argv)
     // Read the command line options
     if (!getOptions(argc, argv, opt_ipath, opt_configFile, opt_modelFile, opt_initFile, displayFeatures,
                     opt_click_allowed, opt_display, cao3DModel, trackCylinder, useOgre, showOgreConfigDialog,
-                    useScanline)) {
+                    useScanline, computeCovariance, projectionError)) {
       return (-1);
     }
 
@@ -374,6 +386,12 @@ main(int argc, const char ** argv)
     // Tells if the tracker has to use the scanline visibility tests
     tracker.setScanLineVisibilityTest(useScanline);
 
+    // Tells if the tracker has to compute the covariance matrix
+    tracker.setCovarianceComputation(computeCovariance);
+
+    // Tells if the tracker has to compute the projection error
+    tracker.setProjectionErrorComputation(projectionError);
+
     // Retrieve the camera parameters from the tracker
     tracker.getCameraParameters(cam);
 
@@ -413,9 +431,6 @@ main(int argc, const char ** argv)
 
     if (opt_display)
       vpDisplay::flush(I);
-
-    // Uncomment if you want to compute the covariance matrix.
-    // tracker.setCovarianceComputation(true); //Important if you want tracker.getCovarianceMatrix() to work.
 
     while (!reader.end())
     {
@@ -459,6 +474,8 @@ main(int argc, const char ** argv)
         tracker.setCameraParameters(cam);
         tracker.setOgreVisibilityTest(useOgre);
         tracker.setScanLineVisibilityTest(useScanline);
+        tracker.setCovarianceComputation(computeCovariance);
+        tracker.setProjectionErrorComputation(projectionError);
         tracker.initFromPose(I, cMo);
       }
 
@@ -499,9 +516,13 @@ main(int argc, const char ** argv)
         }
       }
 
-      // Uncomment if you want to print the covariance matrix.
-      // Make sure tracker.setCovarianceComputation(true) has been called (uncomment below).
-      // std::cout << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      if(computeCovariance) {
+        std::cout << "Covariance matrix: \n" << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      }
+
+      if(projectionError) {
+        std::cout << "Projection error: " << tracker.getProjectionError() << std::endl << std::endl;
+      }
 
       vpDisplay::flush(I) ;
     }
@@ -525,7 +546,7 @@ main(int argc, const char ** argv)
   
     return 0;
   }
-  catch(vpException e) {
+  catch(vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
     return 1;
   }

--- a/example/tracking/mbtKltMultiTracking.cpp
+++ b/example/tracking/mbtKltMultiTracking.cpp
@@ -61,7 +61,7 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/mbt/vpMbKltMultiTracker.h>
 
-#define GETOPTARGS  "x:m:i:n:dchtfolw"
+#define GETOPTARGS  "x:m:i:n:dchtfolwv"
 
 
 void usage(const char *name, const char *badparam)
@@ -72,7 +72,7 @@ Example of tracking based on the 3D model.\n\
 SYNOPSIS\n\
   %s [-i <test image path>] [-x <config file>]\n\
   [-m <model name>] [-n <initialisation file base name>]\n\
-  [-t] [-c] [-d] [-h] [-f] [-o] [-w] [-l]",
+  [-t] [-c] [-d] [-h] [-f] [-o] [-w] [-l] [-v]",
   name );
 
   fprintf(stdout, "\n\
@@ -123,7 +123,10 @@ OPTIONS:                                               \n\
      When Ogre3D is enable [-o] show Ogre3D configuration dialog that allows to set the renderer.\n\
 \n\
   -l\n\
-     Use the scanline for visibility tests\n\
+     Use the scanline for visibility tests.\n\
+\n\
+  -v\n\
+     Compute covariance matrix.\n\
 \n\
   -h \n\
      Print the help.\n\n");
@@ -135,7 +138,7 @@ OPTIONS:                                               \n\
 
 bool getOptions(int argc, const char **argv, std::string &ipath, std::string &configFile, std::string &modelFile,
                 std::string &initFile, bool &displayKltPoints, bool &click_allowed, bool &display,
-                bool& cao3DModel, bool &useOgre, bool &showOgreConfigDialog, bool &useScanline)
+                bool& cao3DModel, bool &useOgre, bool &showOgreConfigDialog, bool &useScanline, bool &computeCovariance)
 {
   const char *optarg_;
   int   c;
@@ -153,6 +156,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, std::string &co
     case 'o': useOgre = true; break;
     case 'l': useScanline = true; break;
     case 'w': showOgreConfigDialog  = true; break;
+    case 'v': computeCovariance  = true; break;
     case 'h': usage(argv[0], NULL); return false; break;
 
     default:
@@ -192,6 +196,7 @@ main(int argc, const char ** argv)
     bool useOgre = false;
     bool showOgreConfigDialog = false;
     bool useScanline = false;
+    bool computeCovariance = false;
     bool quit = false;
 
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH environment variable value
@@ -203,7 +208,8 @@ main(int argc, const char ** argv)
 
     // Read the command line options
     if (!getOptions(argc, argv, opt_ipath, opt_configFile, opt_modelFile, opt_initFile, displayKltPoints,
-                    opt_click_allowed, opt_display, cao3DModel, useOgre, showOgreConfigDialog, useScanline)) {
+                    opt_click_allowed, opt_display, cao3DModel, useOgre, showOgreConfigDialog, useScanline,
+                    computeCovariance)) {
       return (-1);
     }
 
@@ -362,6 +368,9 @@ main(int argc, const char ** argv)
     // Tells if the tracker has to use the scanline visibility tests
     tracker.setScanLineVisibilityTest(useScanline);
 
+    // Tells if the tracker has to compute the covariance matrix
+    tracker.setCovarianceComputation(computeCovariance);
+
     // Retrieve the camera parameters from the tracker
     tracker.getCameraParameters(cam1, cam2);
 
@@ -404,9 +413,6 @@ main(int argc, const char ** argv)
       vpDisplay::flush(I1);
       vpDisplay::flush(I2);
     }
-
-    // Uncomment if you want to compute the covariance matrix.
-    // tracker.setCovarianceComputation(true); //Important if you want tracker.getCovarianceMatrix() to work.
 
     while (!reader.end())
     {
@@ -459,6 +465,7 @@ main(int argc, const char ** argv)
         tracker.setCameraParameters(cam1, cam2);
         tracker.setOgreVisibilityTest(useOgre);
         tracker.setScanLineVisibilityTest(useScanline);
+        tracker.setCovarianceComputation(computeCovariance);
         tracker.initFromPose(I1, I2, c1Mo, c2Mo);
       }
 
@@ -491,9 +498,9 @@ main(int argc, const char ** argv)
         }
       }
 
-      // Uncomment if you want to print the covariance matrix.
-      // Make sure tracker.setCovarianceComputation(true) has been called (uncomment below).
-      // std::cout << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      if(computeCovariance) {
+        std::cout << "Covariance matrix: \n" << tracker.getCovarianceMatrix() << std::endl << std::endl;
+      }
 
       vpDisplay::flush(I1);
       vpDisplay::flush(I2);

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeTracker.h
@@ -491,9 +491,10 @@ protected:
   void computeVVSSecondPhaseCheckLevenbergMarquard(const unsigned int iter, const unsigned int nbrow,
       const vpColVector &m_error_prev, const vpColVector &m_w_prev, const vpHomogeneousMatrix &cMoPrev,
       double &mu, bool &reStartFromLastIncrement);
-  void computeVVSSecondPhasePoseEstimation(const unsigned int nerror, const vpMatrix &L, const vpColVector &factor,
-      const unsigned int iter, const bool isoJoIdentity_, vpColVector &weighted_error, double &mu,
-      vpColVector &m_error_prev, vpColVector &m_w_prev, vpHomogeneousMatrix &cMoPrev, double &residu_1, double &r);
+  void computeVVSSecondPhasePoseEstimation(const unsigned int nerror, vpMatrix &L, vpMatrix &L_true, vpMatrix &LVJ_true,
+      vpColVector &W_true, const vpColVector &factor, const unsigned int iter, const bool isoJoIdentity_,
+      vpColVector &weighted_error, double &mu, vpColVector &m_error_prev, vpColVector &m_w_prev,
+      vpHomogeneousMatrix &cMoPrev, double &residu_1, double &r);
   void computeVVSSecondPhaseWeights(const unsigned int iter, const unsigned int nerror,
       const unsigned int nbrow, vpColVector &weighted_error,
       vpRobust &robust_lines, vpRobust &robust_cylinders, vpRobust &robust_circles,

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbKltTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbKltTracker.h
@@ -440,7 +440,7 @@ protected:
   void computeVVSInteractionMatrixAndResidu(unsigned int shift, vpColVector &R, vpMatrix &L, vpHomography &H,
                                             std::list<vpMbtDistanceKltPoints*> &kltPolygons_, std::list<vpMbtDistanceKltCylinder*> &kltCylinders_,
                                             const vpHomogeneousMatrix &ctTc0_);
-  void computeVVSPoseEstimation(const unsigned int iter, const vpMatrix &L,
+  void computeVVSPoseEstimation(const unsigned int iter, vpMatrix &L,
                                 const vpColVector &w, vpMatrix &L_true, vpMatrix &LVJ_true, double &normRes, double &normRes_1, vpColVector &w_true,
                                 vpColVector &R, vpMatrix &LTL, vpColVector &LTR, vpColVector &error_prev, vpColVector &v, double &mu,
                                 vpHomogeneousMatrix &cMoPrev, vpHomogeneousMatrix &ctTc0_Prev);

--- a/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
@@ -448,8 +448,8 @@ void vpMbEdgeMultiTracker::computeVVS(std::map<std::string, const vpImage<unsign
         }
       }
 
-      computeVVSSecondPhasePoseEstimation(nerror, L, factor, iter, isoJoIdentity_, weighted_error, mu, m_error_prev,
-          m_w_prev, cMoPrev, residu_1, r);
+      computeVVSSecondPhasePoseEstimation(nerror, L, L_true, LVJ_true, W_true, factor, iter, isoJoIdentity_,
+          weighted_error, mu, m_error_prev, m_w_prev, cMoPrev, residu_1, r);
     }
 
     iter++;

--- a/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
@@ -279,15 +279,15 @@ vpMbEdgeTracker::computeVVS(const vpImage<unsigned char>& _I, const unsigned int
           w_lines, w_cylinders, w_circles, error_lines, error_cylinders, error_circles, nberrors_lines, nberrors_cylinders,
           nberrors_circles);
 
-      computeVVSSecondPhasePoseEstimation(nerror, L, factor, iter, isoJoIdentity_, weighted_error, mu, m_error_prev,
-          m_w_prev, cMoPrev, residu_1, r);
+      computeVVSSecondPhasePoseEstimation(nerror, L, L_true, LVJ_true, W_true, factor, iter, isoJoIdentity_,
+          weighted_error, mu, m_error_prev, m_w_prev, cMoPrev, residu_1, r);
 
     } // endif(!restartFromLast)
 
     iter++;
   }
 
-  // std::cout << "VVS estimate pose cMo:\n" << cMo << std::endl;
+//   std::cout << "VVS estimate pose cMo:\n" << cMo << std::endl;
   if(computeCovariance){
     vpMatrix D;
     D.diag(W_true);
@@ -850,9 +850,10 @@ vpMbEdgeTracker::computeVVSSecondPhaseCheckLevenbergMarquard(const unsigned int 
 }
 
 void
-vpMbEdgeTracker::computeVVSSecondPhasePoseEstimation(const unsigned int nerror, const vpMatrix &L, const vpColVector &factor,
-    const unsigned int iter, const bool isoJoIdentity_, vpColVector &weighted_error, double &mu,
-    vpColVector &m_error_prev, vpColVector &m_w_prev, vpHomogeneousMatrix &cMoPrev, double &residu_1, double &r) {
+vpMbEdgeTracker::computeVVSSecondPhasePoseEstimation(const unsigned int nerror, vpMatrix &L, vpMatrix &L_true,
+    vpMatrix &LVJ_true, vpColVector &W_true, const vpColVector &factor, const unsigned int iter, const bool isoJoIdentity_,
+    vpColVector &weighted_error, double &mu, vpColVector &m_error_prev, vpColVector &m_w_prev,
+    vpHomogeneousMatrix &cMoPrev, double &residu_1, double &r) {
   double num=0;
   double den=0;
   double wi;
@@ -860,9 +861,6 @@ vpMbEdgeTracker::computeVVSSecondPhasePoseEstimation(const unsigned int nerror, 
 
   vpMatrix LTL;
   vpColVector LTR;
-  vpColVector W_true;
-  vpMatrix L_true;
-  vpMatrix LVJ_true;
 
   L_true = L;
   W_true = vpColVector(nerror);

--- a/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
@@ -858,7 +858,7 @@ vpMbKltTracker::computeVVSInteractionMatrixAndResidu(unsigned int shift, vpColVe
 }
 
 void
-vpMbKltTracker::computeVVSPoseEstimation(const unsigned int iter, const vpMatrix &L,
+vpMbKltTracker::computeVVSPoseEstimation(const unsigned int iter, vpMatrix &L,
     const vpColVector &w, vpMatrix &L_true, vpMatrix &LVJ_true, double &normRes, double &normRes_1, vpColVector &w_true,
     vpColVector &R, vpMatrix &LTL, vpColVector &LTR, vpColVector &error_prev, vpColVector &v, double &mu,
     vpHomogeneousMatrix &cMoPrev, vpHomogeneousMatrix &ctTc0_Prev) {


### PR DESCRIPTION
- Fix covariance computation in vpMbEdgeTracker and in vpMbEdgeMultiTracker classes. 
- Add options to print covariance matrix and projection error in the MBT examples.