### PR TITLE
Fix recursive load cao model.

### DIFF
--- a/modules/core/include/visp3/core/vpIoTools.h
+++ b/modules/core/include/visp3/core/vpIoTools.h
@@ -184,13 +184,14 @@ public:
   	'/';
   #endif
 
+  static std::string getAbsolutePathname(const std::string &pathname);
   static std::string getFileExtension(const std::string &pathname, const bool checkFile=false);
   static std::string getName(const std::string &pathname);
   static std::string getNameWE(const std::string &pathname);
   static std::string getParent(const std::string& pathname);
-  static std::string getRealPath(const std::string &pathname);
   static std::string createFilePath(const std::string& parent, const std::string child);
   static bool isAbsolutePathname(const std::string& pathname);
+  static bool isSamePathname(const std::string& pathname1, const std::string& pathname2);
   static std::pair<std::string, std::string> splitDrive(const std::string& pathname);
   static std::vector<std::string> splitChain(const std::string & chain, const std::string & sep);
 

--- a/modules/core/include/visp3/core/vpIoTools.h
+++ b/modules/core/include/visp3/core/vpIoTools.h
@@ -188,6 +188,7 @@ public:
   static std::string getName(const std::string &pathname);
   static std::string getNameWE(const std::string &pathname);
   static std::string getParent(const std::string& pathname);
+  static std::string getRealPath(const std::string &pathname);
   static std::string createFilePath(const std::string& parent, const std::string child);
   static bool isAbsolutePathname(const std::string& pathname);
   static std::pair<std::string, std::string> splitDrive(const std::string& pathname);

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -1268,6 +1268,26 @@ std::string vpIoTools::getParent(const std::string& pathname)
 }
 
 /*!
+  Returns the real path using realpath on Unix systems, otherwise returns the same path.
+  \return Returns an absolute pathname that names the same file,
+  whose resolution does not involve '.', '..', or symbolic links.
+ */
+std::string vpIoTools::getRealPath(const std::string &pathname) {
+  std::string real_path_str = pathname;
+
+#if defined(__unix__)
+  char *real_path = realpath(pathname.c_str(), NULL);
+
+  if (real_path != NULL) {
+    real_path_str = real_path;
+    delete real_path;
+  }
+#endif
+
+  return real_path_str;
+}
+
+/*!
   Return the file path that corresponds to the concatenated
   \e parent and \e child string files
   by adding the corresponding separator for unix or windows.

--- a/modules/core/test/tools/io/testIoTools.cpp
+++ b/modules/core/test/tools/io/testIoTools.cpp
@@ -36,11 +36,9 @@
  *****************************************************************************/
 
 /*!
-
   \example testIoTools.cpp
 
   \brief Test functions in IoTools.
-
 */
 
 #include <stdio.h>
@@ -52,14 +50,14 @@
 int
 main(int argc, const char ** argv)
 {
-	const char c = vpIoTools::separator;
-	if(c == '\\')
-	{
-		std::cout << "The directory separator character is '" << c << "' (Windows platform)." << std::endl;
-	}
-	else {
-		std::cout << "The directory separator character is '" << c << "' (Unix like platform)." << std::endl;
-	}
+  const char c = vpIoTools::separator;
+  if(c == '\\')
+  {
+    std::cout << "The directory separator character is '" << c << "' (Windows platform)." << std::endl;
+  }
+  else {
+    std::cout << "The directory separator character is '" << c << "' (Unix like platform)." << std::endl;
+  }
 
 #if defined(_WIN32)
   std::string pathname = "C:\\Program Files (x86)\\Java\\jre7";
@@ -67,65 +65,65 @@ main(int argc, const char ** argv)
   std::string pathname = "/usr/bin/java";
 #endif
 
-	std::cout << "Parent of " << pathname << " is " << vpIoTools::getParent(pathname) << std::endl;
-	std::cout << "Name of " << pathname << " is " << vpIoTools::getName(pathname) << std::endl;
+  std::cout << "Parent of " << pathname << " is " << vpIoTools::getParent(pathname) << std::endl;
+  std::cout << "Name of " << pathname << " is " << vpIoTools::getName(pathname) << std::endl;
 
 
-	if(argc == 3 && std::string(argv[1]) == std::string("-i"))
-	{
-		std::cout << "Parent of " << argv[2] << " is " << vpIoTools::getParent(argv[2]) << std::endl;
-		std::cout << "Name of " << argv[2] << " is " << vpIoTools::getName(argv[2]) << std::endl;
-	}
+  if(argc == 3 && std::string(argv[1]) == std::string("-i"))
+  {
+    std::cout << "Parent of " << argv[2] << " is " << vpIoTools::getParent(argv[2]) << std::endl;
+    std::cout << "Name of " << argv[2] << " is " << vpIoTools::getName(argv[2]) << std::endl;
+  }
 
-	std::string windowsPathnameStyle = "\\usr\\bin\\java";
-	std::cout << "Parent of " << windowsPathnameStyle << " is " << vpIoTools::getParent(windowsPathnameStyle) << std::endl;
-	std::cout << "Name of " << windowsPathnameStyle << " is " << vpIoTools::getName(windowsPathnameStyle) << std::endl;
+  std::string windowsPathnameStyle = "\\usr\\bin\\java";
+  std::cout << "Parent of " << windowsPathnameStyle << " is " << vpIoTools::getParent(windowsPathnameStyle) << std::endl;
+  std::cout << "Name of " << windowsPathnameStyle << " is " << vpIoTools::getName(windowsPathnameStyle) << std::endl;
 
-	std::string parent = "/usr/toto/", child = "\\blabla\\java";
-	std::cout << "parent=" << vpIoTools::path(parent) << " ; child=" << vpIoTools::path(child) << std::endl;
-	std::cout << "Create file path from parent=" << parent << " and child=" << child << " is "
-			<< vpIoTools::createFilePath(parent, child) << std::endl;
+  std::string parent = "/usr/toto/", child = "\\blabla\\java";
+  std::cout << "parent=" << vpIoTools::path(parent) << " ; child=" << vpIoTools::path(child) << std::endl;
+  std::cout << "Create file path from parent=" << parent << " and child=" << child << " is "
+            << vpIoTools::createFilePath(parent, child) << std::endl;
 
-	std::string expandPath = "~/Documents/fictional directory/fictional file";
-	std::cout << "Path for " << expandPath << " is " << vpIoTools::path(expandPath) << std::endl;
+  std::string expandPath = "~/Documents/fictional directory/fictional file";
+  std::cout << "Path for " << expandPath << " is " << vpIoTools::path(expandPath) << std::endl;
 
-	std::cout << "Test get name with an empty pathname=" << vpIoTools::getName("") << std::endl;
-	std::cout << "Get parent with an empty pathname=" << vpIoTools::getParent("") << std::endl;
-	std::cout << "Get parent with a filename=" << vpIoTools::getParent("my_file.txt") << std::endl;
-	expandPath = "~/Documents/fictional dir/fictional file.txt";
-	std::cout << "Get name with a unix expand pathname " << expandPath << "=" << vpIoTools::getName(expandPath) << std::endl;
-	std::cout << "Get parent with a unix expand pathname " << expandPath << "=" << vpIoTools::getParent(expandPath) << std::endl;
-
-
-	pathname = "c:/dir";
-	std::cout << "pathname=" << vpIoTools::splitDrive(pathname).first << " ; " << vpIoTools::splitDrive(pathname).second << std::endl;
-
-	std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
-
-	pathname = "c:/dir/fictional directory/fictional file.txt";
-	std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
-
-	pathname = "/home/user/Documents/fictional directory/fictional file.txt";
-	std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
-
-	pathname = "~/Documents/fictional directory/fictional file.txt";
-	std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
-
-	pathname = "fictional directory/fictional file.txt";
-	std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
+  std::cout << "Test get name with an empty pathname=" << vpIoTools::getName("") << std::endl;
+  std::cout << "Get parent with an empty pathname=" << vpIoTools::getParent("") << std::endl;
+  std::cout << "Get parent with a filename=" << vpIoTools::getParent("my_file.txt") << std::endl;
+  expandPath = "~/Documents/fictional dir/fictional file.txt";
+  std::cout << "Get name with a unix expand pathname " << expandPath << "=" << vpIoTools::getName(expandPath) << std::endl;
+  std::cout << "Get parent with a unix expand pathname " << expandPath << "=" << vpIoTools::getParent(expandPath) << std::endl;
 
 
-	//Test vpIoTools::splitDrive
+  pathname = "c:/dir";
+  std::cout << "pathname=" << vpIoTools::splitDrive(pathname).first << " ; " << vpIoTools::splitDrive(pathname).second << std::endl;
+
+  std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
+
+  pathname = "c:/dir/fictional directory/fictional file.txt";
+  std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
+
+  pathname = "/home/user/Documents/fictional directory/fictional file.txt";
+  std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
+
+  pathname = "~/Documents/fictional directory/fictional file.txt";
+  std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
+
+  pathname = "fictional directory/fictional file.txt";
+  std::cout << "isAbsolutePath of " << pathname << "=" << vpIoTools::isAbsolutePathname(pathname) << std::endl;
+
+
+  //Test vpIoTools::splitDrive
   unsigned int nbFail = 0, nbOk = 0;
 #if defined(_WIN32)
-	if(strcmp(vpIoTools::splitDrive("c:\\foo\\bar").first.c_str(), "c:") == 0) {
-	  nbOk++;
-	}
-	else {
-	  nbFail++;
-	  std::cout << "Fail=" << vpIoTools::splitDrive("c:\\foo\\bar").first << " should be=c:" << std::endl;
+  if(strcmp(vpIoTools::splitDrive("c:\\foo\\bar").first.c_str(), "c:") == 0) {
+    nbOk++;
   }
-	if(strcmp(vpIoTools::splitDrive("c:\\foo\\bar").second.c_str(), "\\foo\\bar") == 0) {
+  else {
+    nbFail++;
+    std::cout << "Fail=" << vpIoTools::splitDrive("c:\\foo\\bar").first << " should be=c:" << std::endl;
+  }
+  if(strcmp(vpIoTools::splitDrive("c:\\foo\\bar").second.c_str(), "\\foo\\bar") == 0) {
     nbOk++;
   }
   else {
@@ -133,7 +131,7 @@ main(int argc, const char ** argv)
     std::cout << "Fail=" << vpIoTools::splitDrive("c:\\foo\\bar").second << " should be=\\foo\\bar" << std::endl;
   }
 
-	if(strcmp(vpIoTools::splitDrive("c:/foo/bar").first.c_str(), "c:") == 0) {
+  if(strcmp(vpIoTools::splitDrive("c:/foo/bar").first.c_str(), "c:") == 0) {
     nbOk++;
   }
   else {
@@ -241,6 +239,11 @@ main(int argc, const char ** argv)
   }
 
   std::cout << "Test vpIoTools::splitDrive (Win32) - passed: " << nbOk << "/" << (nbOk+nbFail) << std::endl;
+
+  if (nbFail > 0) {
+    std::cerr << "Failed test: vpIoTools::splitDrive (Win32)" << std::endl;
+    return EXIT_FAILURE;
+  }
 #endif
 
 
@@ -330,6 +333,11 @@ main(int argc, const char ** argv)
   }
 
   std::cout << "Test vpIoTools::getFileExtension (WIN32 platform) - passed: " << nbOk << "/" << (nbOk+nbFail) << std::endl;
+
+  if (nbFail > 0) {
+    std::cerr << "Failed test: vpIoTools::getFileExtension (WIN32 platform)" << std::endl;
+    return EXIT_FAILURE;
+  }
 #else
   nbFail = 0;
   nbOk = 0;
@@ -434,7 +442,102 @@ main(int argc, const char ** argv)
 #endif
 
 
-	std::cout << std::endl << "End" << std::endl;
+  //Test isSamePathname()
+#if defined(_WIN32)
+  std::string path1 = "tmp/test/file.txt";
+  std::string path2 = "tmp/test/../test/file.txt";
 
-	return 0;
+  nbOk = 0;
+  nbFail = 0;
+  bool res = false;
+
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  path1 = ".\\tmp/test/file.txt";
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  path1 = ".\\tmp/test\\../fake dir/..\\test\\file.txt";
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  path2 = "/tmp/test/../test/file.txt";
+  res = vpIoTools::isSamePathname(path1, path2); //False
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk : nbOk+1;
+  nbFail = res ? nbFail+1 : nbFail;
+
+  std::cout << "Test vpIoTools::isSamePathname (WIN32 platform) - passed: " << nbOk << "/" << (nbOk+nbFail) << std::endl;
+  if (nbFail > 0) {
+    std::cerr << "Failed test: vpIoTools::isSamePathname (WIN32 platform)" << std::endl;
+    return EXIT_FAILURE;
+  }
+#else
+  //realpath requires not fake path, so we create dummy file and directories
+
+  // Get the user login name
+  std::string username = "";
+  vpIoTools::getUserName(username);
+  vpIoTools::makeDirectory("/tmp/" + username);
+  vpIoTools::makeDirectory("/tmp/" + username + "/test");
+  vpIoTools::makeDirectory("/tmp/" + username + "/dummy dir");
+
+  std::string path1 = "/tmp/" + username + "/test/file.txt";
+  std::string path2 = "/tmp/" + username + "/test/../test/file.txt";
+  std::ofstream dummy_file(path1.c_str());
+  if (!dummy_file.is_open()) {
+    return EXIT_SUCCESS;
+  }
+  dummy_file.close();
+
+  nbOk = 0;
+  nbFail = 0;
+  bool res = false;
+
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  path1 = "\\tmp/" + username + "/./test/file.txt";
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  path1 = "\\tmp/" + username + "/test\\../dummy dir/..\\test\\file.txt";
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  path2 = "/tmp/" + username + "/test/../test";
+  res = vpIoTools::isSamePathname(path1, path2); //False
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk : nbOk+1;
+  nbFail = res ? nbFail+1 : nbFail;
+
+  path1 = "/tmp/" + username + "/test/";
+  res = vpIoTools::isSamePathname(path1, path2); //True
+  std::cout << "vpIoTools::isSamePathname(" << path1 << ", " << path2 << ")? " << res << std::endl;
+  nbOk = res ? nbOk+1 : nbOk;
+  nbFail = res ? nbFail : nbFail+1;
+
+  std::cout << "Test vpIoTools::isSamePathname (Unix platform) - passed: " << nbOk << "/" << (nbOk+nbFail) << std::endl;
+  if (nbFail > 0) {
+    std::cerr << "Failed test: vpIoTools::isSamePathname (Unix platform)" << std::endl;
+    return EXIT_FAILURE;
+  }
+#endif
+
+
+  std::cout << std::endl << "End" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -1324,38 +1324,35 @@ vpMbTracker::loadCAOModel(const std::string& modelFile,
           if(!line.compare(0, prefix.size(), prefix)) {
 
               //Get the loaded model pathname
-              std::string headerPathname = line.substr(6);
-              size_t firstIndex = headerPathname.find_first_of("\")");
-              headerPathname = headerPathname.substr(0, firstIndex);
+              std::string headerPathRead = line.substr(6);
+              size_t firstIndex = headerPathRead.find_first_of("\")");
+              headerPathRead = headerPathRead.substr(0, firstIndex);
 
-              std::string headerPath = headerPathname;
-              if(!vpIoTools::isAbsolutePathname(headerPathname)) {
+              std::string headerPath = headerPathRead;
+              if(!vpIoTools::isAbsolutePathname(headerPathRead)) {
                   std::string parentDirectory = vpIoTools::getParent(modelFile);
-                  headerPath = vpIoTools::createFilePath(parentDirectory, headerPathname);
+                  headerPath = vpIoTools::createFilePath(parentDirectory, headerPathRead);
               }
+
+              //Normalize path
+              headerPath = vpIoTools::path(headerPath);
+
+              //Get real path
+              headerPath = vpIoTools::getRealPath(headerPath);
 
               bool cyclic = false;
-              std::string headerModelFilename = vpIoTools::getName(headerPath);
-              if (!headerModelFilename.compare(vpIoTools::getName(modelFile))) {
+              for (std::vector<std::string>::const_iterator it = vectorOfModelFilename.begin();
+                   it != vectorOfModelFilename.end() && !cyclic; ++it) {
+                if (headerPath == *it) {
                   cyclic = true;
-              }
-
-              for (std::vector<std::string>::const_iterator it =
-                      vectorOfModelFilename.begin();
-                      it != vectorOfModelFilename.end() - 1 && !cyclic;
-                      ++it) {
-                  std::string loadedModelFilename = vpIoTools::getName(*it);
-                  if (!headerModelFilename.compare(loadedModelFilename)) {
-                      cyclic = true;
-                  }
+                }
               }
 
               if (!cyclic) {
-                  if (vpIoTools::checkFilename(modelFile)) {
+                  if (vpIoTools::checkFilename(headerPath)) {
                       loadCAOModel(headerPath, vectorOfModelFilename, startIdFace, verbose, false);
                   } else {
-                      throw vpException(vpException::ioError,
-                              "file cannot be open");
+                      throw vpException(vpException::ioError, "file cannot be open");
                   }
               } else {
                   std::cout << "WARNING Cyclic dependency detected with file "

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -1338,7 +1338,7 @@ vpMbTracker::loadCAOModel(const std::string& modelFile,
         headerPath = vpIoTools::path(headerPath);
 
         //Get real path
-        headerPath = vpIoTools::getRealPath(headerPath);
+        headerPath = vpIoTools::getAbsolutePathname(headerPath);
 
         bool cyclic = false;
         for (std::vector<std::string>::const_iterator it = vectorOfModelFilename.begin();


### PR DESCRIPTION
Before, a cyclic dependency was detected using only the name of the file.
Now, we use the full absolute path instead.
Works on Unix system using [realpath](http://man7.org/linux/man-pages/man3/realpath.3.html) and [GetFullPathName](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364963(v=vs.85).aspx) on Windows.