### PR TITLE
Fix bug in extration of vpRotationMatrix from vpPoseVector using vpPo…

### DIFF
--- a/modules/core/src/math/transformation/vpPoseVector.cpp
+++ b/modules/core/src/math/transformation/vpPoseVector.cpp
@@ -330,7 +330,7 @@ vpTranslationVector vpPoseVector::getTranslationVector() const
  */
 vpRotationMatrix vpPoseVector::getRotationMatrix() const
 {
-  vpRotationMatrix R((*this)[0], (*this)[1], (*this)[2]);
+  vpRotationMatrix R((*this)[3], (*this)[4], (*this)[5]);
   return R;
 }
 


### PR DESCRIPTION
…seVector::getRotationMatrix()