### PR TITLE
Add option to set an epsilon in vpPose with a VVS method

### DIFF
--- a/modules/vision/include/visp3/vision/vpPose.h
+++ b/modules/vision/include/visp3/vision/vpPose.h
@@ -97,33 +97,45 @@ public:
     CHECK_DEGENERATE_POINTS           = 0x8   /*!< Check for degenerate points during the RANSAC. */
   };
 
-  unsigned int npt ;             //!< Number of point used in pose computation
-  std::list<vpPoint> listP ;     //!< Array of point (use here class vpPoint)
+  unsigned int npt;             //!< Number of point used in pose computation
+  std::list<vpPoint> listP;     //!< Array of point (use here class vpPoint)
 
-  double residual ;     //!< Residual in meter
+  double residual;     //!< Residual in meter
 
 protected :
   double lambda ;//!< parameters use for the virtual visual servoing approach
 
 private:
-  int vvsIterMax ; //! define the maximum number of iteration in VVS
+  //! define the maximum number of iteration in VVS
+  int vvsIterMax;
   //! variable used in the Dementhon approach
-  std::vector<vpPoint> c3d ;
+  std::vector<vpPoint> c3d;
   //! Flag used to specify if the covariance matrix has to be computed or not.
   bool computeCovariance;
   //! Covariance matrix
   vpMatrix covarianceMatrix;
-  
+  //! Found a solution when there are at least a minimum number of points in the consensus set
   unsigned int ransacNbInlierConsensus;
+  //! Maximum number of iterations for the RANSAC
   int ransacMaxTrials;
+  //! List of inlier points
   std::vector<vpPoint> ransacInliers;
+  //! List of inlier point indexes (from the input list)
   std::vector<unsigned int> ransacInlierIndex;
+  //! RANSAC threshold to consider a sample inlier or not
   double ransacThreshold;
+  //! Minimal distance point to plane to consider if the point belongs or not to the plane
   double distanceToPlaneForCoplanarityTest;
+  //! RANSAC flags to remove or not degenerate points
   int ransacFlags;
+  //! List of points used for the RANSAC (std::vector is contiguous whereas std::list is a linked list)
   std::vector<vpPoint> listOfPoints;
+  //! If true, use a parallel RANSAC implementation
   bool useParallelRansac;
+  //! Number of threads to spawn for the parallel RANSAC implementation
   int nbParallelRansacThreads;
+  //! Stop the optimization loop when the residual change (|r-r_prec|) <= epsilon
+  double vvsEpsilon;
 
 
   //For parallel RANSAC
@@ -221,12 +233,19 @@ public:
   void printPoint() ; 
   void setDistanceToPlaneForCoplanarityTest(double d) ;
   void setLambda(double a) { lambda = a ; }
+  void setVvsEpsilon(const double eps) {
+    if (eps >= 0) {
+      vvsEpsilon = eps;
+    } else {
+      throw vpException(vpException::badValue, "Epsilon value must be >= 0.");
+    }
+  }
   void setVvsIterMax(int nb) { vvsIterMax = nb ; }
   
   void setRansacNbInliersToReachConsensus(const unsigned int &nbC){ ransacNbInlierConsensus = nbC; }
   void setRansacThreshold(const double &t) {
     //Test whether or not t is > 0
-    if(t > 0) {
+    if(t > std::numeric_limits<double>::epsilon()) {
       ransacThreshold = t;
     } else {
       throw vpException(vpException::badValue, "The Ransac threshold must be positive as we deal with distance.");

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -65,23 +65,27 @@ vpPose::init()
 #if (DEBUG_LEVEL1)
   std::cout << "begin vpPose::Init() " << std::endl ;
 #endif
-  npt = 0 ;
+
+  npt = 0;
   listP.clear();
-  c3d.clear();
-
-  lambda = 0.25 ;
-
-  vvsIterMax = 200 ;
-
-  distanceToPlaneForCoplanarityTest = 0.001 ;
-  
-  computeCovariance = false;
-  
-  ransacMaxTrials = 1000;
-  ransacThreshold = 0.0001;
-  ransacNbInlierConsensus = 4;
-
   residual = 0;
+  lambda = 0.25;
+  vvsIterMax = 200;
+  c3d.clear();
+  computeCovariance = false;
+  covarianceMatrix.clear();
+  ransacNbInlierConsensus = 4;
+  ransacMaxTrials = 1000;
+  ransacInliers.clear();
+  ransacInlierIndex.clear();
+  ransacThreshold = 0.0001;
+  distanceToPlaneForCoplanarityTest = 0.001;
+  ransacFlags = PREFILTER_DUPLICATE_POINTS;
+  listOfPoints.clear();
+  useParallelRansac = false;
+  nbParallelRansacThreads = 0;
+  vvsEpsilon = 1e-8;
+
 #if (DEBUG_LEVEL1)
   std::cout << "end vpPose::Init() " << std::endl ;
 #endif
@@ -94,18 +98,9 @@ vpPose::vpPose()
     computeCovariance(false), covarianceMatrix(),
     ransacNbInlierConsensus(4), ransacMaxTrials(1000), ransacInliers(), ransacInlierIndex(), ransacThreshold(0.0001),
     distanceToPlaneForCoplanarityTest(0.001), ransacFlags(PREFILTER_DUPLICATE_POINTS),
-    listOfPoints(), useParallelRansac(false), nbParallelRansacThreads(0) //0 means that OpenMP is used to get the number of CPU threads
+    listOfPoints(), useParallelRansac(false), nbParallelRansacThreads(0), //0 means that OpenMP is used to get the number of CPU threads
+    vvsEpsilon(1e-8)
 {
-#if (DEBUG_LEVEL1)
-  std::cout << "begin vpPose::vpPose() " << std::endl ;
-#endif
-
-  init() ;
-
-#if (DEBUG_LEVEL1)
-  std::cout << "end vpPose::vpPose() " << std::endl ;
-#endif
-
 }
 
 /*!
@@ -130,6 +125,7 @@ void
 vpPose::clearPoint()
 {
   listP.clear();
+  listOfPoints.clear();
   npt = 0 ;
 }
 

--- a/modules/vision/src/pose-estimation/vpPoseVirtualVisualServoing.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseVirtualVisualServoing.cpp
@@ -87,7 +87,8 @@ vpPose::poseVirtualVS(vpHomogeneousMatrix & cMo)
 
     vpHomogeneousMatrix cMoPrev = cMo;
     //while((int)((residu_1 - r)*1e12) !=0)
-    while(std::fabs((residu_1 - r)*1e12) > std::numeric_limits<double>::epsilon())
+//    while(std::fabs((residu_1 - r)*1e12) > std::numeric_limits<double>::epsilon())
+    while( std::fabs(residu_1 - r) > vvsEpsilon )
     {      
       residu_1 = r ;
 


### PR DESCRIPTION
Add possibility to change the epsilon value used in the VVS optimization loop (to determine if we have converged or not).

Before the code was:
`while(std::fabs((residu_1 - r)*1e12) > std::numeric_limits<double>::epsilon())`
It means that we assume there is convergence when (more or less) `std::fabs(residu_1 - r) <= std::numeric_limits<double>::epsilon() / 1e12 `. With double type, `std::numeric_limits<double>::epsilon()` is equal to `2.2204460492503131e-16`.

Now we use a default value of `1e-8` with the possibility to change the value with `setVvsEpsilon()`.

In the following figure, the residuals are plot at each iteration without the modification (for 4 different pose estimation cases).
![figure_original](https://cloud.githubusercontent.com/assets/8035162/24614210/d8fd3db0-188a-11e7-8320-3179ee964b10.png)

With the modification:
![figure_modif](https://cloud.githubusercontent.com/assets/8035162/24614233/eef01ec6-188a-11e7-84b5-74f1e68d3b42.png)

Note that the default maximum number of VVS iterations is 200 so we stop before in both cases but it should be useless to use a so strict stopping criterion in my opinion.

Add also some missing variable initializations in `vpPose::init()`.