### PR TITLE
sorting result of vpIoTools::getDirFiles()

### DIFF
--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -1732,6 +1732,7 @@ std::vector<std::string> vpIoTools::getDirFiles(const std::string &pathname) {
   }
   while (FindNextFile(hFind, &FindFileData));
   FindClose(hFind);
+  std::sort(files.begin(), files.end());
   return files;
 
 #  else

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -1676,7 +1676,7 @@ std::vector<std::string> vpIoTools::splitChain(const std::string & chain, const 
 
 
 /*!
-   List of files in directory
+   List of files in directory, in alphabetical order.
    There is no difference if pathname contains terminating backslash or not
    Unlike scandir(), does not return "." and ".."
    \param pathname : path to directory
@@ -1705,6 +1705,7 @@ std::vector<std::string> vpIoTools::getDirFiles(const std::string &pathname) {
     free(list[i]);
   }
   free(list);
+  std::sort(files.begin(), files.end());
   return files;
 
 #elif defined(_WIN32)


### PR DESCRIPTION
Adding a sort of the vector containing all the files in a directory,  to have a vector sorted in alphabetical order in output