### PR TITLE
Update vpRealSense to be able to handle multiple stream format.

### DIFF
--- a/modules/sensor/src/rgb-depth/realsense/vpRealSense_impl.h
+++ b/modules/sensor/src/rgb-depth/realsense/vpRealSense_impl.h
@@ -40,12 +40,20 @@
 #include <visp3/core/vpImage.h>
 
 template <class Type>
-void vp_rs_get_frame_data_impl(const rs::device *m_device, const std::vector <rs::intrinsics> &m_intrinsics, const rs::stream &stream, vpImage<Type> &data)
+void vp_rs_get_frame_data_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, const rs::stream &stream, vpImage<Type> &data)
 {
   // Retrieve data from stream
   if (m_device->is_stream_enabled(stream)) {
-    int width = m_intrinsics[(rs_stream)stream].width;
-    int height = m_intrinsics[(rs_stream)stream].height;
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(stream);
+    if (it_intrinsics == m_intrinsics.end()) {
+      std::stringstream ss;
+      ss << "Cannot find intrinsics for " << stream << "  stream!";
+      throw vpException(vpException::fatalError, ss.str());
+      return;
+    }
+
+    unsigned int width = (unsigned int) it_intrinsics->second.width;
+    unsigned int height = (unsigned int) it_intrinsics->second.height;
     data.resize(height, width);
 
     memcpy((unsigned char *)data.bitmap, (unsigned char *)m_device->get_frame_data(stream), width*height*sizeof(Type));
@@ -55,16 +63,96 @@ void vp_rs_get_frame_data_impl(const rs::device *m_device, const std::vector <rs
   }
 }
 
+// Retrieve data from native stream
+void vp_rs_get_native_frame_data_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, const rs::stream &stream, unsigned char * const data)
+{
+  if (m_device->is_stream_enabled(stream)) {
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(stream);
+    if (it_intrinsics == m_intrinsics.end()) {
+      std::stringstream ss;
+      ss << "Cannot find intrinsics for " << stream << "  stream!";
+      throw vpException(vpException::fatalError, ss.str());
+      return;
+    }
+
+    size_t size = (size_t) (it_intrinsics->second.width * it_intrinsics->second.height);
+
+    switch (m_device->get_stream_format(stream)) {
+      //8 bits
+      case rs::format::raw8:
+        std::cout << "Stream: raw8 not tested!" << std::endl;
+      case rs::format::y8:
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), size );
+        break;
+
+      //Four 10-bit luminance values encoded into a 5-byte macropixel
+      case rs::format::raw10:
+        std::cout << "Stream: raw10 not tested!" << std::endl;
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), (5 * (size/4)) );
+        break;
+
+      //16 bits
+      case rs::format::raw16:
+        std::cout << "Stream: raw16 not tested!" << std::endl;
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), size*2 );
+        break;
+
+      case rs::format::disparity16:
+        std::cout << "Stream: disparity16 not tested!" << std::endl;
+      case rs::format::y16:
+      case rs::format::z16:
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), size*2 );
+        break;
+
+      //24 bits
+      case rs::format::bgr8:
+      case rs::format::rgb8:
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), size*3 );
+        break;
+
+      //32 bits
+      case rs::format::yuyv:
+        std::cout << "Stream: yuyv not tested!" << std::endl;
+      case rs::format::bgra8:
+      case rs::format::rgba8:
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), size*4 );
+        break;
+
+      //96 bits
+      case rs::format::xyz32f:
+        std::cout << "Stream: xyz32f not tested!" << std::endl;
+        memcpy( data, (unsigned char *) m_device->get_frame_data(stream), size*3*4 );
+        break;
+
+      case rs::format::any:
+      default:
+        break;
+    }
+  }
+  else {
+    throw vpException(vpException::fatalError, "RealSense Camera - stream %d not enabled!", (rs_stream) stream);
+  }
+}
+
 // Retrieve color image
-void vp_rs_get_color_impl(const rs::device *m_device, const std::vector <rs::intrinsics> &m_intrinsics, vpImage<vpRGBa> &color)
+void vp_rs_get_color_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, vpImage<vpRGBa> &color)
 {
   if (m_device->is_stream_enabled(rs::stream::color)) {
-    int width = m_intrinsics[RS_STREAM_COLOR].width;
-    int height = m_intrinsics[RS_STREAM_COLOR].height;
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(rs::stream::color);
+    if (it_intrinsics == m_intrinsics.end()) {
+      std::stringstream ss;
+      throw vpException(vpException::fatalError, "Cannot find intrinsics for color stream!");
+      return;
+    }
+
+    unsigned int width = (unsigned int) it_intrinsics->second.width;
+    unsigned int height = (unsigned int) it_intrinsics->second.height;
     color.resize(height, width);
 
     if (m_device->get_stream_format(rs::stream::color) == rs::format::rgb8)
-      vpImageConvert::RGBToRGBa((unsigned char *)m_device->get_frame_data(rs::stream::color), (unsigned char *)color.bitmap, width, height);
+      vpImageConvert::RGBToRGBa( (unsigned char *) m_device->get_frame_data(rs::stream::color), (unsigned char *) color.bitmap, width, height );
+    else if (m_device->get_stream_format(rs::stream::color) == rs::format::rgba8)
+      memcpy( (unsigned char *) color.bitmap, (unsigned char *) m_device->get_frame_data(rs::stream::color), width*height*sizeof(vpRGBa) );
     else
       throw vpException(vpException::fatalError, "RealSense Camera - color stream not supported!");
   }
@@ -74,15 +162,23 @@ void vp_rs_get_color_impl(const rs::device *m_device, const std::vector <rs::int
 }
 
 // Retrieve grey image
-void vp_rs_get_grey_impl(const rs::device *m_device, const std::vector <rs::intrinsics> &m_intrinsics, vpImage<unsigned char> &grey)
+void vp_rs_get_grey_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, vpImage<unsigned char> &grey)
 {
   if (m_device->is_stream_enabled(rs::stream::color)) {
-    int width = m_intrinsics[RS_STREAM_COLOR].width;
-    int height = m_intrinsics[RS_STREAM_COLOR].height;
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(rs::stream::color);
+    if (it_intrinsics == m_intrinsics.end()) {
+      throw vpException(vpException::fatalError, "Cannot find intrinsics for color stream!");
+      return;
+    }
+
+    unsigned int width = (unsigned int) it_intrinsics->second.width;
+    unsigned int height = (unsigned int) it_intrinsics->second.height;
     grey.resize(height, width);
 
     if (m_device->get_stream_format(rs::stream::color) == rs::format::rgb8)
-      vpImageConvert::RGBToGrey((unsigned char *)m_device->get_frame_data(rs::stream::color), (unsigned char *)grey.bitmap, width, height);
+      vpImageConvert::RGBToGrey( (unsigned char *) m_device->get_frame_data(rs::stream::color), (unsigned char *) grey.bitmap, width, height );
+    else if (m_device->get_stream_format(rs::stream::color) == rs::format::rgba8)
+      vpImageConvert::RGBaToGrey( (unsigned char *) m_device->get_frame_data(rs::stream::color), (unsigned char *) grey.bitmap, width*height );
     else
       throw vpException(vpException::fatalError, "RealSense Camera - color stream not supported!");
   }
@@ -92,24 +188,30 @@ void vp_rs_get_grey_impl(const rs::device *m_device, const std::vector <rs::intr
 }
 
 // Retrieve point cloud
-void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs::intrinsics> &m_intrinsics, float max_Z, std::vector<vpColVector> &pointcloud)
+void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, float max_Z, std::vector<vpColVector> &pointcloud)
 {
   if (m_device->is_stream_enabled(rs::stream::depth)) {
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(rs::stream::color);
+    if (it_intrinsics == m_intrinsics.end()) {
+      throw vpException(vpException::fatalError, "Cannot find intrinsics for depth stream!");
+      return;
+    }
+
     const float depth_scale = m_device->get_depth_scale();
 
     vpColVector p3d(4); // X,Y,Z coordinates
     rs::float3 depth_point;
     uint16_t * depth = (uint16_t *)m_device->get_frame_data(rs::stream::depth);
-    int width = m_intrinsics[RS_STREAM_DEPTH].width;
-    int height = m_intrinsics[RS_STREAM_DEPTH].height;
-    pointcloud.resize(width*height);
+    int width = it_intrinsics->second.width;
+    int height = it_intrinsics->second.height;
+    pointcloud.resize((size_t) (width*height));
 
     for (int i = 0; i < height; i++) {
       for (int j = 0; j < width; j++) {
         float scaled_depth = depth[i*width + j] * depth_scale;
 
         rs::float2 depth_pixel = { (float) j, (float) i};
-        depth_point = m_intrinsics[RS_STREAM_DEPTH].deproject(depth_pixel, scaled_depth);
+        depth_point = it_intrinsics->second.deproject(depth_pixel, scaled_depth);
 
         if (depth_point.z <= 0 || depth_point.z > max_Z) {
           depth_point.x = depth_point.y = depth_point.z = 0;
@@ -119,7 +221,7 @@ void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs
         p3d[2] = depth_point.z;
         p3d[3] = 1;
 
-        pointcloud[i*width + j] = p3d;
+        pointcloud[(size_t) (i*width + j)] = p3d;
       }
     }
   }
@@ -130,14 +232,20 @@ void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs
 
 #ifdef VISP_HAVE_PCL
 // Retrieve point cloud
-void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs::intrinsics> &m_intrinsics, float max_Z, pcl::PointCloud<pcl::PointXYZ>::Ptr &pointcloud)
+void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::map<rs::stream, rs::intrinsics> &m_intrinsics, float max_Z, pcl::PointCloud<pcl::PointXYZ>::Ptr &pointcloud)
 {
   if (m_device->is_stream_enabled(rs::stream::depth)) {
-    int width = m_intrinsics[RS_STREAM_DEPTH].width;
-    int height = m_intrinsics[RS_STREAM_DEPTH].height;
-    pointcloud->width = width;
-    pointcloud->height = height;
-    pointcloud->resize(width * height);
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(rs::stream::depth);
+    if (it_intrinsics == m_intrinsics.end()) {
+      throw vpException(vpException::fatalError, "Cannot find intrinsics for depth stream!");
+      return;
+    }
+
+    int width = it_intrinsics->second.width;
+    int height = it_intrinsics->second.height;
+    pointcloud->width = (uint32_t) width;
+    pointcloud->height = (uint32_t) height;
+    pointcloud->resize((size_t) (width * height));
 
     const float depth_scale = m_device->get_depth_scale();
 
@@ -150,14 +258,14 @@ void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs
         float scaled_depth = depth[i*width + j] * depth_scale;
 
         rs::float2 depth_pixel = { (float) j, (float) i};
-        depth_point = m_intrinsics[RS_STREAM_DEPTH].deproject(depth_pixel, scaled_depth);
+        depth_point = it_intrinsics->second.deproject(depth_pixel, scaled_depth);
 
         if (depth_point.z <= 0 || depth_point.z > max_Z) {
           depth_point.x = depth_point.y = depth_point.z = 0;
         }
-        pointcloud->points[i*width + j].x = depth_point.x;
-        pointcloud->points[i*width + j].y = depth_point.y;
-        pointcloud->points[i*width + j].z = depth_point.z;
+        pointcloud->points[(size_t) (i*width + j)].x = depth_point.x;
+        pointcloud->points[(size_t) (i*width + j)].y = depth_point.y;
+        pointcloud->points[(size_t) (i*width + j)].z = depth_point.z;
       }
     }
   }
@@ -167,14 +275,26 @@ void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs
 }
 
 // Retrieve point cloud
-void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs::intrinsics> &m_intrinsics, float max_Z, pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pointcloud)
+void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, float max_Z, pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pointcloud)
 {
   if (m_device->is_stream_enabled(rs::stream::depth) && m_device->is_stream_enabled(rs::stream::color)) {
-    int depth_width = m_intrinsics[RS_STREAM_DEPTH].width;
-    int depth_height = m_intrinsics[RS_STREAM_DEPTH].height;
-    pointcloud->width = depth_width;
-    pointcloud->height = depth_height;
-    pointcloud->resize(depth_width * depth_height);
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics_depth = m_intrinsics.find(rs::stream::depth);
+    if (it_intrinsics_depth == m_intrinsics.end()) {
+      throw vpException(vpException::fatalError, "Cannot find intrinsics for depth stream!");
+      return;
+    }
+
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics_color = m_intrinsics.find(rs::stream::color);
+    if (it_intrinsics_color == m_intrinsics.end()) {
+      throw vpException(vpException::fatalError, "Cannot find intrinsics for color stream!");
+      return;
+    }
+
+    int depth_width = it_intrinsics_depth->second.width;
+    int depth_height = it_intrinsics_depth->second.height;
+    pointcloud->width = (uint32_t) depth_width;
+    pointcloud->height = (uint32_t) depth_height;
+    pointcloud->resize((size_t) (depth_width * depth_height));
 
     const float depth_scale = m_device->get_depth_scale();
 
@@ -185,25 +305,26 @@ void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs
     rs::float2 color_pixel;
     uint16_t * depth = (uint16_t *)m_device->get_frame_data(rs::stream::depth);
     unsigned char * color = (unsigned char *)m_device->get_frame_data(rs::stream::color);
-    int color_width = m_intrinsics[RS_STREAM_COLOR].width;
-    int color_height = m_intrinsics[RS_STREAM_COLOR].height;
+    int color_width = it_intrinsics_color->second.width;
+    int color_height = it_intrinsics_color->second.height;
 
+    unsigned int nb_color_pixel = (m_device->get_stream_format(rs::stream::color) == rs::format::rgb8 || m_device->get_stream_format(rs::stream::color) == rs::format::bgr8) ? 3 : 4;
     for (int i = 0; i < depth_height; i++) {
       for (int j = 0; j < depth_width; j++) {
         float scaled_depth = depth[i*depth_width + j] * depth_scale;
 
         rs::float2 depth_pixel = { (float) j, (float) i};
-        depth_point = m_intrinsics[RS_STREAM_DEPTH].deproject(depth_pixel, scaled_depth);
+        depth_point = it_intrinsics_depth->second.deproject(depth_pixel, scaled_depth);
 
         if (depth_point.z <= 0 || depth_point.z > max_Z) {
           depth_point.x = depth_point.y = depth_point.z = 0;
         }
-        pointcloud->points[i*depth_width + j].x = depth_point.x;
-        pointcloud->points[i*depth_width + j].y = depth_point.y;
-        pointcloud->points[i*depth_width + j].z = depth_point.z;
+        pointcloud->points[(size_t) (i*depth_width + j)].x = depth_point.x;
+        pointcloud->points[(size_t) (i*depth_width + j)].y = depth_point.y;
+        pointcloud->points[(size_t) (i*depth_width + j)].z = depth_point.z;
 
         color_point = depth_2_color_extrinsic.transform(depth_point);
-        color_pixel = m_intrinsics[RS_STREAM_COLOR].project(color_point);
+        color_pixel = it_intrinsics_color->second.project(color_point);
 
         if (color_pixel.y < 0 || color_pixel.y >= color_height
             || color_pixel.x < 0 || color_pixel.x >= color_width)
@@ -214,17 +335,25 @@ void vp_rs_get_pointcloud_impl(const rs::device *m_device, const std::vector <rs
           uint32_t rgb = (static_cast<uint32_t>(r) << 16 |
                           static_cast<uint32_t>(g) << 8 | static_cast<uint32_t>(b));
 
-          pointcloud->points[i*depth_width + j].rgb = *reinterpret_cast<float*>(&rgb);
+          pointcloud->points[(size_t) (i*depth_width + j)].rgb = *reinterpret_cast<float*>(&rgb);
         }
         else
         {
           unsigned int i_ = (unsigned int) color_pixel.y;
           unsigned int j_ = (unsigned int) color_pixel.x;
 
-          uint32_t rgb = (static_cast<uint32_t>(color[(i_*color_width + j_)*3]) << 16 |
-                          static_cast<uint32_t>(color[(i_*color_width + j_)*3] + 1) << 8 |
-                          static_cast<uint32_t>(color[(i_*color_width + j_)*3] + 2));
-          pointcloud->points[i*depth_width + j].rgb = *reinterpret_cast<float*>(&rgb);
+          uint32_t rgb = 0;
+          if (m_device->get_stream_format(rs::stream::color) == rs::format::rgb8 || m_device->get_stream_format(rs::stream::color) == rs::format::rgba8) {
+            rgb = (static_cast<uint32_t>(color[(i_* (unsigned int) color_width + j_) * nb_color_pixel]) << 16 |
+                   static_cast<uint32_t>(color[(i_* (unsigned int) color_width + j_) * nb_color_pixel + 1]) << 8 |
+                   static_cast<uint32_t>(color[(i_* (unsigned int) color_width + j_) * nb_color_pixel + 2]));
+          } else if (m_device->get_stream_format(rs::stream::color) == rs::format::bgr8 || m_device->get_stream_format(rs::stream::color) == rs::format::bgra8) {
+            rgb = (static_cast<uint32_t>(color[(i_* (unsigned int) color_width + j_) * nb_color_pixel]) |
+                   static_cast<uint32_t>(color[(i_* (unsigned int) color_width + j_) * nb_color_pixel + 1]) << 8 |
+                   static_cast<uint32_t>(color[(i_* (unsigned int) color_width + j_) * nb_color_pixel + 2]) << 16);
+          }
+
+          pointcloud->points[(size_t) (i*depth_width + j)].rgb = *reinterpret_cast<float*>(&rgb);
         }
       }
     }

--- a/modules/sensor/test/rgb-depth/testRealSense.cpp
+++ b/modules/sensor/test/rgb-depth/testRealSense.cpp
@@ -88,6 +88,7 @@ vpThread::Return displayPointcloudFunction(vpThread::Args args)
   viewer->initCameraParameters ();
   viewer->setPosition(640+80, 480+80);
   viewer->setCameraPosition(0,0,-0.5, 0,-1,0);
+  viewer->setSize(640, 480);
 
   t_CaptureState capture_state_;
 
@@ -134,11 +135,11 @@ int main()
     std::cout << "Extrinsics cMi: \n" << rs.getTransformation(rs::stream::color, rs::stream::infrared) << std::endl;
     std::cout << "Extrinsics dMi: \n" << rs.getTransformation(rs::stream::depth, rs::stream::infrared) << std::endl;
 
-    vpImage<vpRGBa> color(rs.getIntrinsics(rs::stream::color).height, rs.getIntrinsics(rs::stream::color).width);
+    vpImage<vpRGBa> color((unsigned int) rs.getIntrinsics(rs::stream::color).height, (unsigned int) rs.getIntrinsics(rs::stream::color).width);
     vpImage<uint16_t> infrared;
-    vpImage<unsigned char> infrared_display(rs.getIntrinsics(rs::stream::infrared).height, rs.getIntrinsics(rs::stream::infrared).width);;
+    vpImage<unsigned char> infrared_display((unsigned int) rs.getIntrinsics(rs::stream::infrared).height, (unsigned int) rs.getIntrinsics(rs::stream::infrared).width);;
     vpImage<uint16_t> depth;
-    vpImage<vpRGBa> depth_display(rs.getIntrinsics(rs::stream::depth).height, rs.getIntrinsics(rs::stream::depth).width);
+    vpImage<vpRGBa> depth_display((unsigned int) rs.getIntrinsics(rs::stream::depth).height, (unsigned int) rs.getIntrinsics(rs::stream::depth).width);
 
 #ifdef VISP_HAVE_PCL
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointcloud(new pcl::PointCloud<pcl::PointXYZRGB>);
@@ -160,8 +161,8 @@ int main()
 
 #if defined(VISP_HAVE_X11)
     vpDisplayX dc(color, 10, 10, "Color image");
-    vpDisplayX di(infrared_display, color.getWidth()+80, 10, "Infrared image");
-    vpDisplayX dd(depth_display, 10, color.getHeight()+80, "Depth image");
+    vpDisplayX di(infrared_display, (int) color.getWidth()+80, 10, "Infrared image");
+    vpDisplayX dd(depth_display, 10, (int) color.getHeight()+80, "Depth image");
 #elif defined(VISP_HAVE_GDI)
     vpDisplayGDI dc(color, 10, 10, "Color image");
     vpDisplayGDI di(infrared_display, color.getWidth()+80, 10, "Infrared image");

--- a/modules/sensor/test/rgb-depth/testRealSense2.cpp
+++ b/modules/sensor/test/rgb-depth/testRealSense2.cpp
@@ -1,0 +1,495 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test Intel RealSense acquisition.
+ *
+ *****************************************************************************/
+
+/*!
+  \example testRealSense2.cpp
+  Test SR300 Intel RealSense acquisition.
+*/
+
+#include <iostream>
+
+#include <visp3/sensor/vpRealSense.h>
+#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayGDI.h>
+#include <visp3/io/vpImageIo.h>
+#include <visp3/core/vpImageConvert.h>
+#include <visp3/core/vpMutex.h>
+#include <visp3/core/vpThread.h>
+
+#if defined(VISP_HAVE_REALSENSE) && defined(VISP_HAVE_CPP11_COMPATIBILITY)
+#  include <librealsense/rs.h>
+
+// Using a thread to display the pointcloud with PCL produces a segfault on OSX
+#if( ! defined(__APPLE__) && ! defined(__MACH__) ) // Not OSX
+#  if (defined(VISP_HAVE_PTHREAD) || defined(_WIN32)) // Threading available
+#    define USE_THREAD
+#  endif
+#endif
+
+#ifdef VISP_HAVE_PCL
+#  include <pcl/visualization/cloud_viewer.h>
+#  include <pcl/visualization/pcl_visualizer.h>
+#endif
+
+#ifdef VISP_HAVE_PCL
+#ifdef USE_THREAD
+// Shared vars
+typedef enum {
+  capture_waiting,
+  capture_started,
+  capture_stopped
+} t_CaptureState;
+t_CaptureState s_capture_state = capture_waiting;
+vpMutex s_mutex_capture;
+
+
+vpThread::Return displayPointcloudFunction(vpThread::Args args)
+{
+  pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointcloud_ = *((pcl::PointCloud<pcl::PointXYZRGB>::Ptr *) args);
+
+  pcl::visualization::PCLVisualizer::Ptr viewer (new pcl::visualization::PCLVisualizer ("3D Viewer"));
+  pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb(pointcloud_);
+  viewer->setBackgroundColor (0, 0, 0);
+  viewer->addCoordinateSystem (1.0);
+  viewer->initCameraParameters ();
+  viewer->setPosition(640+80, 480+80);
+  viewer->setCameraPosition(0,0,-0.5, 0,-1,0);
+  viewer->setSize(640, 480);
+
+  t_CaptureState capture_state_;
+
+  do {
+    s_mutex_capture.lock();
+    capture_state_ = s_capture_state;
+    s_mutex_capture.unlock();
+
+    static bool update = false;
+    if (capture_state_ == capture_started) {
+      if (! update) {
+        viewer->addPointCloud<pcl::PointXYZRGB> (pointcloud_, rgb, "sample cloud");
+        viewer->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
+        update = true;
+      }
+      else {
+        viewer->updatePointCloud<pcl::PointXYZRGB> (pointcloud_, rgb, "sample cloud");
+      }
+
+      viewer->spinOnce (10);
+    }
+  } while(capture_state_ != capture_stopped);
+
+  std::cout << "End of point cloud display thread" << std::endl;
+  return 0;
+}
+#endif
+#endif
+
+#endif
+
+
+int main()
+{
+#if defined(VISP_HAVE_REALSENSE) && defined(VISP_HAVE_CPP11_COMPATIBILITY) && ( defined(VISP_HAVE_X11) || defined(VISP_HAVE_GDI) )
+  try {
+    vpRealSense rs;
+
+    rs.setEnableStream(rs::stream::color, false);
+    rs.open();
+    if ( rs_get_device_name((const rs_device *) rs.getHandler(), nullptr) != std::string("Intel RealSense SR300") ) {
+      std::cout << "This test file is used to test the Intel RealSense SR300 only." << std::endl;
+      return EXIT_SUCCESS;
+    }
+    rs.close();
+
+
+    rs.setEnableStream(rs::stream::color, false);
+    rs.setEnableStream(rs::stream::depth, true);
+    rs.setEnableStream(rs::stream::infrared, false);
+
+    rs.setStreamSettings(rs::stream::depth, vpRealSense::vpRsStreamParams(640, 240, rs::format::z16, 110));
+
+    rs.open();
+    std::cout << "API version: " << rs_get_api_version(nullptr) << std::endl;
+    std::cout << "Firmware: " << rs_get_device_firmware_version((const rs_device *) rs.getHandler(), nullptr) << std::endl;
+    std::cout << "RealSense sensor characteristics: \n" << rs << std::endl;
+
+    vpImage<uint16_t> depth((unsigned int) rs.getIntrinsics(rs::stream::depth).height, (unsigned int) rs.getIntrinsics(rs::stream::depth).width);
+    vpImage<vpRGBa> I_display_depth(depth.getHeight(), depth.getWidth());
+
+
+    double t_begin = 0.0;
+    std::vector<double> time_vector;
+
+#if defined(VISP_HAVE_X11)
+    vpDisplayX dd(I_display_depth, 0, 0, "Depth image");
+#elif defined(VISP_HAVE_GDI)
+    vpDisplayGDI dd(I_display_depth, 0, 0, "Depth image");
+#endif
+
+    //Test depth stream during 10 s
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( NULL, (unsigned char *) depth.bitmap, NULL, NULL );
+      vpImageConvert::createDepthHistogram(depth, I_display_depth);
+
+      vpDisplay::display(I_display_depth);
+      vpDisplay::flush(I_display_depth);
+
+      if (vpDisplay::getClick(I_display_depth, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+    std::cout << "SR300_DEPTH_Z16_640x240_110FPS - Mean time: " << vpMath::getMean(time_vector) << " ms ; Median time: "
+              << vpMath::getMedian(time_vector) << " ms" << std::endl;
+
+    dd.close(I_display_depth);
+
+
+    rs.setEnableStream(rs::stream::color, true);
+    rs.setEnableStream(rs::stream::depth, false);
+    rs.setEnableStream(rs::stream::infrared, false);
+    rs.setStreamSettings(rs::stream::color, vpRealSense::vpRsStreamParams(1920, 1080, rs::format::rgba8, 30));
+    rs.open();
+
+    vpImage<vpRGBa> I_color((unsigned int) rs.getIntrinsics(rs::stream::color).height, (unsigned int) rs.getIntrinsics(rs::stream::color).width);
+
+#if defined(VISP_HAVE_X11)
+    vpDisplayX dc(I_color, 0, 0, "Color image");
+#elif defined(VISP_HAVE_GDI)
+    vpDisplayGDI dc(I_color, 0, 0, "Color image");
+#endif
+
+    time_vector.clear();
+    //Test color stream during 10 s
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( (unsigned char *) I_color.bitmap, NULL, NULL, NULL );
+
+      vpDisplay::display(I_color);
+      vpDisplay::flush(I_color);
+
+      if (vpDisplay::getClick(I_color, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+    std::cout << "SR300_COLOR_RGBA8_1920x1080_30FPS - Mean time: " << vpMath::getMean(time_vector) << " ms ; Median time: "
+              << vpMath::getMedian(time_vector) << " ms" << std::endl;
+
+    dc.close(I_color);
+
+
+    rs.setEnableStream(rs::stream::color, false);
+    rs.setEnableStream(rs::stream::depth, false);
+    rs.setEnableStream(rs::stream::infrared, true);
+    rs.setStreamSettings(rs::stream::infrared, vpRealSense::vpRsStreamParams(640, 480, rs::format::y16, 200));
+    rs.open();
+
+    vpImage<uint16_t> infrared((unsigned int) rs.getIntrinsics(rs::stream::infrared).height, (unsigned int) rs.getIntrinsics(rs::stream::infrared).width);
+    vpImage<unsigned char> I_display_infrared(infrared.getHeight(), infrared.getWidth());
+
+#if defined(VISP_HAVE_X11)
+    vpDisplayX di(I_display_infrared, 0, 0, "Infrared image");
+#elif defined(VISP_HAVE_GDI)
+    vpDisplayGDI di(I_display_infrared, 0, 0, "Infrared image");
+#endif
+
+    time_vector.clear();
+    //Test infrared stream during 10 s
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( NULL, NULL, NULL, (unsigned char *) infrared.bitmap );
+      vpImageConvert::convert(infrared, I_display_infrared);
+
+      vpDisplay::display(I_display_infrared);
+      vpDisplay::flush(I_display_infrared);
+
+      if (vpDisplay::getClick(I_display_infrared, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+    std::cout << "SR300_INFRARED_Y16_640x480_200FPS - Mean time: " << vpMath::getMean(time_vector) << " ms ; Median time: "
+              << vpMath::getMedian(time_vector) << " ms" << std::endl;
+
+    di.close(I_display_infrared);
+
+
+    rs.setEnableStream(rs::stream::color, false);
+    rs.setEnableStream(rs::stream::depth, true);
+    rs.setEnableStream(rs::stream::infrared, false);
+    rs.setStreamSettings(rs::stream::depth, vpRealSense::vpRsStreamParams(640, 480, rs::format::z16, 60));
+    rs.open();
+
+    depth.resize( (unsigned int) rs.getIntrinsics(rs::stream::depth).height, (unsigned int) rs.getIntrinsics(rs::stream::depth).width );
+    I_display_depth.resize( depth.getHeight(), depth.getWidth() );
+
+#if defined(VISP_HAVE_X11)
+    dd.init(I_display_depth, 0, 0, "Depth image");
+#elif defined(VISP_HAVE_GDI)
+    dd.init(I_display_depth, 0, 0, "Depth image");
+#endif
+
+    time_vector.clear();
+    //Test depth stream during 10 s
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( NULL, (unsigned char *) depth.bitmap, NULL, NULL );
+      vpImageConvert::createDepthHistogram(depth, I_display_depth);
+
+      vpDisplay::display(I_display_depth);
+      vpDisplay::flush(I_display_depth);
+
+      if (vpDisplay::getClick(I_display_depth, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+    std::cout << "SR300_DEPTH_Z16_640x480_60FPS - Mean time: " << vpMath::getMean(time_vector) << " ms ; Median time: "
+              << vpMath::getMedian(time_vector) << " ms" << std::endl;
+
+    dd.close(I_display_depth);
+
+
+    rs.setEnableStream(rs::stream::color, false);
+    rs.setEnableStream(rs::stream::depth, true);
+    rs.setEnableStream(rs::stream::infrared, true);
+    rs.setStreamSettings(rs::stream::depth, vpRealSense::vpRsStreamParams(640, 480, rs::format::z16, 60));
+    rs.setStreamSettings(rs::stream::infrared, vpRealSense::vpRsStreamParams(640, 480, rs::format::y8, 60));
+    rs.open();
+
+#if defined(VISP_HAVE_X11)
+    dd.init(I_display_depth, 0, 0, "Depth image");
+    di.init(I_display_infrared, (int) I_display_depth.getWidth(), 0, "Infrared image");
+#elif defined(VISP_HAVE_GDI)
+    dd.init(I_display_depth, 0, 0, "Depth image");
+    di.init(I_display_infrared, I_display_depth.getWidth(), 0, "Infrared image");
+#endif
+
+    time_vector.clear();
+    //Test depth stream during 10 s
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( NULL, (unsigned char *) depth.bitmap, NULL, (unsigned char *) I_display_infrared.bitmap );
+      vpImageConvert::createDepthHistogram(depth, I_display_depth);
+
+      vpDisplay::display(I_display_depth);
+      vpDisplay::display(I_display_infrared);
+      vpDisplay::flush(I_display_depth);
+      vpDisplay::flush(I_display_infrared);
+
+      if (vpDisplay::getClick(I_display_depth, false) || vpDisplay::getClick(I_display_infrared, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+    std::cout << "SR300_DEPTH_Z16_640x480_60FPS + SR300_INFRARED_Y8_640x480_60FPS - Mean time: " << vpMath::getMean(time_vector)
+              << " ms ; Median time: " << vpMath::getMedian(time_vector) << " ms" << std::endl;
+
+
+    dd.close(I_display_depth);
+    di.close(I_display_infrared);
+
+
+
+#ifdef VISP_HAVE_PCL
+    pcl::PointCloud<pcl::PointXYZRGB>::Ptr pointcloud(new pcl::PointCloud<pcl::PointXYZRGB>);
+
+#ifdef USE_THREAD
+    vpThread thread_display_pointcloud(displayPointcloudFunction, (vpThread::Args)&pointcloud);
+#else
+    pcl::visualization::PCLVisualizer::Ptr viewer (new pcl::visualization::PCLVisualizer ("3D Viewer"));
+    pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb(pointcloud);
+    viewer->setBackgroundColor (0, 0, 0);
+    viewer->addCoordinateSystem (1.0);
+    viewer->initCameraParameters ();
+    viewer->setCameraPosition(0,0,-0.5, 0,-1,0);
+    viewer->setSize(640, 480);
+#endif
+
+    rs.setEnableStream(rs::stream::color, true);
+    rs.setEnableStream(rs::stream::depth, true);
+    rs.setEnableStream(rs::stream::infrared, true);
+    rs.setStreamSettings(rs::stream::color, vpRealSense::vpRsStreamParams(640, 480, rs::format::rgba8, 60));
+    rs.setStreamSettings(rs::stream::depth, vpRealSense::vpRsStreamParams(640, 480, rs::format::z16, 60));
+    rs.setStreamSettings(rs::stream::infrared, vpRealSense::vpRsStreamParams(640, 480, rs::format::y8, 60));
+    rs.open();
+
+    I_color.resize(480, 640);
+
+#if defined(VISP_HAVE_X11)
+    dc.init(I_color, 0, 0, "Color image");
+    dd.init(I_display_depth, 0, (int) I_color.getHeight()+80, "Depth image");
+    di.init(I_display_infrared, (int) I_display_depth.getWidth(), 0, "Infrared image");
+#elif defined(VISP_HAVE_GDI)
+    dc.init(I_color, 0, 0, "Color image");
+    dd.init(I_display_depth, 0, (int) I_color.getHeight()+80, "Depth image");
+    di.init(I_display_infrared, (int) I_display_depth.getWidth(), 0, "Infrared image");
+#endif
+
+    time_vector.clear();
+    //Test depth stream during 10 s
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( (unsigned char *) I_color.bitmap, (unsigned char *) depth.bitmap, NULL, pointcloud, (unsigned char *) I_display_infrared.bitmap );
+      vpImageConvert::createDepthHistogram(depth, I_display_depth);
+
+#ifdef VISP_HAVE_PCL
+#ifdef USE_THREAD
+      {
+        vpMutex::vpScopedLock lock(s_mutex_capture);
+        s_capture_state = capture_started;
+      }
+#else
+      static bool update = false;
+        if (! update) {
+          viewer->addPointCloud<pcl::PointXYZRGB> (pointcloud, rgb, "sample cloud");
+          viewer->setPointCloudRenderingProperties (pcl::visualization::PCL_VISUALIZER_POINT_SIZE, 1, "sample cloud");
+          viewer->setPosition( (int) I_color.getWidth()+80, (int) I_color.getHeight()+80) ;
+          update = true;
+        }
+        else {
+          viewer->updatePointCloud<pcl::PointXYZRGB> (pointcloud, rgb, "sample cloud");
+        }
+
+        viewer->spinOnce (10);
+#endif
+#endif
+
+      vpDisplay::display(I_color);
+      vpDisplay::display(I_display_depth);
+      vpDisplay::display(I_display_infrared);
+      vpDisplay::flush(I_color);
+      vpDisplay::flush(I_display_depth);
+      vpDisplay::flush(I_display_infrared);
+
+      if (vpDisplay::getClick(I_color, false) || vpDisplay::getClick(I_display_depth, false) || vpDisplay::getClick(I_display_infrared, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+    std::cout << "SR300_COLOR_RGBA8_640x480_60FPS + SR300_DEPTH_Z16_640x480_60FPS + SR300_INFRARED_Y8_640x480_60FPS - Mean time: " << vpMath::getMean(time_vector)
+              << " ms ; Median time: " << vpMath::getMedian(time_vector) << " ms" << std::endl;
+
+#ifdef VISP_HAVE_PCL
+#ifdef USE_THREAD
+    {
+      vpMutex::vpScopedLock lock(s_mutex_capture);
+      s_capture_state = capture_stopped;
+    }
+#endif
+#endif
+
+    dc.close(I_color);
+    dd.close(I_display_depth);
+    di.close(I_display_infrared);
+
+#endif
+
+
+
+#if VISP_HAVE_OPENCV_VERSION >= 0x020409
+    rs.setEnableStream(rs::stream::color, true);
+    rs.setEnableStream(rs::stream::depth, false);
+    rs.setEnableStream(rs::stream::infrared, true);
+    rs.setStreamSettings(rs::stream::color, vpRealSense::vpRsStreamParams(640, 480, rs::format::bgr8, 60));
+    rs.setStreamSettings(rs::stream::infrared, vpRealSense::vpRsStreamParams(640, 480, rs::format::y8, 200));
+    rs.open();
+
+    cv::Mat color_mat(480, 640, CV_8UC3);
+    cv::Mat infrared_mat(480, 640, CV_8U);
+
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( color_mat.data, NULL, NULL, infrared_mat.data );
+
+      cv::imshow("Color mat", color_mat);
+      cv::imshow("Infrared mat", infrared_mat);
+      char c = cv::waitKey(10);
+      if (c == 27) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+#endif
+
+  } catch(const vpException &e) {
+    std::cerr << "RealSense error " << e.what() << std::endl;
+  } catch(const rs::error & e)  {
+    std::cerr << "RealSense error calling " << e.get_failed_function() << "(" << e.get_failed_args() << "): " << e.what() << std::endl;
+  } catch(const std::exception & e) {
+    std::cerr << e.what() << std::endl;
+  }
+
+#else
+  std::cout << "Install RealSense SDK to make this test working. X11 or GDI are needed also." << std::endl;
+#endif
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Work in progress.

It is possible to configure the streams directly using the `rs::device` obtained by `getHandler()`.
So the proposed changes are just a more convenient way to configure the streams.
The proposed changes can be discussed / reverted.
