### PR TITLE
Fix missing member copy in vpPolygon assignment operator.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -100,6 +100,7 @@ ViSP 3.0.1 (in development)
     . [#117] vpMomentAlpha: out of range of [-Pi, Pi] in relative mode 
     . [#118] vpKeyPoint: perhaps misleading in document
     . [#120] Build failed with clang/llvm
+    . [#126] vpPolygon::operator=() does not copy everything.
 
 ----------------------------------------------
 ViSP 3.0.0 (released December 18th, 2015)

--- a/modules/core/src/tools/geometry/vpPolygon.cpp
+++ b/modules/core/src/tools/geometry/vpPolygon.cpp
@@ -130,6 +130,7 @@ vpPolygon::operator=(const vpPolygon& poly)
   _center = poly._center;
   _area = poly._area;
   _goodPoly = poly._goodPoly;
+  _bbox = poly._bbox;
   m_PnPolyConstants = poly.m_PnPolyConstants;
   m_PnPolyMultiples = poly.m_PnPolyMultiples;
   return *this;


### PR DESCRIPTION
Resolve #126 