### PR TITLE
Add AprilTag references, remove implementation from doc

### DIFF
--- a/doc/biblio/references.bib
+++ b/doc/biblio/references.bib
@@ -454,3 +454,24 @@ x-advisor = {Chaumette, F.},
    Year = {2016},
    url = {https://hal.inria.fr/hal-01246370}
 }
+
+@inproceedings{olson2011tags,
+    TITLE      = {{AprilTag}: A robust and flexible visual fiducial system},
+    AUTHOR     = {Edwin Olson},
+    BOOKTITLE  = {Proceedings of the {IEEE} International Conference on Robotics and
+                 Automation ({ICRA})},
+    YEAR       = {2011},
+    MONTH      = {May},
+    PAGES      = {3400-3407},
+    KEYWORDS   = {Robot navigation, SLAM, Visual Fiducial, ARToolkit},
+    PUBLISHER  = {IEEE},
+}
+
+@inproceedings{wang2016iros,
+    AUTHOR     = {John Wang and Edwin Olson},
+    TITLE      = {{AprilTag} 2: Efficient and robust fiducial detection},
+    BOOKTITLE  = {Proceedings of the {IEEE/RSJ} International Conference on Intelligent
+                 Robots and Systems {(IROS)}},
+    YEAR       = {2016},
+    MONTH      = {October},
+}

--- a/modules/detection/include/visp3/detection/vpDetectorAprilTag.h
+++ b/modules/detection/include/visp3/detection/vpDetectorAprilTag.h
@@ -47,6 +47,8 @@
   \ingroup group_detection_tag
   Base class for AprilTag detector. This class is a wrapper over <a href="https://april.eecs.umich.edu/software/apriltag.html">AprilTag</a>.
   There is no need to download and install AprilTag from source code or existing pre-built packages since the source code is embedded in ViSP.
+  Reference papers are <I> AprilTag: A robust and flexible visual fiducial system </I> (\cite olson2011tags) and <I> AprilTag 2: Efficient and robust
+  fiducial detection </I> (\cite wang2016iros).
 
   The detect() function allows to detect multiple tags in an image. Once detected,
   for each tag it is possible to retrieve the location of the corners using getPolygon(),

--- a/modules/detection/src/tag/vpDetectorAprilTag.cpp
+++ b/modules/detection/src/tag/vpDetectorAprilTag.cpp
@@ -51,7 +51,7 @@
 #include <visp3/core/vpPixelMeterConversion.h>
 #include <visp3/vision/vpPose.h>
 
-
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 class vpDetectorAprilTag::Impl {
 public:
   Impl(const vpAprilTagFamily &tagFamily, const vpPoseEstimationMethod &method)
@@ -309,6 +309,7 @@ protected:
   apriltag_detector_t *m_td;
   apriltag_family_t *m_tf;
 };
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /*!
    Default constructor.


### PR DESCRIPTION
Add AprilTag references. 
Do not expose AprilTag implementation in Doxygen.