### PR TITLE
Add possibility to retrieve clipped polygons.

### DIFF
--- a/modules/core/src/tools/geometry/vpPolygon3D.cpp
+++ b/modules/core/src/tools/geometry/vpPolygon3D.cpp
@@ -177,74 +177,78 @@ vpPolygon3D::computePolygonClipped(const vpCameraParameters &cam)
       polyClippedTemp.push_back(std::make_pair(p[i%nbpt],vpPolygon3D::NO_CLIPPING));
   }
 
-  if(clippingFlag != vpPolygon3D::NO_CLIPPING)
-  for(unsigned int i = 1 ; i < 64 ; i=i*2)
-  {
+  if(clippingFlag != vpPolygon3D::NO_CLIPPING) {
+    for(unsigned int i = 1 ; i < 64 ; i=i*2)
+    {
       if(((clippingFlag & i) == i) || ((clippingFlag > vpPolygon3D::FAR_CLIPPING) && (i==1)))
       {
-      for(unsigned int j = 0 ; j < polyClippedTemp.size() ; j++)
-      {
-          vpPoint p1Clipped = polyClippedTemp[j].first;
-          vpPoint p2Clipped = polyClippedTemp[(j+1)%polyClippedTemp.size()].first;
+        if(i > vpPolygon3D::FAR_CLIPPING && !cam.isFovComputed()) // To make sure we do not compute FOV clipping if camera normals are not computed
+          continue;
 
-          unsigned int p2ClippedInfoBefore = polyClippedTemp[(j+1)%polyClippedTemp.size()].second;
-          unsigned int p1ClippedInfo = polyClippedTemp[j].second;
-          unsigned int p2ClippedInfo = polyClippedTemp[(j+1)%polyClippedTemp.size()].second;
+        for(unsigned int j = 0 ; j < polyClippedTemp.size() ; j++)
+        {
+            vpPoint p1Clipped = polyClippedTemp[j].first;
+            vpPoint p2Clipped = polyClippedTemp[(j+1)%polyClippedTemp.size()].first;
 
-          bool problem = true;
+            unsigned int p2ClippedInfoBefore = polyClippedTemp[(j+1)%polyClippedTemp.size()].second;
+            unsigned int p1ClippedInfo = polyClippedTemp[j].second;
+            unsigned int p2ClippedInfo = polyClippedTemp[(j+1)%polyClippedTemp.size()].second;
 
-          switch(i){
-          case 1:
-            problem = !(vpPolygon3D::getClippedPointsDistance(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
-                                                               i, distNearClip));
-            break;
-          case 2:
-            problem = !(vpPolygon3D::getClippedPointsDistance(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
-                                                               i, distFarClip));
-            break;
-          case 4:
-            problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
-                                                        fovNormals[0], vpPolygon3D::LEFT_CLIPPING));
-            break;
-          case 8:
-            problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
-                                                        fovNormals[1], vpPolygon3D::RIGHT_CLIPPING));
-            break;
-          case 16:
-            problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
-                                                        fovNormals[2], vpPolygon3D::UP_CLIPPING));
-            break;
-          case 32:
-            problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
-                                                        fovNormals[3], vpPolygon3D::DOWN_CLIPPING));
-            break;
-          }
+            bool problem = true;
 
-          if(!problem)
-          {
-            p1Clipped.projection();
-            polyClippedTemp2.push_back(std::make_pair(p1Clipped, p1ClippedInfo));
-
-            if(p2ClippedInfo != p2ClippedInfoBefore)
-            {
-              p2Clipped.projection();
-              polyClippedTemp2.push_back(std::make_pair(p2Clipped, p2ClippedInfo));
+            switch(i){
+            case 1:
+              problem = !(vpPolygon3D::getClippedPointsDistance(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
+                                                                 i, distNearClip));
+              break;
+            case 2:
+              problem = !(vpPolygon3D::getClippedPointsDistance(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
+                                                                 i, distFarClip));
+              break;
+            case 4:
+              problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
+                                                          fovNormals[0], vpPolygon3D::LEFT_CLIPPING));
+              break;
+            case 8:
+              problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
+                                                          fovNormals[1], vpPolygon3D::RIGHT_CLIPPING));
+              break;
+            case 16:
+              problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
+                                                          fovNormals[2], vpPolygon3D::UP_CLIPPING));
+              break;
+            case 32:
+              problem = !(vpPolygon3D::getClippedPointsFovGeneric(p1Clipped, p2Clipped, p1Clipped, p2Clipped, p1ClippedInfo, p2ClippedInfo,
+                                                          fovNormals[3], vpPolygon3D::DOWN_CLIPPING));
+              break;
             }
 
-            if(nbpt == 2){
-              if(p2ClippedInfo == p2ClippedInfoBefore)
+            if(!problem)
+            {
+              p1Clipped.projection();
+              polyClippedTemp2.push_back(std::make_pair(p1Clipped, p1ClippedInfo));
+
+              if(p2ClippedInfo != p2ClippedInfoBefore)
               {
                 p2Clipped.projection();
                 polyClippedTemp2.push_back(std::make_pair(p2Clipped, p2ClippedInfo));
               }
-              break;
-            }
-          }
-      }
 
-      polyClippedTemp = polyClippedTemp2;
-      polyClippedTemp2.clear();
+              if(nbpt == 2){
+                if(p2ClippedInfo == p2ClippedInfoBefore)
+                {
+                  p2Clipped.projection();
+                  polyClippedTemp2.push_back(std::make_pair(p2Clipped, p2ClippedInfo));
+                }
+                break;
+              }
+            }
+        }
+
+        polyClippedTemp = polyClippedTemp2;
+        polyClippedTemp2.clear();
       }
+    }
   }
 
   polyClipped = polyClippedTemp;

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
@@ -321,7 +321,7 @@ public:
   }
 
   virtual std::pair<std::vector<vpPolygon>, std::vector<std::vector<vpPoint> > > getPolygonFaces(const bool orderPolygons=true,
-      const bool useVisibility=true);
+      const bool useVisibility=true, const bool clipPolygon=false);
 
   /*!
     Get the current pose between the object and the camera.

--- a/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
@@ -1333,6 +1333,8 @@ void vpMbEdgeTracker::init(const vpImage<unsigned char>& I)
   }
 #endif
   
+  if(clippingFlag > 2)
+    cam.computeFov(I.getWidth(), I.getHeight());
   
   initPyramid(I, Ipyramid);
   visibleFace(I, cMo, a);
@@ -1341,7 +1343,9 @@ void vpMbEdgeTracker::init(const vpImage<unsigned char>& I)
   resetMovingEdge();
 
   if(useScanLine){
-    cam.computeFov(I.getWidth(), I.getHeight());
+    if(clippingFlag <= 2)
+      cam.computeFov(I.getWidth(), I.getHeight());
+
     faces.computeClippedPolygons(cMo,cam);
     faces.computeScanLineRender(cam, I.getWidth(), I.getHeight());
   }

--- a/modules/vision/test/key-point/testKeyPoint-2.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-2.cpp
@@ -255,7 +255,7 @@ int main(int argc, const char ** argv) {
     //Keep only keypoints on the cube
     std::vector<vpPolygon> polygons;
     std::vector<std::vector<vpPoint> > roisPt;
-    std::pair<std::vector<vpPolygon>, std::vector<std::vector<vpPoint> > > pair = tracker.getPolygonFaces(false);
+    std::pair<std::vector<vpPolygon>, std::vector<std::vector<vpPoint> > > pair = tracker.getPolygonFaces(true); //To detect an issue with CI
     polygons = pair.first;
     roisPt = pair.second;
 
@@ -279,7 +279,7 @@ int main(int argc, const char ** argv) {
     keypoints.detect(I, trainKeyPoints, elapsedTime);
 
     //Keep only keypoints on the cube
-    pair = tracker.getPolygonFaces(false);
+    pair = tracker.getPolygonFaces(true, true, true); //To detect an issue with CI
     polygons = pair.first;
     roisPt = pair.second;
 
@@ -302,7 +302,7 @@ int main(int argc, const char ** argv) {
     keypoints.detect(I, trainKeyPoints, elapsedTime);
 
     //Keep only keypoints on the cube
-    pair = tracker.getPolygonFaces(false);
+    pair = tracker.getPolygonFaces(false); //To detect an issue with CI
     polygons = pair.first;
     roisPt = pair.second;
 


### PR DESCRIPTION
Add possiblity to retrieve clipped polygons in `vpMbTracker`. 

It allows to proper use the keypoint learning process when the object in the scene contains parts that are out of the field of view of the camera.