### PR TITLE
Fix apriltag memory leak, add contrib bibtex

### DIFF
--- a/doc/config-doxygen.in
+++ b/doc/config-doxygen.in
@@ -703,7 +703,8 @@ LAYOUT_FILE            =
 # LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
 # search path. See also \cite for info how to create references.
 
-CITE_BIB_FILES         = "@VISP_SOURCE_DIR@/doc/biblio/references.bib"
+CITE_BIB_FILES         = "@VISP_SOURCE_DIR@/doc/biblio/references.bib" \
+                         "@VISP_CONTRIB_MODULES_PATH@/doc/biblio/references.bib"
 
 #---------------------------------------------------------------------------
 # Configuration options related to warning and progress messages

--- a/modules/core/src/tools/geometry/vpPolygon.cpp
+++ b/modules/core/src/tools/geometry/vpPolygon.cpp
@@ -297,7 +297,6 @@ bool
 vpPolygon::isInside(const vpImagePoint& ip, const PointInPolygonMethod &method) const
 {
   if (_corners.size() < 3) {
-    std::cerr << "It is not a polygon (_corners.size() < 3)!" << std::endl;
     return false;
   }
 
@@ -360,7 +359,6 @@ vpPolygon::isInside(const vpImagePoint& ip, const PointInPolygonMethod &method) 
 void
 vpPolygon::precalcValuesPnPoly() {
   if (_corners.size() < 3) {
-    std::cerr << "It is not a polygon (_corners.size() < 3)!" << std::endl;
     return;
   }
 

--- a/modules/detection/src/tag/vpDetectorAprilTag.cpp
+++ b/modules/detection/src/tag/vpDetectorAprilTag.cpp
@@ -254,7 +254,7 @@ public:
       }
     }
 
-    zarray_destroy(detections);
+    apriltag_detections_destroy(detections);
 
     return detected;
   }


### PR DESCRIPTION
- Remove useless error message. 
- Add contrib bibtex in doxygen.
- Fix apriltag memory leak. 

> ==30290== 960 bytes in 12 blocks are indirectly lost in loss record 1 of 2
> ==30290==    at 0x4C29975: calloc (vg_replace_malloc.c:711)
> ==30290==    by 0x4E5B1DA: matd_create (matd.c:58)
> ==30290==    by 0x4E5B372: matd_copy (matd.c:162)
> ==30290==    by 0x4E5D3A9: matd_op (matd.c:846)
> ==30290==    by 0x4E46C65: quad_decode_task (apriltag.c:1043)
> ==30290==    by 0x4E57850: workerpool_run_single (workerpool.c:176)
> ==30290==    by 0x4E47AAD: apriltag_detector_detect (apriltag.c:1252)
> ==30290==    by 0x4E4081A: vpDetectorAprilTag::Impl::detect(vpImage&lt;unsigned char&gt; const&amp;, std::vector&lt;std::vector&lt;vpImagePoint, std::allocator&lt;vpImagePoint&gt; &gt;, std::allocator&lt;std::vector&lt;vpImagePoint, std::allocator&lt;vpImagePoint&gt; &gt; &gt; &gt;&amp;, std::vector&lt;std::string, std::allocator&lt;std::string&gt; &gt;&amp;, bool, bool) (vpDetectorAprilTag.cpp:139)
> ==30290==    by 0x4E3D779: vpDetectorAprilTag::detect(vpImage&lt;unsigned char&gt; const&amp;, double, vpCameraParameters const&amp;, std::vector&lt;vpHomogeneousMatrix, std::allocator&lt;vpHomogeneousMatrix&gt; &gt;&amp;) (vpDetectorAprilTag.cpp:360)
> ==30290==    by 0x4033A7: main (testAprilTag.cpp:263)
> ==30290== 
> <b>MLK</b> ==30290== 2,304 (1,344 direct, 960 indirect) bytes in 12 blocks are definitely lost in loss record 2 of 2
> ==30290==    at 0x4C29975: calloc (vg_replace_malloc.c:711)
> ==30290==    by 0x4E46B60: quad_decode_task (apriltag.c:1024)
> ==30290==    by 0x4E57850: workerpool_run_single (workerpool.c:176)
> ==30290==    by 0x4E47AAD: apriltag_detector_detect (apriltag.c:1252)
> ==30290==    by 0x4E4081A: vpDetectorAprilTag::Impl::detect(vpImage&lt;unsigned char&gt; const&amp;, std::vector&lt;std::vector&lt;vpImagePoint, std::allocator&lt;vpImagePoint&gt; &gt;, std::allocator&lt;std::vector&lt;vpImagePoint, std::allocator&lt;vpImagePoint&gt; &gt; &gt; &gt;&amp;, std::vector&lt;std::string, std::allocator&lt;std::string&gt; &gt;&amp;, bool, bool) (vpDetectorAprilTag.cpp:139)
> ==30290==    by 0x4E3D779: vpDetectorAprilTag::detect(vpImage&lt;unsigned char&gt; const&amp;, double, vpCameraParameters const&amp;, std::vector&lt;vpHomogeneousMatrix, std::allocator&lt;vpHomogeneousMatrix&gt; &gt;&amp;) (vpDetectorAprilTag.cpp:360)
> ==30290==    by 0x4033A7: main (testAprilTag.cpp:263)