### PR TITLE
Add stream aligned data for RealSense cameras.

### DIFF
--- a/modules/sensor/src/rgb-depth/realsense/vpRealSense.cpp
+++ b/modules/sensor/src/rgb-depth/realsense/vpRealSense.cpp
@@ -494,9 +494,14 @@ void vpRealSense::acquire(vpImage<vpRGBa> &color, std::vector<vpColVector> &poin
   \param data_pointCloud : Point cloud vector pointer or NULL if not wanted.
   \param data_infrared : Infrared image buffer or NULL if not wanted.
   \param data_infrared2 : Infrared (for the second IR camera if available) image buffer or NULL if not wanted.
+  \param stream_color : Type of color stream (e.g. rs::stream::color, rs::stream::rectified_color, rs::stream::color_aligned_to_depth).
+  \param stream_depth : Type of depth stream (e.g. rs::stream::depth, rs::stream::depth_aligned_to_color, rs::stream::depth_aligned_to_rectified_color, rs::stream::depth_aligned_to_infrared2).
+  \param stream_infrared : Type of infrared stream (only rs::stream::infrared should be possible).
+  \param stream_infrared2 : Type of infrared2 stream (e.g. rs::stream::infrared2, rs::stream::infrared2_aligned_to_depth) if supported by the camera.
  */
 void vpRealSense::acquire(unsigned char * const data_image, unsigned char * const data_depth, std::vector<vpColVector> * const data_pointCloud,
-                          unsigned char * const data_infrared, unsigned char * const data_infrared2) {
+                          unsigned char * const data_infrared, unsigned char * const data_infrared2, const rs::stream &stream_color, const rs::stream &stream_depth,
+                          const rs::stream &stream_infrared, const rs::stream &stream_infrared2) {
   if (m_device == NULL) {
     throw vpException(vpException::fatalError, "RealSense Camera - Device not opened!");
   }
@@ -508,11 +513,11 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   m_device->wait_for_frames();
 
   if (data_image != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::color, data_image);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::color, data_image, stream_color);
   }
 
   if (data_depth != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::depth, data_depth);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::depth, data_depth, stream_depth);
 
     if (data_pointCloud != NULL) {
       vp_rs_get_pointcloud_impl(m_device, m_intrinsics, m_max_Z, *data_pointCloud);
@@ -520,11 +525,11 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   }
 
   if (data_infrared != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared, data_infrared);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared, data_infrared, stream_infrared);
   }
 
   if (data_infrared2 != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared2, data_infrared2);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared2, data_infrared2, stream_infrared2);
   }
 }
 
@@ -814,10 +819,15 @@ void vpRealSense::acquire(vpImage<unsigned char> &grey, vpImage<uint16_t> &infra
   \param pointcloud : Point cloud (in PCL format and without texture information) pointer or NULL if not wanted.
   \param data_infrared : Infrared image buffer or NULL if not wanted.
   \param data_infrared2 : Infrared (for the second IR camera if available) image buffer or NULL if not wanted.
+  \param stream_color : Type of color stream (e.g. rs::stream::color, rs::stream::rectified_color, rs::stream::color_aligned_to_depth).
+  \param stream_depth : Type of depth stream (e.g. rs::stream::depth, rs::stream::depth_aligned_to_color, rs::stream::depth_aligned_to_rectified_color, rs::stream::depth_aligned_to_infrared2).
+  \param stream_infrared : Type of infrared stream (only rs::stream::infrared should be possible).
+  \param stream_infrared2 : Type of infrared2 stream (e.g. rs::stream::infrared2, rs::stream::infrared2_aligned_to_depth) if supported by the camera.
  */
 void vpRealSense::acquire(unsigned char * const data_image, unsigned char * const data_depth, std::vector<vpColVector> * const data_pointCloud,
                           pcl::PointCloud<pcl::PointXYZ>::Ptr &pointcloud, unsigned char * const data_infrared,
-                          unsigned char * const data_infrared2) {
+                          unsigned char * const data_infrared2, const rs::stream &stream_color, const rs::stream &stream_depth,
+                          const rs::stream &stream_infrared, const rs::stream &stream_infrared2) {
   if (m_device == NULL) {
     throw vpException(vpException::fatalError, "RealSense Camera - Device not opened!");
   }
@@ -829,11 +839,11 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   m_device->wait_for_frames();
 
   if (data_image != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::color, data_image);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::color, data_image, stream_color);
   }
 
   if (data_depth != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::depth, data_depth);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::depth, data_depth, stream_depth);
   }
 
   if (data_pointCloud != NULL) {
@@ -845,11 +855,11 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   }
 
   if (data_infrared != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared, data_infrared);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared, data_infrared, stream_infrared);
   }
 
   if (data_infrared2 != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared2, data_infrared2);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared2, data_infrared2, stream_infrared2);
   }
 }
 
@@ -861,10 +871,15 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   \param pointcloud : Point cloud (in PCL format and with texture information) pointer or NULL if not wanted.
   \param data_infrared : Infrared image buffer or NULL if not wanted.
   \param data_infrared2 : Infrared (for the second IR camera if available) image buffer or NULL if not wanted.
+  \param stream_color : Type of color stream (e.g. rs::stream::color, rs::stream::rectified_color, rs::stream::color_aligned_to_depth).
+  \param stream_depth : Type of depth stream (e.g. rs::stream::depth, rs::stream::depth_aligned_to_color, rs::stream::depth_aligned_to_rectified_color, rs::stream::depth_aligned_to_infrared2).
+  \param stream_infrared : Type of infrared stream (only rs::stream::infrared should be possible).
+  \param stream_infrared2 : Type of infrared2 stream (e.g. rs::stream::infrared2, rs::stream::infrared2_aligned_to_depth) if supported by the camera.
  */
 void vpRealSense::acquire(unsigned char * const data_image, unsigned char * const data_depth, std::vector<vpColVector> * const data_pointCloud,
                           pcl::PointCloud<pcl::PointXYZRGB>::Ptr &pointcloud, unsigned char * const data_infrared,
-                          unsigned char * const data_infrared2) {
+                          unsigned char * const data_infrared2, const rs::stream &stream_color, const rs::stream &stream_depth,
+                          const rs::stream &stream_infrared, const rs::stream &stream_infrared2) {
   if (m_device == NULL) {
     throw vpException(vpException::fatalError, "RealSense Camera - Device not opened!");
   }
@@ -876,11 +891,11 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   m_device->wait_for_frames();
 
   if (data_image != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::color, data_image);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::color, data_image, stream_color);
   }
 
   if (data_depth != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::depth, data_depth);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::depth, data_depth, stream_depth);
   }
 
   if (data_pointCloud != NULL) {
@@ -892,11 +907,11 @@ void vpRealSense::acquire(unsigned char * const data_image, unsigned char * cons
   }
 
   if (data_infrared != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared, data_infrared);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared, data_infrared, stream_infrared);
   }
 
   if (data_infrared2 != NULL) {
-    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared2, data_infrared2);
+    vp_rs_get_native_frame_data_impl(m_device, m_intrinsics, rs::stream::infrared2, data_infrared2, stream_infrared2);
   }
 }
 #endif

--- a/modules/sensor/src/rgb-depth/realsense/vpRealSense_impl.h
+++ b/modules/sensor/src/rgb-depth/realsense/vpRealSense_impl.h
@@ -66,19 +66,20 @@ void vp_rs_get_frame_data_impl(const rs::device *m_device, const std::map <rs::s
 }
 
 // Retrieve data from native stream
-void vp_rs_get_native_frame_data_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, const rs::stream &stream, unsigned char * const data)
+void vp_rs_get_native_frame_data_impl(const rs::device *m_device, const std::map <rs::stream, rs::intrinsics> &m_intrinsics, const rs::stream &native_stream,
+                                      unsigned char * const data, const rs::stream &stream)
 {
-  if (m_device->is_stream_enabled(stream)) {
-    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(stream);
+  if (m_device->is_stream_enabled(native_stream)) {
+    std::map<rs::stream, rs::intrinsics>::const_iterator it_intrinsics = m_intrinsics.find(native_stream);
     if (it_intrinsics == m_intrinsics.end()) {
       std::stringstream ss;
-      ss << "Cannot find intrinsics for " << stream << "  stream!";
+      ss << "Cannot find intrinsics for " << native_stream << "  stream!";
       throw vpException(vpException::fatalError, ss.str());
     }
 
     size_t size = (size_t) (it_intrinsics->second.width * it_intrinsics->second.height);
 
-    switch (m_device->get_stream_format(stream)) {
+    switch (m_device->get_stream_format(native_stream)) {
       //8 bits
       case rs::format::raw8:
         std::cout << "Stream: raw8 not tested!" << std::endl;
@@ -135,7 +136,7 @@ void vp_rs_get_native_frame_data_impl(const rs::device *m_device, const std::map
     }
   }
   else {
-    throw vpException(vpException::fatalError, "RealSense Camera - stream %d not enabled!", (rs_stream) stream);
+    throw vpException(vpException::fatalError, "RealSense Camera - stream %d not enabled!", (rs_stream) native_stream);
   }
 }
 

--- a/modules/sensor/test/rgb-depth/testRealSense2.cpp
+++ b/modules/sensor/test/rgb-depth/testRealSense2.cpp
@@ -447,6 +447,71 @@ int main()
 #endif
 
 
+    //Color stream aligned to depth
+    rs.setEnableStream(rs::stream::color, true);
+    rs.setEnableStream(rs::stream::depth, true);
+    rs.setEnableStream(rs::stream::infrared, false);
+    rs.setStreamSettings(rs::stream::color, vpRealSense::vpRsStreamParams(640, 480, rs::format::rgba8, 30));
+    rs.setStreamSettings(rs::stream::depth, vpRealSense::vpRsStreamParams(640, 480, rs::format::z16, 30));
+    rs.open();
+
+    dc.init(I_color, 0, 0, "Color aligned to depth");
+    di.init(I_display_depth, (int) I_color.getWidth(), 0, "Depth image");
+
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( (unsigned char *) I_color.bitmap, (unsigned char *) depth.bitmap, NULL, NULL, NULL, rs::stream::color_aligned_to_depth );
+      vpImageConvert::createDepthHistogram(depth, I_display_depth);
+
+      vpDisplay::display(I_color);
+      vpDisplay::display(I_display_depth);
+      vpDisplay::flush(I_color);
+      vpDisplay::flush(I_display_depth);
+
+      if (vpDisplay::getClick(I_color, false) || vpDisplay::getClick(I_display_depth, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+
+    dc.close(I_color);
+    dd.close(I_display_depth);
+
+
+    //Depth stream aligned to color
+    dc.init(I_color, 0, 0, "Color image");
+    di.init(I_display_depth, (int) I_color.getWidth(), 0, "Depth aligned to color");
+
+    t_begin = vpTime::measureTimeMs();
+    while (true) {
+      double t = vpTime::measureTimeMs();
+      rs.acquire( (unsigned char *) I_color.bitmap, (unsigned char *) depth.bitmap, NULL, NULL, NULL, rs::stream::color, rs::stream::depth_aligned_to_color );
+      vpImageConvert::createDepthHistogram(depth, I_display_depth);
+
+      vpDisplay::display(I_color);
+      vpDisplay::display(I_display_depth);
+      vpDisplay::flush(I_color);
+      vpDisplay::flush(I_display_depth);
+
+      if (vpDisplay::getClick(I_color, false) || vpDisplay::getClick(I_display_depth, false)) {
+        break;
+      }
+
+      time_vector.push_back(vpTime::measureTimeMs() - t);
+      if (vpTime::measureTimeMs() - t_begin >= 10000) {
+        break;
+      }
+    }
+
+    dc.close(I_color);
+    dd.close(I_display_depth);
+
+
 
 #if VISP_HAVE_OPENCV_VERSION >= 0x020409
     rs.setEnableStream(rs::stream::color, true);


### PR DESCRIPTION
Add possibility to get stream aligned data for the Intel RealSense cameras.

- Color stream / depth stream:

![color_depth](https://cloud.githubusercontent.com/assets/8035162/22067867/4849ccb6-dd93-11e6-8278-c720a7ef77e5.png)

- Color aligned to depth / depth stream:

![color_aligned_to_depth_depth](https://cloud.githubusercontent.com/assets/8035162/22067894/6adfbbb4-dd93-11e6-9dcd-a96be1974503.png)

- Color / Depth aligned to color stream:

![color_depth_aligned_to_color](https://cloud.githubusercontent.com/assets/8035162/22067906/7874a6f4-dd93-11e6-843d-3efce2c008c0.png)

Useful links:

- [Projection and Deprojection in librealsense](https://github.com/IntelRealSense/librealsense/blob/master/doc/projection.md)