### PR TITLE
Fix build errors when flag BUILD_DEPRECATED_FUNCTIONS is set to OFF.

### DIFF
--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -202,20 +202,6 @@ vpMatrix::eye()
 }
 
 /*!
-  Set the matrix diagonal elements to \e val.
-  More generally set M[i][i] = val.
-*/
-void
-vpMatrix::setIdentity(const double & val)
-{
-  for (unsigned int i=0;i<rowNum;i++)
-    for (unsigned int j=0;j<colNum;j++)
-      if (i==j) (*this)[i][j] = val ;
-      else      (*this)[i][j] = 0;
-}
-
-
-/*!
   Compute and return the transpose of the matrix.
 */
 vpMatrix vpMatrix::t() const
@@ -3596,5 +3582,21 @@ vpMatrix::column(const unsigned int j)
   for (unsigned int i =0 ; i < getRows() ; i++)     c[i] = (*this)[i][j-1] ;
   return c ;
 }
+
+/*!
+  \deprecated You should rather use diag(const double &)
+
+  Set the matrix diagonal elements to \e val.
+  More generally set M[i][i] = val.
+*/
+void
+vpMatrix::setIdentity(const double & val)
+{
+  for (unsigned int i=0;i<rowNum;i++)
+    for (unsigned int j=0;j<colNum;j++)
+      if (i==j) (*this)[i][j] = val ;
+      else      (*this)[i][j] = 0;
+}
+
 #endif //#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
 

--- a/modules/core/src/math/transformation/vpForceTwistMatrix.cpp
+++ b/modules/core/src/math/transformation/vpForceTwistMatrix.cpp
@@ -192,17 +192,6 @@ vpForceTwistMatrix::vpForceTwistMatrix(const double tx, const double ty, const d
 }
 
 /*!
-  Set the twist transformation matrix to identity.
-  \sa eye()
-*/
-void
-vpForceTwistMatrix::setIdentity()
-{
-  eye() ;
-}
-
-
-/*!
 
   Operator that allows to multiply a skew transformation matrix by an
   other skew transformation matrix.
@@ -511,3 +500,19 @@ vpForceTwistMatrix::print(std::ostream& s, unsigned int length, char const* intr
 
   return (int)(maxBefore+maxAfter);
 }
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+
+/*!
+  \deprecated You should rather use eye().
+
+  Set the twist transformation matrix to identity.
+  \sa eye()
+*/
+void
+vpForceTwistMatrix::setIdentity()
+{
+  eye() ;
+}
+
+#endif //#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -757,15 +757,6 @@ vpHomogeneousMatrix::print() const
   vpPoseVector r(*this) ;
   std::cout << r.t() ;
 }
-/*!
-   Set homogeneous matrix to identity.
-   \sa eye()
- */
-void
-vpHomogeneousMatrix::setIdentity()
-{
-  eye() ;
-}
 
 /*!
   Converts an homogeneous matrix to a vector of 12 floats.
@@ -860,3 +851,19 @@ vpHomogeneousMatrix::getCol(const unsigned int j) const
     c[i] = (*this)[i][j];
   return c;
 }
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+
+/*!
+  \deprecated You should rather use eye().
+
+   Set homogeneous matrix to identity.
+   \sa eye()
+ */
+void
+vpHomogeneousMatrix::setIdentity()
+{
+  eye() ;
+}
+
+#endif //#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)

--- a/modules/core/src/math/transformation/vpRotationMatrix.cpp
+++ b/modules/core/src/math/transformation/vpRotationMatrix.cpp
@@ -57,17 +57,6 @@
 #include <math.h>
 const double vpRotationMatrix::threshold = 1e-6;
 
-
-/*!
-  Initializes the rotation matrix as identity.
-  
-  \sa eye()
-*/
-void
-vpRotationMatrix::setIdentity()
-{
-  eye();
-}
 /*!
   Initialize the rotation matrix as identity.
   
@@ -754,3 +743,19 @@ vpRotationMatrix::getCol(const unsigned int j) const
   return c;
 }
 
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+
+/*!
+  \deprecated You should rather use eye().
+
+  Initializes the rotation matrix as identity.
+
+  \sa eye()
+*/
+void
+vpRotationMatrix::setIdentity()
+{
+  eye();
+}
+
+#endif //#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)

--- a/modules/core/src/math/transformation/vpVelocityTwistMatrix.cpp
+++ b/modules/core/src/math/transformation/vpVelocityTwistMatrix.cpp
@@ -180,18 +180,6 @@ vpVelocityTwistMatrix::vpVelocityTwistMatrix(const double tx,
 
 /*!
 
-  Set the velocity twist transformation matrix to identity.
-
-*/
-void
-vpVelocityTwistMatrix::setIdentity()
-{
-  eye() ;
-}
-
-
-/*!
-
   Operator that allows to multiply a velocity twist transformation matrix by an
   other velocity twist transformation matrix.
 
@@ -528,3 +516,19 @@ vpVelocityTwistMatrix::print(std::ostream& s, unsigned int length, char const* i
 
   return (int)(maxBefore+maxAfter);
 }
+
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+
+/*!
+  \deprecated You should rather use eye().
+
+  Set the velocity twist transformation matrix to identity.
+
+*/
+void
+vpVelocityTwistMatrix::setIdentity()
+{
+  eye() ;
+}
+
+#endif // #if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)

--- a/modules/vision/include/visp3/vision/vpHomography.h
+++ b/modules/vision/include/visp3/vision/vpHomography.h
@@ -391,7 +391,7 @@ class VISP_EXPORT vpHomography : public vpArray2D<double>
 
 #if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
   /*!
-    @name Deprecated functions
+    \deprecated You should rather use eye().
   */
   //@{
     void setIdentity();

--- a/modules/vision/src/homography-estimation/vpHomography.cpp
+++ b/modules/vision/src/homography-estimation/vpHomography.cpp
@@ -60,7 +60,7 @@
 vpHomography::vpHomography()
   : vpArray2D<double>(3,3), aMb(), bP()
 {
-  setIdentity();
+  eye();
 }
 
 

--- a/modules/vision/src/homography-estimation/vpHomographyRansac.cpp
+++ b/modules/vision/src/homography-estimation/vpHomographyRansac.cpp
@@ -239,7 +239,7 @@ vpHomography::computeTransformation(vpColVector &x, unsigned int *ind, vpColVect
   }
   catch(...)
     {
-      aHb.setIdentity();
+      aHb.eye();
     }
 
   M.resize(9);


### PR DESCRIPTION
Fix build errors when flag BUILD_DEPRECATED_FUNCTIONS is set to OFF.

Mainly add missing preprocessor "#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)"