### PR TITLE
Fix MSVC compilation issues.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,10 @@ VP_CHECK_PACKAGE(IsNaN)
 VP_CHECK_PACKAGE(IsInf)
 # Find Round (should be after USE_CPP11)
 VP_CHECK_PACKAGE(Round)
+# Find Erfc
+VP_CHECK_PACKAGE(Erfc)
+# Find Strtof
+VP_CHECK_PACKAGE(Strtof)
 
 #----------------------------------------------------------------------
 # For Dart server and tests
@@ -693,6 +697,12 @@ VP_SET(VISP_HAVE_FUNC__FINITE TRUE IF HAVE_FUNC__FINITE) # for header vpConfig.h
 VP_SET(VISP_HAVE_FUNC_ROUND TRUE IF HAVE_FUNC_ROUND) # for header vpConfig.h
 # Find std::round function (cmath)
 VP_SET(VISP_HAVE_FUNC_STD_ROUND TRUE IF HAVE_FUNC_STD_ROUND) # for header vpConfig.h
+# Find erfc function (math.h)
+VP_SET(VISP_HAVE_FUNC_ERFC TRUE IF HAVE_FUNC_ERFC) # for header vpConfig.h
+# Find std::erfc function (cmath)
+VP_SET(VISP_HAVE_FUNC_STD_ERFC TRUE IF HAVE_FUNC_STD_ERFC) # for header vpConfig.h
+# Find strtof function (stdlib.h)
+VP_SET(VISP_HAVE_FUNC_STRTOF TRUE IF HAVE_FUNC_STRTOF) # for header vpConfig.h
 
 VP_SET(VISP_HAVE_ACCESS_TO_NAS TRUE IF NAS_FOUND) # for header vpConfig.h
 VP_SET(VISP_BUILD_DEPRECATED_FUNCTIONS TRUE IF BUILD_DEPRECATED_FUNCTIONS) # for header vpConfig.h

--- a/cmake/FindErfc.cmake
+++ b/cmake/FindErfc.cmake
@@ -1,0 +1,52 @@
+#############################################################################
+#
+# This file is part of the ViSP software.
+# Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+#
+# This software is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# ("GPL") version 2 as published by the Free Software Foundation.
+# See the file LICENSE.txt at the root directory of this source
+# distribution for additional information about the GNU GPL.
+#
+# For using ViSP with software that can not be combined with the GNU
+# GPL, please contact Inria about acquiring a ViSP Professional
+# Edition License.
+#
+# See http://visp.inria.fr for more information.
+#
+# This software was developed at:
+# Inria Rennes - Bretagne Atlantique
+# Campus Universitaire de Beaulieu
+# 35042 Rennes Cedex
+# France
+#
+# If you have questions regarding the use of this file, please contact
+# Inria at visp@inria.fr
+#
+# This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+# WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Description:
+# Try to find erfc function.
+#
+# Authors:
+# Souriya Trinh
+#
+#############################################################################
+
+include(CheckCXXSourceCompiles)
+
+macro(check_math_expr _expr _var)
+    check_cxx_source_compiles("
+#include <cmath>
+int main(int argc, char ** argv)
+{
+    (void)${_expr};
+    return 0;
+}
+" ${_var})
+endmacro()
+
+check_math_expr("erfc(1.0)"        HAVE_FUNC_ERFC)
+check_math_expr("std::erfc(1.0)"   HAVE_FUNC_STD_ERFC)

--- a/cmake/FindErfc.cmake
+++ b/cmake/FindErfc.cmake
@@ -38,6 +38,9 @@
 include(CheckCXXSourceCompiles)
 
 macro(check_math_expr _expr _var)
+    if(USE_CPP11)
+      set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
+    endif()
     check_cxx_source_compiles("
 #include <cmath>
 int main(int argc, char ** argv)

--- a/cmake/FindIsInf.cmake
+++ b/cmake/FindIsInf.cmake
@@ -40,7 +40,7 @@ include(CheckIncludeFiles)
 include(CheckCXXSourceCompiles)
 
 macro(check_math_expr _expr _var)
-    if(CPP11_CXX_FLAGS)
+    if(USE_CPP11)
       set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
     endif()
     check_cxx_source_compiles("
@@ -58,7 +58,7 @@ check_math_expr("isinf(1.0)"        HAVE_FUNC_ISINF)
 check_math_expr("std::isinf(1.0)"   HAVE_FUNC_STD_ISINF)
 
 if(HAVE_FLOAT_H)
-    if(CPP11_CXX_FLAGS)
+    if(USE_CPP11)
       set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
     endif()
     # The version that should work with MSVC

--- a/cmake/FindIsNaN.cmake
+++ b/cmake/FindIsNaN.cmake
@@ -40,7 +40,7 @@ include(CheckIncludeFiles)
 include(CheckCXXSourceCompiles)
 
 macro(check_math_expr _expr _var)
-    if(CPP11_CXX_FLAGS)
+    if(USE_CPP11)
       set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
     endif()
     check_cxx_source_compiles("
@@ -58,7 +58,7 @@ check_math_expr("isnan(1.0)"        HAVE_FUNC_ISNAN)
 check_math_expr("std::isnan(1.0)"   HAVE_FUNC_STD_ISNAN)
 
 if(HAVE_FLOAT_H)
-    if(CPP11_CXX_FLAGS)
+    if(USE_CPP11)
       set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
     endif()
     # The version that should work with MSVC

--- a/cmake/FindRound.cmake
+++ b/cmake/FindRound.cmake
@@ -40,7 +40,7 @@ include(CheckIncludeFiles)
 include(CheckCXXSourceCompiles)
 
 macro(check_math_expr1 _expr _var)
-    if(CPP11_CXX_FLAGS)
+    if(USE_CPP11)
       set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
     endif()
     check_cxx_source_compiles("
@@ -54,7 +54,7 @@ int main(int argc, char ** argv)
 endmacro()
 
 macro(check_math_expr2 _expr _var)
-    if(CPP11_CXX_FLAGS)
+    if(USE_CPP11)
       set(CMAKE_REQUIRED_FLAGS ${CPP11_CXX_FLAGS})
     endif()
     check_cxx_source_compiles("

--- a/cmake/FindStrtof.cmake
+++ b/cmake/FindStrtof.cmake
@@ -1,0 +1,51 @@
+#############################################################################
+#
+# This file is part of the ViSP software.
+# Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+#
+# This software is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# ("GPL") version 2 as published by the Free Software Foundation.
+# See the file LICENSE.txt at the root directory of this source
+# distribution for additional information about the GNU GPL.
+#
+# For using ViSP with software that can not be combined with the GNU
+# GPL, please contact Inria about acquiring a ViSP Professional
+# Edition License.
+#
+# See http://visp.inria.fr for more information.
+#
+# This software was developed at:
+# Inria Rennes - Bretagne Atlantique
+# Campus Universitaire de Beaulieu
+# 35042 Rennes Cedex
+# France
+#
+# If you have questions regarding the use of this file, please contact
+# Inria at visp@inria.fr
+#
+# This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+# WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+#
+# Description:
+# Try to find erfc function.
+#
+# Authors:
+# Souriya Trinh
+#
+#############################################################################
+
+include(CheckCXXSourceCompiles)
+
+macro(check_expr _expr _var)
+    check_cxx_source_compiles("
+#include <stdlib.h>
+int main(int argc, char ** argv)
+{
+    (void)${_expr};
+    return 0;
+}
+" ${_var})
+endmacro()
+
+check_expr("strtof(\"  -0.0000000123junk\", NULL)"        HAVE_FUNC_STRTOF)

--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -370,6 +370,15 @@
 // Defined if std::round function is available
 #cmakedefine VISP_HAVE_FUNC_STD_ROUND
 
+// Defined if erfc function is available
+#cmakedefine VISP_HAVE_FUNC_ERFC
+
+// Defined if std::erfc function is available
+#cmakedefine VISP_HAVE_FUNC_STD_ERFC
+
+// Defined if strtof function is available
+#cmakedefine VISP_HAVE_FUNC_STRTOF
+
 // Handle portable symbol export.
 // Defining manually which symbol should be exported is required
 // under Windows whether MinGW or MSVC is used.

--- a/modules/core/include/visp3/core/vpRobust.h
+++ b/modules/core/include/visp3/core/vpRobust.h
@@ -45,6 +45,7 @@
 #ifndef CROBUST_HH
 #define CROBUST_HH
 
+#include <visp3/core/vpConfig.h>
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpMath.h>
 
@@ -181,6 +182,7 @@ public:
   double constrainedChiHuber(double x);
   //@}
   
+#if !defined(VISP_HAVE_FUNC_ERFC) && !defined(VISP_HAVE_FUNC_STD_ERFC)
   //---------------------------------
   // Mathematic functions used to calculate the Expectation
   //---------------------------------
@@ -192,6 +194,7 @@ public:
   void gcf(double *gammcf, double a, double x, double *gln);
   double gammln(double xx);
   //@}
+#endif
   
   /** @name Sort function  */
   //@{

--- a/modules/core/src/math/robust/vpRobust.cpp
+++ b/modules/core/src/math/robust/vpRobust.cpp
@@ -414,17 +414,36 @@ vpRobust::scale(vpRobustEstimatorType method, vpColVector &x)
   for(unsigned int i=0; i<n; i++)
   {
     double chiTmp = constrainedChi(method, x[i]);
+#if defined(VISP_HAVE_FUNC_STD_ERFC)
+    Expectation += chiTmp*std::erfc(chiTmp);
+#elif defined(VISP_HAVE_FUNC_ERFC)
     Expectation += chiTmp*erfc(chiTmp);
+#else
+    Expectation += chiTmp*(1-erf(chiTmp));
+#endif
+
     Sum_chi += chiTmp;
 
 #ifdef VP_DEBUG
 #if VP_DEBUG_MODE == 3
     {
+#if defined(VISP_HAVE_FUNC_STD_ERFC)
+      std::cout << "erf = " << std::erfc(chiTmp) << std::endl;
+#elif defined(VISP_HAVE_FUNC_ERFC)
       std::cout << "erf = " << erfc(chiTmp) << std::endl;
+#else
+      std::cout << "erf = " << (1-erf(chiTmp)) << std::endl;
+#endif
       std::cout << "x[i] = " << x[i] <<std::endl;
       std::cout << "chi = " << chiTmp << std::endl;
       std::cout << "Sum chi = " << chiTmp*vpMath::sqr(sig_prev) << std::endl;
+#if defined(VISP_HAVE_FUNC_STD_ERFC)
+      std::cout << "Expectation = " << chiTmp*std::erfc(chiTmp) << std::endl;
+#elif defined(VISP_HAVE_FUNC_ERFC)
       std::cout << "Expectation = " << chiTmp*erfc(chiTmp) << std::endl;
+#else
+      std::cout << "Expectation = " << chiTmp*(1-erf(chiTmp)) << std::endl;
+#endif
       //getchar();
     }
 #endif
@@ -463,17 +482,35 @@ vpRobust::simultscale(vpColVector &x)
   {
 
     double chiTmp = simult_chi_huber(x[i]);
+#if defined(VISP_HAVE_FUNC_STD_ERFC)
+    Expectation += chiTmp*std::erfc(chiTmp);
+#elif defined(VISP_HAVE_FUNC_ERFC)
     Expectation += chiTmp*erfc(chiTmp);
+#else
+    Expectation += chiTmp*(1-erf(chiTmp));
+#endif
     Sum_chi += chiTmp;
 
 #ifdef VP_DEBUG
 #if VP_DEBUG_MODE == 3
     {
+#if defined(VISP_HAVE_FUNC_STD_ERFC)
+      std::cout << "erf = " << std::erfc(chiTmp) << std::endl;
+#elif defined(VISP_HAVE_FUNC_ERFC)
       std::cout << "erf = " << erfc(chiTmp) << std::endl;
+#else
+      std::cout << "erf = " << (1-erf(chiTmp)) << std::endl;
+#endif
       std::cout << "x[i] = " << x[i] <<std::endl;
       std::cout << "chi = " << chiTmp << std::endl;
       std::cout << "Sum chi = " << chiTmp*vpMath::sqr(sig_prev) << std::endl;
+#if defined(VISP_HAVE_FUNC_STD_ERFC)
+      std::cout << "Expectation = " << chiTmp*std::erfc(chiTmp) << std::endl;
+#elif defined(VISP_HAVE_FUNC_ERFC)
       std::cout << "Expectation = " << chiTmp*erfc(chiTmp) << std::endl;
+#else
+      std::cout << "Expectation = " << chiTmp*(1-erf(chiTmp)) << std::endl;
+#endif
       //getchar();
     }
 #endif
@@ -761,6 +798,7 @@ vpRobust::select(vpColVector &a, int l, int r, int k)
 }
 
 
+#if !defined(VISP_HAVE_FUNC_ERFC) && !defined(VISP_HAVE_FUNC_STD_ERFC)
 double
 vpRobust::erf(double x)
 {
@@ -869,6 +907,7 @@ vpRobust::gammln(double xx)
   }
   return -tmp+log(2.50662827465*ser);
 }
+#endif
 
 
 

--- a/modules/core/src/tools/xml/vpXmlParser.cpp
+++ b/modules/core/src/tools/xml/vpXmlParser.cpp
@@ -261,7 +261,11 @@ vpXmlParser::xmlReadFloatChild (xmlDocPtr doc, xmlNodePtr node)
   float val_float;
 
   val_char = (char *) xmlNodeListGetString(doc, node ->xmlChildrenNode, 1);
+#if defined(VISP_HAVE_FUNC_STRTOF)
   val_float = strtof ((char *)val_char, &control_convert);
+#else
+  val_float = (float) strtod ((char *)val_char, &control_convert);
+#endif
 
   if (val_char == control_convert){
     xmlFree((xmlChar*) val_char);


### PR DESCRIPTION
Fix missing [erfc](https://msdn.microsoft.com/en-us/library/dn329048%28v=vs.120%29.aspx) (introduced in this [commit](https://github.com/lagadic/visp/commit/5fed3606f0159163dbec8d0217410b1c6c226377)) in VS2012 and previous version.

Fix missing [strtof](https://msdn.microsoft.com/en-us/library/dn320175%28v=vs.120%29.aspx) (introduced in this [commit](https://github.com/lagadic/visp/pull/86)) in VS2012 and previous version.
