### PR TITLE
Add Lapack support for matrix multiplications

### DIFF
--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -672,6 +672,11 @@ class VISP_EXPORT vpMatrix : public vpArray2D<double>
 #endif
 
  private:
+  static void blas_dgemm(char trans_a, char trans_b, const int M, const int N, const int K, double alpha, double * a_data,
+                         const int lda, double * b_data, const int ldb, double beta, double * c_data, const int ldc);
+  static void blas_dgemv(char trans, const int M, const int N, double alpha, double * a_data, const int lda, double * x_data,
+                         const int incx, double beta, double * y_data, const int incy);
+
   static void computeCovarianceMatrixVVS(const vpHomogeneousMatrix &cMo, const vpColVector &deltaS, const vpMatrix &Ls, vpMatrix &Js, vpColVector &deltaP);
 };
 

--- a/modules/core/src/math/matrix/vpMatrix_mul.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_mul.cpp
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2017 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Matrix multiplication Lapack routines.
+ *
+ *****************************************************************************/
+
+#include <visp3/core/vpConfig.h>
+#include <visp3/core/vpMatrix.h>
+
+#ifdef VISP_HAVE_LAPACK
+#  ifdef VISP_HAVE_LAPACK_BUILT_IN
+typedef long int integer;
+#  else
+typedef int integer;
+#  endif
+
+extern "C" void dgemm_(char *transa, char *transb, integer *M, integer *N, integer *K, double *alpha, double *a,
+                       integer *lda, double *b, integer *ldb, double *beta, double *c, integer *ldc);
+
+extern "C" void dgemv_(char *trans, integer *M, integer *N, double *alpha, double *a, integer *lda,
+                       double *x, integer *incx, double *beta, double *y, integer *incy);
+#endif
+
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+
+#ifdef VISP_HAVE_LAPACK
+void vpMatrix::blas_dgemm(char trans_a, char trans_b, const int M_, const int N_, const int K_, double alpha, double * a_data,
+                          const int lda_, double * b_data, const int ldb_, double beta, double * c_data, const int ldc_) {
+  integer M = (integer) M_, K = (integer) K_, N = (integer) N_;
+  integer lda = (integer) lda_, ldb = (integer) ldb_, ldc = (integer) ldc_;
+
+  dgemm_(&trans_a, &trans_b, &M, &N, &K, &alpha, a_data, &lda, b_data, &ldb, &beta, c_data, &ldc);
+}
+
+void vpMatrix::blas_dgemv(char trans, const int M_, const int N_, double alpha, double * a_data, const int lda_, double * x_data,
+                          const int incx_, double beta, double * y_data, const int incy_) {
+  integer M = (integer) M_, N = (integer) N_;
+  integer lda = (integer) lda_, incx = (integer) incx_, incy = (integer) incy_;
+
+  dgemv_(&trans, &M, &N, &alpha, a_data, &lda, x_data, &incx, &beta, y_data, &incy);
+}
+
+#endif
+
+#endif // #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/modules/core/test/math/testMatrix.cpp
+++ b/modules/core/test/math/testMatrix.cpp
@@ -76,14 +76,14 @@ namespace {
     return (max - min) * ( (double) rand() / (double) RAND_MAX ) + min;
   }
 
-  bool equalMatrix(const vpMatrix &A, const vpMatrix &B) {
+  bool equalMatrix(const vpMatrix &A, const vpMatrix &B, const double tol=std::numeric_limits<double>::epsilon()) {
     if (A.getRows() != B.getRows() || A.getCols() != B.getCols()) {
       return false;
     }
 
     for (unsigned int i = 0; i < A.getRows(); i++) {
       for (unsigned int j = 0; j < A.getCols(); j++) {
-        if ( !vpMath::equal(A[i][j], B[i][j], std::numeric_limits<double>::epsilon()) ) {
+        if ( !vpMath::equal(A[i][j], B[i][j], tol) ) {
           return false;
         }
       }
@@ -91,6 +91,149 @@ namespace {
 
     return true;
   }
+
+#ifdef VISP_HAVE_LAPACK
+  vpMatrix generateRandomMatrix(const unsigned int rows, const unsigned int cols, const double min, const double max) {
+    vpMatrix M(rows, cols);
+
+    for (unsigned int i = 0; i < M.getRows(); i++) {
+      for (unsigned int j = 0; j < M.getCols(); j++) {
+        M[i][j] = getRandomValues(min, max);
+      }
+    }
+
+    return M;
+  }
+
+  vpColVector generateRandomVector(const unsigned int rows, const double min, const double max) {
+    vpColVector v(rows);
+
+    for (unsigned int i = 0; i < v.getRows(); i++) {
+      v[i] = getRandomValues(min, max);
+    }
+
+    return v;
+  }
+
+  //Copy of vpMatrix::mult2Matrices
+  vpMatrix dgemm_regular(const vpMatrix &A, const vpMatrix &B) {
+    vpMatrix C;
+
+    if ((A.getRows() != C.getRows()) || (B.getCols() != C.getCols())) C.resize(A.getRows(), B.getCols(), false);
+
+    if (A.getCols() != B.getRows()) {
+      throw(vpException(vpException::dimensionError,
+                        "Cannot multiply (%dx%d) matrix by (%dx%d) matrix",
+                        A.getRows(), A.getCols(), B.getRows(), B.getCols()));
+    }
+
+    // 5/12/06 some "very" simple optimization to avoid indexation
+    unsigned int BcolNum = B.getCols();
+    unsigned int BrowNum = B.getRows();
+    unsigned int i,j,k;
+    for (i=0;i<A.getRows();i++)
+    {
+      double *rowptri = A[i];
+      double *ci = C[i];
+      for (j=0;j<BcolNum;j++)
+      {
+        double s = 0;
+        for (k=0;k<BrowNum;k++) s += rowptri[k] * B[k][j];
+        ci[j] = s;
+      }
+    }
+
+    return C;
+  }
+
+  //Copy of vpMatrix::AtA
+  vpMatrix AtA_regular(const vpMatrix &A) {
+    vpMatrix B;
+    B.resize(A.getCols(), A.getCols(), false);
+
+    unsigned int i,j,k;
+    double s;
+    double *ptr;
+    for (i=0;i<A.getCols();i++)
+    {
+      double *Bi = B[i] ;
+      for (j=0;j<i;j++)
+      {
+        ptr=A.data;
+        s = 0 ;
+        for (k=0;k<A.getRows();k++)
+        {
+          s +=(*(ptr+i)) * (*(ptr+j));
+          ptr+=A.getCols();
+        }
+        *Bi++ = s ;
+        B[j][i] = s;
+      }
+      ptr=A.data;
+      s = 0 ;
+      for (k=0;k<A.getRows();k++)
+      {
+        s +=(*(ptr+i)) * (*(ptr+i));
+        ptr+=A.getCols();
+      }
+      *Bi = s;
+    }
+
+    return B;
+  }
+
+  //Copy of vpMatrix::multMatrixVector
+  vpMatrix dgemv_regular(const vpMatrix &A, const vpColVector &v) {
+    vpColVector w;
+
+    if (A.getCols() != v.getRows()) {
+      throw(vpException(vpException::dimensionError,
+                        "Cannot multiply a (%dx%d) matrix by a (%d) column vector",
+                        A.getRows(), A.getCols(), v.getRows())) ;
+    }
+
+    w.resize(A.getRows(), false);
+
+    for (unsigned int j=0;j<A.getCols();j++) {
+      double vj = v[j] ; // optimization em 5/12/2006
+      for (unsigned int i=0;i<A.getRows();i++) {
+        w[i]+=A[i][j] * vj;
+      }
+    }
+
+    return w;
+  }
+
+  //Copy of vpMatrix::operator*(const vpVelocityTwistMatrix &V)
+  vpMatrix mat_mul_twist_matrix(const vpMatrix &A, const vpVelocityTwistMatrix &V) {
+    vpMatrix M;
+
+    if (A.getCols() != V.getRows()) {
+      throw(vpException(vpException::dimensionError,
+                        "Cannot multiply (%dx%d) matrix by (6x6) velocity twist matrix",
+                        A.getRows(), A.getCols()));
+    }
+
+    M.resize(A.getRows(), 6, false);
+
+    unsigned int VcolNum = V.getCols();
+    unsigned int VrowNum = V.getRows();
+
+    for (unsigned int i=0;i<A.getRows();i++)
+    {
+      double *rowptri = A[i];
+      double *ci = M[i];
+      for (unsigned int j=0;j<VcolNum;j++)
+      {
+        double s = 0;
+        for (unsigned int k=0;k<VrowNum;k++) s += rowptri[k] * V[k][j];
+        ci[j] = s;
+      }
+    }
+
+    return M;
+  }
+#endif
 }
 
 
@@ -541,7 +684,143 @@ main()
       std::cout << "juxtaposeM:\n" << juxtaposeM << std::endl;
     }
 
-    std::cout << "All tests succeed" << std::endl;
+#ifdef VISP_HAVE_LAPACK
+    {
+      std::cout << "------------------------" << std::endl;
+      std::cout << "--- BENCHMARK dgemm/dgemv" << std::endl;
+      std::cout << "------------------------" << std::endl;
+
+      size_t nb_matrices = 10000;
+      unsigned int rows = 200, cols = 6;
+      double min = -1.0, max = 1.0;
+      std::vector<vpMatrix> vec_A, vec_B, vec_C, vec_C_regular;
+      vec_C.reserve(nb_matrices);
+      vec_C_regular.reserve(nb_matrices);
+
+      for (size_t i = 0; i < nb_matrices; i++) {
+        vec_A.push_back( generateRandomMatrix(cols, rows, min, max) );
+        vec_B.push_back( generateRandomMatrix(rows, cols, min, max) );
+      }
+
+      double t = vpTime::measureTimeMs();
+      for (size_t i = 0; i < nb_matrices; i++) {
+        vec_C.push_back( vec_A[i]*vec_B[i] );
+      }
+      t = vpTime::measureTimeMs() - t;
+      std::cout << nb_matrices << " matrix multiplication: (6x200) x (200x6)" << std::endl;
+      std::cout << "Lapack: " << t << " ms" << std::endl;
+      std::cout << "vec_C:\n" << vec_C.back() << std::endl;
+
+      t = vpTime::measureTimeMs();
+      for (size_t i = 0; i < nb_matrices; i++) {
+        vec_C_regular.push_back( dgemm_regular(vec_A[i], vec_B[i]) );
+      }
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\nRegular: " << t << " ms" << std::endl;
+      std::cout << "vec_C_regular:\n" << vec_C_regular.back() << std::endl;
+
+
+      vpMatrix A = generateRandomMatrix(480, 640, min, max), B = generateRandomMatrix(640, 480, min, max);
+      vpMatrix AB, AB_regular;
+
+      t = vpTime::measureTimeMs();
+      AB = A*B;
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\nMatrix multiplication: (480x640) x (640x480)" << std::endl;
+      std::cout << "Lapack: " << t << " ms" << std::endl;
+      std::cout << "Min=" << AB.getMinValue() << " ; Max=" << AB.getMaxValue() << std::endl;
+
+      t = vpTime::measureTimeMs();
+      AB_regular = dgemm_regular(A, B);
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "Regular: " << t << " ms" << std::endl;
+      std::cout << "Min=" << AB_regular.getMinValue() << " ; Max=" << AB_regular.getMaxValue() << std::endl;
+      bool res = equalMatrix(AB, AB_regular, 1e-9);
+      std::cout << "Check result: " << res << std::endl;
+      if (!res) {
+        std::cerr << "Problem with matrix multiplication!" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+
+      int nb_iterations = 1000;
+      vpMatrix L = generateRandomMatrix(1000, 6, min, max);
+      vpMatrix LTL, LTL_regular;
+
+      t = vpTime::measureTimeMs();
+      for (int i = 0; i < nb_iterations; i++)
+        LTL = L.AtA();
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\n" << nb_iterations << " iterations of AtA for size: (1000x6)" << std::endl;
+      std::cout << "Lapack: " << t << " ms" << std::endl;
+      std::cout << "LTL:\n" << LTL << std::endl;
+
+      t = vpTime::measureTimeMs();
+      for (int i = 0; i < nb_iterations; i++)
+        LTL_regular = AtA_regular(L);
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\nRegular: " << t << " ms" << std::endl;
+      std::cout << "LTL_regular:\n" << LTL_regular << std::endl;
+      res = equalMatrix(LTL, LTL_regular, 1e-9);
+      std::cout << "Check result: " << res << std::endl;
+      if (!res) {
+        std::cerr << "Problem with vpMatrix::AtA()!" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+
+      vpMatrix LT = generateRandomMatrix(6, 1000, min, max);
+      vpColVector R = generateRandomVector(1000, min, max);
+      vpMatrix LTR, LTR_regular;
+
+      t = vpTime::measureTimeMs();
+      for (int i = 0; i < nb_iterations; i++)
+        LTR = LT*R;
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\n" << nb_iterations << " iterations of matrix vector multiplication: (6x1000) x (1000x1)" << std::endl;
+      std::cout << "Lapack: " << t << " ms" << std::endl;
+      std::cout << "LTR:\n" << LTR.t() << std::endl;
+
+      t = vpTime::measureTimeMs();
+      for (int i = 0; i < nb_iterations; i++)
+        LTR_regular = dgemv_regular(LT, R);
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\nRegular: " << t << " ms" << std::endl;
+      std::cout << "LTR_regular:\n" << LTR_regular.t() << std::endl;
+      res = equalMatrix(LTR, LTR_regular, 1e-9);
+      std::cout << "Check result: " << res << std::endl;
+      if (!res) {
+        std::cerr << "Problem with dgemv!" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+
+      vpVelocityTwistMatrix V(getRandomValues(min, max), getRandomValues(min, max), getRandomValues(min, max),
+                              getRandomValues(min, max), getRandomValues(min, max), getRandomValues(min, max));
+      vpMatrix LV, LV_regular;
+
+      t = vpTime::measureTimeMs();
+      for (int i = 0; i < nb_iterations; i++)
+        LV = L*V;
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "\n" << nb_iterations << " iterations of matrix velocity twist matrix multiplication: (1000x6) x (6x6)" << std::endl;
+      std::cout << "Lapack: " << t << " ms" << std::endl;
+
+      t = vpTime::measureTimeMs();
+      for (int i = 0; i < nb_iterations; i++)
+        LV_regular = mat_mul_twist_matrix(L, V);
+      t = vpTime::measureTimeMs() - t;
+      std::cout << "Regular: " << t << " ms" << std::endl;
+      res = equalMatrix(LV, LV_regular, 1e-9);
+      std::cout << "Check result: " << res << std::endl;
+      if (!res) {
+        std::cerr << "Problem with matrix and velocity twist matrix multiplication!" << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+#endif
+
+    std::cout << "\nAll tests succeed" << std::endl;
     return EXIT_SUCCESS;
   }
   catch(vpException &e) {
@@ -549,4 +828,3 @@ main()
     return EXIT_FAILURE;
   }
 }
-


### PR DESCRIPTION
Use Lapack BLAS if available to compute matrix multiplication and matrix/colVector multiplication.
For instance, a large `(480x640) x (640x480)` matrix multiplication:
 - before: 321 ms
 - after: 9 ms

For more reduced matrix size, 10000 matrix multiplications: `(6x200) x (200x6):`
 - before 96 ms
 - after 46 ms

resolve #190 
