### PR TITLE
Include winsock2.h before windows.h to ensure that winsock.h is not

### DIFF
--- a/modules/core/include/visp3/core/vpImageConvert.h
+++ b/modules/core/include/visp3/core/vpImageConvert.h
@@ -78,6 +78,9 @@
 #endif
 
 #if defined(_WIN32)
+// Include WinSock2.h before windows.h to ensure that winsock.h is not included by windows.h 
+// since winsock.h and winsock2.h are incompatible
+#  include <WinSock2.h> 
 #  include <windows.h>
 #endif
 

--- a/modules/core/include/visp3/core/vpMutex.h
+++ b/modules/core/include/visp3/core/vpMutex.h
@@ -47,6 +47,9 @@
 #if defined(VISP_HAVE_PTHREAD)
 #  include <pthread.h>
 #elif defined(_WIN32)
+// Include WinSock2.h before windows.h to ensure that winsock.h is not included by windows.h 
+// since winsock.h and winsock2.h are incompatible
+#  include <WinSock2.h> 
 #  include <windows.h>
 #endif
 

--- a/modules/core/include/visp3/core/vpThread.h
+++ b/modules/core/include/visp3/core/vpThread.h
@@ -10,6 +10,9 @@
 #  include <pthread.h>
 #  include <string.h>
 #elif defined(_WIN32)
+// Include WinSock2.h before windows.h to ensure that winsock.h is not included by windows.h 
+// since winsock.h and winsock2.h are incompatible
+#  include <WinSock2.h> 
 #  include <windows.h>
 #endif
 


### PR DESCRIPTION
included by windows.h (Closes #162)