### PR TITLE
Add const type qualifier in vpPylonGrabber classes

### DIFF
--- a/modules/sensor/include/visp3/sensor/vpPylonGrabber.h
+++ b/modules/sensor/include/visp3/sensor/vpPylonGrabber.h
@@ -299,7 +299,7 @@ public:
 
     \sa getCameraSerial()
    */
-  virtual void setCameraSerial(std::string &serial) = 0;
+  virtual void setCameraSerial(const std::string &serial) = 0;
   /*!
     Set camera exposure mode and parameter.
 

--- a/modules/sensor/src/framegrabber/pylon/vpPylonGrabberGigE.cpp
+++ b/modules/sensor/src/framegrabber/pylon/vpPylonGrabberGigE.cpp
@@ -338,7 +338,7 @@ void vpPylonGrabberGigE::setCameraIndex(unsigned int index)
 
   \sa getCameraSerial()
  */
-void vpPylonGrabberGigE::setCameraSerial(std::string &serial)
+void vpPylonGrabberGigE::setCameraSerial(const std::string &serial)
 {
   m_numCameras = getNumCameras();
   for (unsigned int i = 0; i < m_numCameras; i++) {

--- a/modules/sensor/src/framegrabber/pylon/vpPylonGrabberGigE.h
+++ b/modules/sensor/src/framegrabber/pylon/vpPylonGrabberGigE.h
@@ -100,7 +100,7 @@ public:
 
   float setBlackLevel(float blacklevel_value = 0);
   void setCameraIndex(unsigned int index);
-  void setCameraSerial(std::string &serial);
+  void setCameraSerial(const std::string &serial);
   float setExposure(bool exposure_on, bool exposure_auto,
                     float exposure_value = 0);
   float setGain(bool gain_auto, float gain_value = 0);

--- a/modules/sensor/src/framegrabber/pylon/vpPylonGrabberUsb.cpp
+++ b/modules/sensor/src/framegrabber/pylon/vpPylonGrabberUsb.cpp
@@ -332,7 +332,7 @@ void vpPylonGrabberUsb::setCameraIndex(unsigned int index)
 
   \sa getCameraSerial()
  */
-void vpPylonGrabberUsb::setCameraSerial(std::string &serial)
+void vpPylonGrabberUsb::setCameraSerial(const std::string &serial)
 {
   m_numCameras = getNumCameras();
   for (unsigned int i = 0; i < m_numCameras; i++) {

--- a/modules/sensor/src/framegrabber/pylon/vpPylonGrabberUsb.h
+++ b/modules/sensor/src/framegrabber/pylon/vpPylonGrabberUsb.h
@@ -100,7 +100,7 @@ public:
 
   float setBlackLevel(float blacklevel_value = 0);
   void setCameraIndex(unsigned int index);
-  void setCameraSerial(std::string &serial);
+  void setCameraSerial(const std::string &serial);
   float setExposure(bool exposure_on, bool exposure_auto,
                     float exposure_value = 0);
   float setGain(bool gain_auto, float gain_value = 0);


### PR DESCRIPTION
It's safer to change serial inputs into const types.