### PR TITLE
Fix missing braces, fix issue when copying an image and display

### DIFF
--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -1034,6 +1034,12 @@ template<class Type>
 vpImage<Type> & vpImage<Type>::operator=(vpImage<Type> other)
 {
   swap(*this, other);
+  //Swap back display pointer if it was not null
+  //vpImage<unsigned char> I2(480, 640);
+  //vpDisplayX d(I2);
+  //I2 = I1; //copy only the data
+  if (other.display != NULL)
+    display = other.display;
 
   return *this;
 }

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -4591,13 +4591,14 @@ void vpMbGenericTracker::TrackerWrapper::setPose(const vpImage<unsigned char> &I
   bool performKltSetPose = false;
 
 #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
-  if (m_trackerType & KLT_TRACKER)
+  if (m_trackerType & KLT_TRACKER) {
     performKltSetPose = true;
 
     if (useScanLine || clippingFlag > 3)
       cam.computeFov(I.getWidth(), I.getHeight());
 
     vpMbKltTracker::setPose(I, cdMo);
+  }
 #endif
 
   if (!performKltSetPose) {


### PR DESCRIPTION
- Fix issue when copying an image and display pointer that should not be copied.
- Add missing braces in `setPose`.