### PR TITLE
Speed-up vpMbKltTracker::reinit() function.

### DIFF
--- a/3rdparty/clipper/CMakeLists.txt
+++ b/3rdparty/clipper/CMakeLists.txt
@@ -8,7 +8,7 @@ file(GLOB lib_hdrs *.hpp)
 add_library(${CLIPPER_LIBRARY} STATIC ${lib_srcs} ${lib_hdrs})
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
 if(ENABLE_SOLUTION_FOLDERS)

--- a/modules/tracker/mbt/src/klt/vpMbtDistanceKltCylinder.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbtDistanceKltCylinder.cpp
@@ -402,7 +402,60 @@ vpMbtDistanceKltCylinder::updateMask(
           int i_min, i_max, j_min, j_max;
           std::vector<vpImagePoint> roi;
           (*hiddenface)[(unsigned int) listIndicesCylinderBBox[kc]]->getRoiClipped(cam, roi);
+
+          double shiftBorder_d = (double) shiftBorder;
+        #if defined (VISP_HAVE_CLIPPER)
+          std::vector<vpImagePoint> roi_offset;
+
+          ClipperLib::Path path;
+          for (std::vector<vpImagePoint>::const_iterator it = roi.begin(); it != roi.end(); ++it) {
+            path.push_back( ClipperLib::IntPoint(it->get_u(), it->get_v()) );
+          }
+
+          ClipperLib::Paths solution;
+          ClipperLib::ClipperOffset co;
+          co.AddPath(path, ClipperLib::jtRound, ClipperLib::etClosedPolygon);
+          co.Execute(solution, -shiftBorder_d);
+
+          //Keep biggest polygon by area
+          if (!solution.empty()) {
+            size_t index_max = 0;
+
+            if (solution.size() > 1) {
+              double max_area = 0;
+              vpPolygon polygon_area;
+
+              for (size_t i = 0; i < solution.size(); i++) {
+                std::vector<vpImagePoint> corners;
+
+                for (size_t j = 0; j < solution[i].size(); j++) {
+                  corners.push_back( vpImagePoint(solution[i][j].Y, solution[i][j].X) );
+                }
+
+                polygon_area.buildFrom(corners);
+                if (polygon_area.getArea() > max_area) {
+                  max_area = polygon_area.getArea();
+                  index_max = i;
+                }
+              }
+            }
+
+            for (size_t i = 0; i < solution[index_max].size(); i++) {
+              roi_offset.push_back( vpImagePoint(solution[index_max][i].Y, solution[index_max][i].X) );
+            }
+          } else {
+            roi_offset = roi;
+          }
+
+          vpPolygon polygon_test(roi_offset);
+          vpImagePoint imPt;
+        #endif
+
+        #if defined (VISP_HAVE_CLIPPER)
+          vpPolygon3D::getMinMaxRoi(roi_offset, i_min, i_max, j_min,j_max);
+        #else
           vpPolygon3D::getMinMaxRoi(roi, i_min, i_max, j_min,j_max);
+        #endif
 
           /* check image boundaries */
           if(i_min > height){ //underflow
@@ -418,13 +471,20 @@ vpMbtDistanceKltCylinder::updateMask(
             j_max = width;
           }
 
-          double shiftBorder_d = (double) shiftBorder;
         #if (VISP_HAVE_OPENCV_VERSION >= 0x020408)
-          for(int i=i_min; i< i_max; i++){
+          for (int i = i_min; i < i_max; i++) {
             double i_d = (double) i;
-            for(int j=j_min; j< j_max; j++){
+
+            for(int j = j_min; j < j_max; j++) {
               double j_d = (double) j;
-              if(shiftBorder != 0){
+
+            #if defined (VISP_HAVE_CLIPPER)
+              imPt.set_ij(i_d, j_d);
+              if (polygon_test.isInside(imPt)) {
+                mask.ptr<uchar>(i)[j] = nb;
+              }
+            #else
+              if (shiftBorder != 0) {
                 if( vpPolygon::isInside(roi, i_d, j_d)
                     && vpPolygon::isInside(roi, i_d+shiftBorder_d, j_d+shiftBorder_d)
                     && vpPolygon::isInside(roi, i_d-shiftBorder_d, j_d+shiftBorder_d)
@@ -438,6 +498,7 @@ vpMbtDistanceKltCylinder::updateMask(
                   mask.at<unsigned char>(i,j) = nb;
                 }
               }
+            #endif
             }
           }
         #else


### PR DESCRIPTION
Speed-up vpMbKltTracker::reinit() function. Full real-time tracking can now be achieved with KLT and derived trackers.

Mask computed with the old version:
![m_debug_mask_old](https://cloud.githubusercontent.com/assets/8035162/23628949/662a9d9e-02b6-11e7-8b9f-77e8eb4306e8.png)

Mask computed with the new version:
![m_debug_mask](https://cloud.githubusercontent.com/assets/8035162/23628972/71d567aa-02b6-11e7-8da6-52249b72138e.png)

DIfference:
![m_debug_mask_diff](https://cloud.githubusercontent.com/assets/8035162/23628982/78d25644-02b6-11e7-84ef-f0e38a17d7bb.png)
