### PR TITLE
Feature proposal: possibility to add extra info when saving camera parameters.

### DIFF
--- a/modules/core/include/visp3/core/vpXmlParserCamera.h
+++ b/modules/core/include/visp3/core/vpXmlParserCamera.h
@@ -207,7 +207,8 @@ public:
       CODE_XML_PX,
       CODE_XML_PY,
       CODE_XML_KUD,
-      CODE_XML_KDU
+      CODE_XML_KDU,
+      CODE_XML_ADDITIONAL_INFO
     } vpXmlCodeType;
 
   typedef enum 
@@ -243,7 +244,8 @@ public:
 	    const unsigned int image_width = 0, const unsigned int image_height = 0);
   int save(const vpCameraParameters &cam, const std::string &filename,
 	   const std::string &camera_name,
-	   const unsigned int image_width = 0, const unsigned int image_height = 0);
+	   const unsigned int image_width = 0, const unsigned int image_height = 0,
+	   const std::string &additionalInfo="");
 
   // get/set functions
   std::string getCameraName(){return this->camera_name;}
@@ -296,6 +298,8 @@ private:
                    const unsigned int image_height = 0,
                    const unsigned int subsampling_width = 0,
                    const unsigned int subsampling_height = 0);
+
+  xmlNodePtr find_additional_info (xmlNodePtr node);
  
   vpXmlCodeSequenceType read_camera_model (xmlDocPtr doc, xmlNodePtr node,
 					                                 vpCameraParameters &camera);


### PR DESCRIPTION
- Add possibility to save extra information about the calibration process. 
- Update the camera_calibration.cpp file to save additional information.

The user can add any type of information he wants as long as it is formatted in XML format.

Example of the resulting file with data in example/calibration:
```
<?xml version="1.0"?>
<root>
  <!--This file stores intrinsic camera parameters used
   in the vpCameraParameters Class of ViSP available
   at http://www.irisa.fr/lagadic/visp/visp.html .
   It can be read with the parse method of
   the vpXmlParserCamera class.-->
  <camera>
    <!--Name of the camera-->
    <name>Camera chessboard</name>
    <!--Size of the image on which camera calibration was performed-->
    <image_width>320</image_width>
    <image_height>240</image_height>
    <!--Intrinsic camera parameters computed for each projection model-->
    <model>
      <!--Projection model type-->
      <type>perspectiveProjWithoutDistortion</type>
      <!--Pixel ratio-->
      <px>278.5184894525</px>
      <py>273.9720724988</py>
      <!--Principal point-->
      <u0>162.1161032686</u0>
      <v0>113.1789418478</v0>
    </model>
    <model>
      <!--Projection model type-->
      <type>perspectiveProjWithDistortion</type>
      <!--Pixel ratio-->
      <px>276.3370768176</px>
      <py>271.9805092922</py>
      <!--Principal point-->
      <u0>162.3656741032</u0>
      <v0>113.4484345283</v0>
      <!--Undistorted to distorted distortion parameter-->
      <kud>0.0273989659</kud>
      <!--Distorted to undistorted distortion parameter-->
      <kdu>-0.0271944553</kdu>
    </model>
    <!--Additional information-->
    <additional_information>
      <date>2016/06/02 17:02:28</date>
      <nb_calibration_images>5</nb_calibration_images>
      <calibration_pattern_type>Chessboard</calibration_pattern_type>
      <board_size>9x6</board_size>
      <square_size>0.025</square_size>
      <global_reprojection_error>
        <without_distortion>0.278426</without_distortion>
        <with_distortion>0.260215</with_distortion>
      </global_reprojection_error>
    </additional_information>
  </camera>
  <camera>
    <!--Name of the camera-->
    <name>Camera circle</name>
    <!--Size of the image on which camera calibration was performed-->
    <image_width>320</image_width>
    <image_height>240</image_height>
    <!--Intrinsic camera parameters computed for each projection model-->
    <model>
      <!--Projection model type-->
      <type>perspectiveProjWithoutDistortion</type>
      <!--Pixel ratio-->
      <px>276.7844986795</px>
      <py>273.2284127849</py>
      <!--Principal point-->
      <u0>164.0290609733</u0>
      <v0>113.2926414122</v0>
    </model>
    <model>
      <!--Projection model type-->
      <type>perspectiveProjWithDistortion</type>
      <!--Pixel ratio-->
      <px>272.6576028537</px>
      <py>268.9209422797</py>
      <!--Principal point-->
      <u0>163.3267494369</u0>
      <v0>112.9548567119</v0>
      <!--Undistorted to distorted distortion parameter-->
      <kud>0.0313251538</kud>
      <!--Distorted to undistorted distortion parameter-->
      <kdu>-0.0309871902</kdu>
    </model>
    <!--Additional information-->
    <additional_information>
      <date>2016/06/02 17:03:08</date>
      <nb_calibration_images>5</nb_calibration_images>
      <calibration_pattern_type>Circles grid</calibration_pattern_type>
      <board_size>6x6</board_size>
      <square_size>0.034</square_size>
      <global_reprojection_error>
        <without_distortion>0.324557</without_distortion>
        <with_distortion>0.298546</with_distortion>
      </global_reprojection_error>
    </additional_information>
  </camera>
</root>
```
