### PR TITLE
Fix: Source and destination overlap in memcpy in vpMbScanLine.

### DIFF
--- a/modules/tracker/mbt/src/vpMbScanLine.cpp
+++ b/modules/tracker/mbt/src/vpMbScanLine.cpp
@@ -381,7 +381,8 @@ vpMbScanLine::drawScene(const std::vector<std::vector<std::pair<vpPoint, unsigne
               for(size_t j = 0 ; j < stack.size() ; ++j)
                   if (stack[j].second.ID == s.ID)
                   {
-                      stack[j] = stack.back();
+                      if (j != stack.size()-1)
+                          stack[j] = stack.back();
                       stack.pop_back();
                       break;
                   }
@@ -465,7 +466,8 @@ vpMbScanLine::drawScene(const std::vector<std::vector<std::pair<vpPoint, unsigne
               for(size_t j = 0 ; j < stack.size() ; ++j)
                   if (stack[j].second.ID == s.ID)
                   {
-                      stack[j] = stack.back();
+                      if (j != stack.size()-1)
+                          stack[j] = stack.back();
                       stack.pop_back();
                       break;
                   }


### PR DESCRIPTION
Detected with Valgrind:

> ==31240== 2422 errors in context 4 of 23:
> ==31240== Source and destination overlap in memcpy(0x348d0b70, 0x348d0b70, 24)
> ==31240==    at 0x4C32513: memcpy@@GLIBC_2.14 (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==31240==    by 0x614D266: memcpy (string3.h:53)
> ==31240==    by 0x614D266: vpColVector::operator=(vpColVector const&) (vpColVector.cpp:534)
> ==31240==    by 0x4EA2743: operator= (stl_pair.h:170)
> ==31240==    by 0x4EA2743: operator= (vpMbScanLine.h:84)
> ==31240==    by 0x4EA2743: operator= (stl_pair.h:161)
> ==31240==    by 0x4EA2743: vpMbScanLine::drawScene(std::vector<std::vector<std::pair<vpPoint, unsigned int>, std::allocator<std::pair<vpPoint, unsigned int> > >*, std::allocator<std::vector<std::pair<vpPoint, unsigned int>, std::allocator<std::pair<vpPoint, unsigned int> > >*> > const&, std::vector<int, std::allocator<int> >, vpCameraParameters const&, unsigned int, unsigned int) (vpMbScanLine.cpp:470)
> ==31240==    by 0x4EBF593: vpMbHiddenFaces<vpMbtPolygon>::computeScanLineRender(vpCameraParameters const&, unsigned int const&, unsigned int const&) (vpMbHiddenFaces.h:420)
> ==31240==    by 0x4EE86B8: vpMbEdgeTracker::track(vpImage<unsigned char> const&) (vpMbEdgeTracker.cpp:1263)
