### PR TITLE
Fix MBT display when a polygon is not tracked.

### DIFF
--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
@@ -349,6 +349,8 @@ public:
   virtual void track(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages);
 
 protected:
+  //Current computeVVS function hides the base computeVVS but it is intended.
+  //The two following lines should have been added to remove compiler warning.
   using vpMbEdgeMultiTracker::computeVVS;
   using vpMbKltMultiTracker::computeVVS;
 
@@ -362,6 +364,7 @@ protected:
       std::map<std::string, unsigned int> &mapOfNumberOfCylinders,
       std::map<std::string, unsigned int> &mapOfNumberOfCircles);
 
+  //Same thing as computeVVS
   using vpMbKltMultiTracker::postTracking;
 
   virtual void postTracking(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
@@ -321,6 +321,8 @@ public:
 
   virtual void setScanLineVisibilityTest(const bool &v);
 
+  virtual void setUseEdgeTracking(const std::string &name, const bool &useEdgeTracking);
+
   virtual void track(const vpImage<unsigned char> &I);
   virtual void track(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2);
   virtual void track(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages);

--- a/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
@@ -2774,6 +2774,11 @@ void vpMbEdgeMultiTracker::setScales(const std::vector<bool>& scale) {
   }
 }
 
+/*!
+  Use Scanline algorithm for visibility tests
+
+  \param v : True to use it, False otherwise
+*/
 void vpMbEdgeMultiTracker::setScanLineVisibilityTest(const bool &v) {
   //Set general setScanLineVisibilityTest
   vpMbTracker::setScanLineVisibilityTest(v);
@@ -2781,6 +2786,19 @@ void vpMbEdgeMultiTracker::setScanLineVisibilityTest(const bool &v) {
   for(std::map<std::string, vpMbEdgeTracker *>::const_iterator it = m_mapOfEdgeTrackers.begin();
       it != m_mapOfEdgeTrackers.end(); ++it) {
     it->second->setScanLineVisibilityTest(v);
+  }
+}
+
+/*!
+  Set if the polygons that have the given name have to be considered during the tracking phase.
+
+  \param name : name of the polygon(s).
+  \param useEdgeTracking : True if it has to be considered, false otherwise.
+*/
+void vpMbEdgeMultiTracker::setUseEdgeTracking(const std::string &name, const bool &useEdgeTracking) {
+  for(std::map<std::string, vpMbEdgeTracker *>::const_iterator it = m_mapOfEdgeTrackers.begin();
+      it != m_mapOfEdgeTrackers.end(); ++it) {
+    it->second->setUseEdgeTracking(name, useEdgeTracking);
   }
 }
 

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceCircle.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceCircle.cpp
@@ -287,7 +287,7 @@ vpMbtDistanceCircle::display(const vpImage<unsigned char>&I, const vpHomogeneous
                              const vpCameraParameters &camera, const vpColor col, const unsigned int thickness,
                              const bool displayFullModel )
 {
-  if(isvisible || displayFullModel){
+  if( (isvisible && isTrackedCircle) || displayFullModel){
     // Perspective projection
     circle->changeFrame(cMo);
 
@@ -319,7 +319,7 @@ vpMbtDistanceCircle::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix
                              const vpCameraParameters &camera, const vpColor col,
                              const unsigned int thickness, const bool displayFullModel)
 {
-  if(isvisible || displayFullModel){
+  if( (isvisible && isTrackedCircle) || displayFullModel){
     // Perspective projection
     circle->changeFrame(cMo);
 

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceCylinder.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceCylinder.cpp
@@ -460,7 +460,7 @@ vpMbtDistanceCylinder::display(const vpImage<unsigned char>&I, const vpHomogeneo
                                const vpCameraParameters&camera, const vpColor col, const unsigned int thickness,
                                const bool displayFullModel)
 {
-  if(isvisible || displayFullModel){
+  if( (isvisible && isTrackedCylinder) || displayFullModel){
     // Perspective projection
     p1->changeFrame(cMo);
     p2->changeFrame(cMo);
@@ -524,7 +524,7 @@ vpMbtDistanceCylinder::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatr
                                const vpCameraParameters &camera, const vpColor col, const unsigned int thickness,
                                const bool displayFullModel)
 {
-  if(isvisible || displayFullModel){
+  if( (isvisible && isTrackedCylinder) || displayFullModel){
     // Perspective projection
     p1->changeFrame(cMo);
     p2->changeFrame(cMo);

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
@@ -625,7 +625,7 @@ void
 vpMbtDistanceLine::display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo,
                            const vpCameraParameters &camera, const vpColor col, const unsigned int thickness, const bool displayFullModel)
 {
-  if(isvisible || displayFullModel){
+  if( (isvisible && isTrackedLine) || displayFullModel){
     p1->changeFrame(cMo);
     p2->changeFrame(cMo);
 
@@ -681,7 +681,7 @@ vpMbtDistanceLine::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &
                            const vpCameraParameters &camera, const vpColor col,
                            const unsigned int thickness, const bool displayFullModel)
 {
-  if(isvisible || displayFullModel){
+  if( (isvisible && isTrackedLine) || displayFullModel){
     p1->changeFrame(cMo);
     p2->changeFrame(cMo);
 

--- a/modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
@@ -524,7 +524,7 @@ void
 vpMbtDistanceKltPoints::display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &/*cMo*/, const vpCameraParameters &camera,
                                 const vpColor col, const unsigned int thickness, const bool displayFullModel)
 {
-    if(polygon->isVisible() || displayFullModel)
+    if( (polygon->isVisible() && isTrackedKltPoints) || displayFullModel)
     {
       std::vector<std::pair<vpPoint,unsigned int> > roi;
       polygon->getPolygonClipped(roi);
@@ -563,7 +563,7 @@ void
 vpMbtDistanceKltPoints::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &/*cMo*/, const vpCameraParameters &camera,
                                 const vpColor col, const unsigned int thickness, const bool displayFullModel)
 {
-  if(polygon->isVisible() || displayFullModel)
+  if( (polygon->isVisible() && isTrackedKltPoints) || displayFullModel)
   {
     std::vector<std::pair<vpPoint,unsigned int> > roi;
     polygon->getPolygonClipped(roi);


### PR DESCRIPTION
- Fix model-based tracker display when a polygon is not tracked. 

- Add missing vpMbEdgeMultiTracker::setUseEdgeTracking function.