### PR TITLE
Add vpImage std::ostream& operator<< to print the image in the console.

### DIFF
--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -1134,11 +1134,11 @@ bool vpImage<Type>::operator==(const vpImage<Type> &I)
   if (this->height != I.getHeight())
     return false;
 
-  printf("wxh: %dx%d bitmap: %p I.bitmap %p\n", width, height, bitmap, I.bitmap);
+//  printf("wxh: %dx%d bitmap: %p I.bitmap %p\n", width, height, bitmap, I.bitmap);
   for (unsigned int i=0 ; i < npixels ; i++)
   {
     if (bitmap[i] != I.bitmap[i]) {
-      std::cout << "differ for pixel " << i << " (" << i%this->height << ", " << i - i%this->height << ")" << std::endl;
+//      std::cout << "differ for pixel " << i << " (" << i%this->height << ", " << i - i%this->height << ")" << std::endl;
       return false;
     }
   }
@@ -1152,17 +1152,18 @@ bool vpImage<Type>::operator==(const vpImage<Type> &I)
 template<class Type>
 bool vpImage<Type>::operator!=(const vpImage<Type> &I)
 {
-  if (this->width != I.getWidth())
-    return true;
-  if (this->height != I.getHeight())
-    return true;
+//  if (this->width != I.getWidth())
+//    return true;
+//  if (this->height != I.getHeight())
+//    return true;
 
-  for (unsigned int i=0 ; i < npixels ; i++)
-  {
-    if (bitmap[i] != I.bitmap[i])
-      return true;
-  }
-  return false ;
+//  for (unsigned int i=0 ; i < npixels ; i++)
+//  {
+//    if (bitmap[i] != I.bitmap[i])
+//      return true;
+//  }
+//  return false ;
+  return !(*this == I);
 }
 
 /*!

--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -56,6 +56,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <iomanip>      // std::setw
 #include <math.h>
 #include <string.h>
 
@@ -296,6 +297,7 @@ public:
   vpImage<Type>& operator=(const Type &v);
   bool operator==(const vpImage<Type> &I);
   bool operator!=(const vpImage<Type> &I);
+  template <class T> friend std::ostream& operator<<(std::ostream &s, const vpImage<T> &I);
 
   // Perform a look-up table transformation
   void performLut(const Type (&lut)[256], const unsigned int nbThreads=1);
@@ -320,6 +322,135 @@ private:
   unsigned int height ;  ///! number of rows
   Type **row ;    //!< points the row pointer array
 };
+
+template <class Type>
+std::ostream& operator<<(std::ostream &s, const vpImage<Type> &I) {
+  if (I.bitmap == NULL) {
+    return s;
+  }
+
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth()-1; j++) {
+      s << I[i][j] << " ";
+    }
+
+    // We don't add "  " after the last column element
+    s << I[i][I.getWidth() -1];
+
+    // We don't add a \n character at the end of the last row line
+    if (i < I.getHeight()-1) {
+      s << std::endl;
+    }
+  }
+
+  return s;
+}
+
+template <>
+inline std::ostream& operator<<(std::ostream &s, const vpImage<unsigned char> &I) {
+  if (I.bitmap == NULL) {
+    return s;
+  }
+
+  std::ios_base::fmtflags original_flags = s.flags();
+
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth()-1; j++) {
+      s << std::setw(3) << static_cast<unsigned>(I[i][j]) << " ";
+    }
+
+    // We don't add "  " after the last column element
+    s << std::setw(3) << static_cast<unsigned>(I[i][I.getWidth() -1]);
+
+    // We don't add a \n character at the end of the last row line
+    if (i < I.getHeight()-1) {
+      s << std::endl;
+    }
+  }
+
+  s.flags(original_flags); // restore s to standard state
+  return s;
+}
+
+template <>
+inline std::ostream& operator<<(std::ostream &s, const vpImage<char> &I) {
+  if (I.bitmap == NULL) {
+    return s;
+  }
+
+  std::ios_base::fmtflags original_flags = s.flags();
+
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth()-1; j++) {
+      s <<std::setw(4) << static_cast<int>(I[i][j]) << " ";
+    }
+
+    // We don't add "  " after the last column element
+    s << std::setw(4) << static_cast<int>(I[i][I.getWidth() -1]);
+
+    // We don't add a \n character at the end of the last row line
+    if (i < I.getHeight()-1) {
+      s << std::endl;
+    }
+  }
+
+  s.flags(original_flags); // restore s to standard state
+  return s;
+}
+
+template <>
+inline std::ostream& operator<<(std::ostream &s, const vpImage<float> &I) {
+  if (I.bitmap == NULL) {
+    return s;
+  }
+
+  std::ios_base::fmtflags original_flags = s.flags();
+  s.precision(9); //http://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10
+
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth()-1; j++) {
+      s << I[i][j] << " ";
+    }
+
+    // We don't add "  " after the last column element
+    s << I[i][I.getWidth() -1];
+
+    // We don't add a \n character at the end of the last row line
+    if (i < I.getHeight()-1) {
+      s << std::endl;
+    }
+  }
+
+  s.flags(original_flags); // restore s to standard state
+  return s;
+}
+
+template <>
+inline std::ostream& operator<<(std::ostream &s, const vpImage<double> &I) {
+  if (I.bitmap == NULL) {
+    return s;
+  }
+
+  std::ios_base::fmtflags original_flags = s.flags();
+  s.precision(17); //http://en.cppreference.com/w/cpp/types/numeric_limits/max_digits10
+
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth()-1; j++) {
+      s << I[i][j] << " ";
+    }
+
+    // We don't add "  " after the last column element
+    s << I[i][I.getWidth() -1];
+
+    // We don't add a \n character at the end of the last row line
+    if (i < I.getHeight()-1) {
+      s << std::endl;
+    }
+  }
+
+  s.flags(original_flags); // restore s to standard state
+  return s;
+}
 
 
 #if defined(VISP_HAVE_PTHREAD) || (defined(_WIN32) && !defined(WINRT_8_0))

--- a/modules/core/test/image/testImagePrinting.cpp
+++ b/modules/core/test/image/testImagePrinting.cpp
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2017 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test image printing.
+ *
+ *****************************************************************************/
+
+#include <iostream>
+#include <visp3/core/vpImage.h>
+
+/*!
+  \example testImagePrinting.cpp
+
+  \brief Test image printing.
+*/
+
+int main() {
+  unsigned int size = 16;
+  vpImage<int> I_int(size, size);
+  vpImage<unsigned char> I_uchar(size, size);
+  vpImage<char> I_char(size, size);
+
+  for (unsigned int i = 0, cpt = 0; i < size; i++) {
+    for (unsigned int j = 0; j < size; j++, cpt++) {
+      I_int[i][j] = (int) cpt;
+      I_uchar[i][j] = (unsigned char) cpt;
+      I_char[i][j] = (char) cpt;
+    }
+  }
+
+  size = 5;
+  vpImage<float> I_float(size, size);
+  vpImage<double> I_double(size, size);
+
+  for (unsigned int i = 0, cpt = 0; i < size; i++) {
+    for (unsigned int j = 0; j < size; j++, cpt++) {
+      I_float[i][j] = (float) sqrt((double) cpt);
+      I_double[i][j] = sqrt((double) cpt);
+    }
+  }
+
+  std::cout << "I_int:\n" << I_int << std::endl;
+  std::cout << "\nI_uchar:\n" << I_uchar << std::endl;
+  std::cout << "\nI_char:\n" << I_char << std::endl;
+  std::cout << "\nI_float:\n" << I_float << std::endl;
+  std::cout << "\nI_double:\n" << I_double << std::endl;
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Add vpImage operator<< to print the image in the console with:

- fixed width for `unsigned char` and `char` type

- full precision for `float` and `double` type.

Useful when debugging image operations.