### PR TITLE
Bug in vpTime::measureTimeMicros() (OS detection was done wrong)

### DIFF
--- a/modules/core/src/tools/time/vpTime.cpp
+++ b/modules/core/src/tools/time/vpTime.cpp
@@ -134,7 +134,7 @@ double measureTimeMicros()
 #  else
 	throw(vpException(vpException::fatalError, "Cannot get time: not implemented on Universal Windows Platform"));
 #  endif
-#else
+#elif !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
   struct timeval tp;
   gettimeofday(&tp,0);
   return(1000000.0*tp.tv_sec + tp.tv_usec);

--- a/modules/core/src/tools/time/vpTime.cpp
+++ b/modules/core/src/tools/time/vpTime.cpp
@@ -121,7 +121,7 @@ double measureTimeMs()
 double measureTimeMicros()
 {
 #if defined(_WIN32)
-#if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
+#if !defined(WINRT)
 	LARGE_INTEGER time, frequency;
   QueryPerformanceFrequency(&frequency);
   if(frequency.QuadPart == 0){
@@ -131,7 +131,7 @@ double measureTimeMicros()
     QueryPerformanceCounter(&time);
     return (double)(1000000.0*time.QuadPart/frequency.QuadPart);
   }
-#  elif WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
+#  else
 	throw(vpException(vpException::fatalError, "Cannot get time: not implemented on Universal Windows Platform"));
 #  endif
 #else


### PR DESCRIPTION
correction of measureTimeMicros() done by looking at leasureTimeMs()