### PR TITLE
Install OpenCV on Travis OSX.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ before_install:
 #  - unzip ${TRAVIS_BUILD_DIR}/ViSP-images-3.0.0.zip -d ${TRAVIS_BUILD_DIR}
   # Get libs for OSX
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update; fi"
-  #- "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap homebrew/science; fi"
-  #- "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install opencv3; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then /usr/bin/yes | pip uninstall numpy; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew tap homebrew/science; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install opencv3; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then export OpenCV_DIR=/usr/local/opt/opencv3; fi"
   - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew install libxml2 libdc1394 gsl; fi"
   
   # Get libs for Linux


### PR DESCRIPTION
Install OpenCV on Travis OSX.
See [[macOS] Conflict between numpy installed by pip and brew #6688](https://github.com/travis-ci/travis-ci/issues/6688).