### PR TITLE
Improve VISP_INPUT_IMAGE_PATH usage to get more flexibility in order …

### DIFF
--- a/demo/wireframe-simulator/CMakeLists.txt
+++ b/demo/wireframe-simulator/CMakeLists.txt
@@ -28,7 +28,7 @@
 # WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 #
 # Description:
-# ViSP overall configuration file. 
+# ViSP overall configuration file.
 #
 # Authors:
 # Fabien Spindler
@@ -63,7 +63,7 @@ endforeach()
 # To run some of these tests don't forget to set VISP_INPUT_IMAGE_PATH
 # environment variable to the ViSP test sequences location.
 # To get these sequence download ViSP-images.tar.gz from
-# http://www.irisa.fr/lagadic/visp/visp.html
+# https://visp.inria.fr/download/
 add_test(servoSimu4Points servoSimu4Points -d)
 add_test(servoSimuCylinder servoSimuCylinder -d)
 add_test(servoSimuSphere servoSimuSphere -d)

--- a/demo/wireframe-simulator/servoSimu4Points.cpp
+++ b/demo/wireframe-simulator/servoSimu4Points.cpp
@@ -102,7 +102,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set mire.pgm image input path.\n\
-     From this path read \"ViSP-images/mire/mire.pgm\" video.\n\
+     From this path read \"mire/mire.pgm\" image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment variable \n\
      produces the same behaviour than using this option.\n\
             \n\
@@ -295,7 +295,7 @@ main(int argc, const char ** argv)
     if (!opt_ipath.empty())
       ipath = opt_ipath;
 
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/mire/mire.pgm");
+    filename = vpIoTools::createFilePath(ipath, "mire/mire.pgm");
 
     imsim.init(filename.c_str(), X);
 

--- a/example/coin-simulator/simulateCircle2DCamVelocity.cpp
+++ b/example/coin-simulator/simulateCircle2DCamVelocity.cpp
@@ -94,7 +94,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/iv/4points.iv\"\n\
+     From this path read \"iv/4points.iv\"\n\
      cad model.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -347,7 +347,7 @@ main(int argc, const char ** argv)
       simu.addAbsoluteFrame() ;
 
       // Load the cad model
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/iv/circle.iv");
+      filename = vpIoTools::createFilePath(ipath, "iv/circle.iv");
       simu.load(filename.c_str(),fMo) ;
 
       simu.setInternalCameraParameters(cam) ;

--- a/example/coin-simulator/simulateFourPoints2DCartesianCamVelocity.cpp
+++ b/example/coin-simulator/simulateFourPoints2DCartesianCamVelocity.cpp
@@ -91,7 +91,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/iv/4points.iv\"\n\
+     From this path read \"iv/4points.iv\"\n\
      cad model.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -354,7 +354,7 @@ int main(int argc, const char ** argv)
       simu.setZoomFactor(1.0f) ;
 
       // Load the cad model
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/iv/4points.iv");
+      filename = vpIoTools::createFilePath(ipath, "iv/4points.iv");
       simu.load(filename.c_str()) ;
 
       simu.setInternalCameraParameters(cam) ;

--- a/example/coin-simulator/simulateFourPoints2DPolarCamVelocity.cpp
+++ b/example/coin-simulator/simulateFourPoints2DPolarCamVelocity.cpp
@@ -89,7 +89,7 @@ fprintf(stdout, "\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/iv/4points.iv\"\n\
+     From this path read \"iv/4points.iv\"\n\
      cad model.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -375,7 +375,7 @@ int main(int argc, const char ** argv)
       simu.setZoomFactor(1.0f) ;
 
       // Load the cad model
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/iv/4points.iv");
+      filename = vpIoTools::createFilePath(ipath, "iv/4points.iv");
       simu.load(filename.c_str()) ;
 
       simu.setInternalCameraParameters(cam) ;

--- a/example/device/display/CMakeLists.txt
+++ b/example/device/display/CMakeLists.txt
@@ -62,7 +62,7 @@ endforeach()
 # To run some of these tests don't forget to set VISP_INPUT_IMAGE_PATH
 # environment variable to the ViSP test sequences location.
 # To get these sequence download ViSP-images.tar.gz from
-# http://www.irisa.fr/lagadic/visp/visp.html
+# https://visp.inria.fr/download/
 add_test(displaySequence displaySequence ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(displayGDI displayGDI -c ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(displayD3D displayD3D -c ${OPTION_TO_DESACTIVE_DISPLAY})

--- a/example/device/display/displayD3D.cpp
+++ b/example/device/display/displayD3D.cpp
@@ -97,7 +97,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -261,7 +261,7 @@ main(int argc, const char ** argv)
     vpImagePoint ip, ip1, ip2;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I, filename) ;
 
     // Create a display using X11
@@ -366,7 +366,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a grey image from the disk and convert it to a color image
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(Irgba, filename) ;
 
     // Create a new display

--- a/example/device/display/displayGDI.cpp
+++ b/example/device/display/displayGDI.cpp
@@ -96,7 +96,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -259,7 +259,7 @@ main(int argc, const char ** argv)
     vpImagePoint ip, ip1, ip2;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I, filename) ;
 
     // Create a display using X11
@@ -364,7 +364,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a grey image from the disk and convert it to a color image
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(Irgba, filename) ;
 
     // Create a new display

--- a/example/device/display/displayGTK.cpp
+++ b/example/device/display/displayGTK.cpp
@@ -99,7 +99,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -267,7 +267,7 @@ main(int argc, const char ** argv)
     vpImagePoint ip, ip1, ip2;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I, filename) ;
 
     // Create a display using X11
@@ -372,7 +372,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a grey image from the disk and convert it to a color image
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(Irgba, filename) ;
 
     // Create a new display

--- a/example/device/display/displayOpenCV.cpp
+++ b/example/device/display/displayOpenCV.cpp
@@ -96,7 +96,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -267,7 +267,7 @@ main(int argc, const char ** argv)
     vpImagePoint ip, ip1, ip2;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I, filename) ;
 
     // Create a display using X11
@@ -372,7 +372,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a grey image from the disk and convert it to a color image
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(Irgba, filename) ;
 
     // Create a new display

--- a/example/device/display/displaySequence.cpp
+++ b/example/device/display/displaySequence.cpp
@@ -116,7 +116,7 @@ SYNOPSIS\n\
  OPTIONS:                                               Default\n\
   -i <test image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/cube/image.%%04d.pgm\"\n\
+     From this path read \"cube/image.%%04d.pgm\"\n\
      images. These images come from ViSP-images-x.y.z.tar.gz\n\
      available on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -154,7 +154,7 @@ SYNOPSIS\n\
 \n\
   -h\n\
      Print the help.\n\n",
-	  ipath.c_str(),ppath.c_str(), first, nimages, step);
+    ipath.c_str(),ppath.c_str(), first, nimages, step);
 
   if (badparam)
     fprintf(stdout, "\nERROR: Bad parameter [%s]\n", badparam);
@@ -300,11 +300,11 @@ main(int argc, const char ** argv)
       //  terminate called after throwing an instance of 'vpImageException'
       //
       //  The sequence is available on the visp www site
-      //  http://www.irisa.fr/lagadic/visp/visp.html
+      //  https://visp.inria.fr/download/
       //  in the download section. It is named "ViSP-images.tar.gz"
 
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+      dirname = vpIoTools::createFilePath(ipath, "cube");
 
       // Build the name of the image file
 

--- a/example/device/display/displayX.cpp
+++ b/example/device/display/displayX.cpp
@@ -96,7 +96,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -267,7 +267,7 @@ main(int argc, const char ** argv)
     vpImagePoint ip, ip1, ip2;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I, filename) ;
 
     // Create a display using X11
@@ -372,7 +372,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a grey image from the disk and convert it to a color image
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(Irgba, filename) ;
 
     // Create a new display

--- a/example/device/display/displayXMulti.cpp
+++ b/example/device/display/displayXMulti.cpp
@@ -99,8 +99,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -269,7 +269,7 @@ main(int argc, const char ** argv)
 
     try {
       // Load a grey image from the disk
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
       vpImageIo::read(I1, filename) ;
     }
     catch(...)
@@ -284,7 +284,7 @@ main(int argc, const char ** argv)
     }
     try {
       // Load a color image from the disk
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
       vpImageIo::read(I2, filename) ;
     }
     catch(...)

--- a/example/device/framegrabber/grabDisk.cpp
+++ b/example/device/framegrabber/grabDisk.cpp
@@ -101,7 +101,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                     %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/cube/image.%%04d.pgm\"\n\
+     From this path read \"cube/image.%%04d.pgm\"\n\
      images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -214,7 +214,7 @@ int main(int argc, const char ** argv)
     std::string env_ipath;
     std::string opt_ipath;
     std::string ipath;
-    std::string opt_basename = "ViSP-images/cube/image.";
+    std::string opt_basename = "cube/image.";
     std::string opt_ext = "pgm";
     bool opt_display = true;
 

--- a/example/direct-visual-servoing/photometricVisualServoing.cpp
+++ b/example/direct-visual-servoing/photometricVisualServoing.cpp
@@ -97,7 +97,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/doisneau/doisneau.jpg\"\n\
+     From this path read \"doisneau/doisneau.jpg\"\n\
      images. \n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -221,7 +221,7 @@ main(int argc, const char ** argv)
     }
 
     vpImage<unsigned char> Itexture ;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(Itexture,filename) ;
 
     vpColVector X[4];

--- a/example/image/imageDiskRW.cpp
+++ b/example/image/imageDiskRW.cpp
@@ -90,7 +90,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -253,7 +253,7 @@ main(int argc, const char ** argv)
     // Although I is a gray level image you can read and write
     // color image. Obviously the color will be translated as a gray level
 
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(I, filename);
 
     filename = vpIoTools::createFilePath(dirname, "IoPPM.Klimt_char.ppm");
@@ -264,7 +264,7 @@ main(int argc, const char ** argv)
     // an exception is thrown
     //Try to load a non existing image
     try {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/image-that-does-not-exist.ppm");
+      filename = vpIoTools::createFilePath(ipath, "image-that-does-not-exist.ppm");
       vpImageIo::read(I,filename) ;
     }
     catch(vpException &e) {
@@ -290,7 +290,7 @@ main(int argc, const char ** argv)
     // read write unsigned char ppm image.
 
     // Load a color image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(Irgba, filename);
 
     // Write the content of the color image on the disk
@@ -299,7 +299,7 @@ main(int argc, const char ** argv)
 
     // test io error
     try {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/image-that-does-not-exist.ppm");
+      filename = vpIoTools::createFilePath(ipath, "image-that-does-not-exist.ppm");
       vpImageIo::read(Irgba,filename) ;
     }
     catch(vpException &e) {

--- a/example/key-point/fernClassifier.cpp
+++ b/example/key-point/fernClassifier.cpp
@@ -97,7 +97,7 @@ OPTIONS:                                               \n\
 \n\
   -i <input image path>                                \n\
      Set image input path.\n\
-     From this path read \"ViSP-images/line/image.%%04d.pgm\"\n\
+     From this path read \"line/image.%%04d.pgm\"\n\
      images. \n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -240,7 +240,7 @@ main(int argc, const char** argv)
 
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+    dirname = vpIoTools::createFilePath(ipath, "cube");
 
     // Build the name of the image file
     unsigned iter = 0; // Image number

--- a/example/key-point/keyPointSurf.cpp
+++ b/example/key-point/keyPointSurf.cpp
@@ -96,7 +96,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/line/image.%%04d.pgm\"\n\
+     From this path read \"line/image.%%04d.pgm\"\n\
      images. \n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -219,7 +219,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> Icur ;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+    dirname = vpIoTools::createFilePath(ipath, "cube");
 
     // Build the name of the image file
     unsigned int iter = 0; // Image number

--- a/example/key-point/planarObjectDetector.cpp
+++ b/example/key-point/planarObjectDetector.cpp
@@ -99,7 +99,7 @@ OPTIONS:                                               \n\
 \n\
   -i <input image path>                                \n\
      Set image input path.\n\
-     From this path read \"ViSP-images/line/image.%%04d.pgm\"\n\
+     From this path read \"line/image.%%04d.pgm\"\n\
      images. \n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -243,7 +243,7 @@ main(int argc, const char** argv)
     vpImage <unsigned char> Iref;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+    dirname = vpIoTools::createFilePath(ipath, "cube");
 
     // Build the name of the image file
     unsigned iter = 0; // Image number

--- a/example/manual/simulation/manSimu4Dots.cpp
+++ b/example/manual/simulation/manSimu4Dots.cpp
@@ -274,7 +274,7 @@ main()
 
     // Set the default input path
     if (! ipath.empty())
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/iv/4points.iv");
+      filename = vpIoTools::createFilePath(ipath, "iv/4points.iv");
 
     std::cout << "Load : " << filename << std::endl
               << "This file should be in the working directory" << std::endl;

--- a/example/manual/simulation/manSimu4Points.cpp
+++ b/example/manual/simulation/manSimu4Points.cpp
@@ -224,7 +224,7 @@ main()
 
     // Set the default input path
     if (! ipath.empty())
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/iv/4points.iv");
+      filename = vpIoTools::createFilePath(ipath, "iv/4points.iv");
 
     std::cout << "Load : " << filename << std::endl
               << "This file should be in the working directory" << std::endl;

--- a/example/ogre-simulator/AROgre.cpp
+++ b/example/ogre-simulator/AROgre.cpp
@@ -100,7 +100,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mire-2/image.%%04d.pgm\". These \n\
+     \"mire-2/image.%%04d.pgm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -568,7 +568,7 @@ int main(int argc, const char **argv)
 
     if (opt_ppath.empty()){
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2");
+      dirname = vpIoTools::createFilePath(ipath, "mire-2");
 
       // Build the name of the image file
 

--- a/example/ogre-simulator/AROgreBasic.cpp
+++ b/example/ogre-simulator/AROgreBasic.cpp
@@ -99,7 +99,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mire-2/image.%%04d.pgm\". These \n\
+     \"mire-2/image.%%04d.pgm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -446,7 +446,7 @@ int main(int argc, const char **argv)
 
     if (opt_ppath.empty()){
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2");
+      dirname = vpIoTools::createFilePath(ipath, "mire-2");
 
       // Build the name of the image file
 

--- a/example/pose-estimation/poseVirtualVS.cpp
+++ b/example/pose-estimation/poseVirtualVS.cpp
@@ -120,7 +120,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/cube/image.%%04d.pgm\"\n\
+     \"cube/image.%%04d.pgm\"\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -304,11 +304,11 @@ main(int argc, const char** argv)
       //  terminate called after throwing an instance of 'vpImageException'
       //
       //  The sequence is available on the visp www site
-      //  http://www.irisa.fr/lagadic/visp/visp.html
+      //  https://visp.inria.fr/download/
       //  in the download section. It is named "ViSP-images-x.y.z.tar.gz"
 
       // directory name
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+      dirname = vpIoTools::createFilePath(ipath, "cube");
 
       // Build the name of the image file
 

--- a/example/tools/histogram.cpp
+++ b/example/tools/histogram.cpp
@@ -93,7 +93,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -243,7 +243,7 @@ main(int argc, const char ** argv)
     // Load a grey image from the disk
     filename = ipath;
     if (opt_ipath.empty())
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     std::cout << "Read: " << filename << std::endl;
     vpImageIo::read(I, filename) ;

--- a/example/tracking/mbtEdgeKltMultiTracking.cpp
+++ b/example/tracking/mbtEdgeKltMultiTracking.cpp
@@ -80,7 +80,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -247,16 +247,16 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
     if (!opt_modelFile.empty()){
       modelFile = opt_modelFile;
@@ -264,11 +264,11 @@ main(int argc, const char ** argv)
       std::string modelFileCao;
       std::string modelFileWrl;
       if(trackCylinder){
-        modelFileCao = "ViSP-images/mbt/cube_and_cylinder.cao";
-        modelFileWrl = "ViSP-images/mbt/cube_and_cylinder.wrl";
+        modelFileCao = "mbt/cube_and_cylinder.cao";
+        modelFileWrl = "mbt/cube_and_cylinder.wrl";
       }else{
-        modelFileCao = "ViSP-images/mbt/cube.cao";
-        modelFileWrl = "ViSP-images/mbt/cube.wrl";
+        modelFileCao = "mbt/cube.cao";
+        modelFileWrl = "mbt/cube.wrl";
       }
 
       if(!opt_ipath.empty()){
@@ -302,9 +302,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I1, I2;
     vpVideoReader reader;

--- a/example/tracking/mbtEdgeKltTracking.cpp
+++ b/example/tracking/mbtEdgeKltTracking.cpp
@@ -78,7 +78,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -245,16 +245,16 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
     if (!opt_modelFile.empty()){
       modelFile = opt_modelFile;
@@ -262,11 +262,11 @@ main(int argc, const char ** argv)
       std::string modelFileCao;
       std::string modelFileWrl;
       if(trackCylinder){
-        modelFileCao = "ViSP-images/mbt/cube_and_cylinder.cao";
-        modelFileWrl = "ViSP-images/mbt/cube_and_cylinder.wrl";
+        modelFileCao = "mbt/cube_and_cylinder.cao";
+        modelFileWrl = "mbt/cube_and_cylinder.wrl";
       }else{
-        modelFileCao = "ViSP-images/mbt/cube.cao";
-        modelFileWrl = "ViSP-images/mbt/cube.wrl";
+        modelFileCao = "mbt/cube.cao";
+        modelFileWrl = "mbt/cube.wrl";
       }
 
       if(!opt_ipath.empty()){
@@ -300,9 +300,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I;
     vpVideoReader reader;

--- a/example/tracking/mbtEdgeMultiTracking.cpp
+++ b/example/tracking/mbtEdgeMultiTracking.cpp
@@ -82,7 +82,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -249,16 +249,16 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
     if (!opt_modelFile.empty()){
       modelFile = opt_modelFile;
@@ -266,11 +266,11 @@ main(int argc, const char ** argv)
       std::string modelFileCao;
       std::string modelFileWrl;
       if(trackCylinder){
-        modelFileCao = "ViSP-images/mbt/cube_and_cylinder.cao";
-        modelFileWrl = "ViSP-images/mbt/cube_and_cylinder.wrl";
+        modelFileCao = "mbt/cube_and_cylinder.cao";
+        modelFileWrl = "mbt/cube_and_cylinder.wrl";
       }else{
-        modelFileCao = "ViSP-images/mbt/cube.cao";
-        modelFileWrl = "ViSP-images/mbt/cube.wrl";
+        modelFileCao = "mbt/cube.cao";
+        modelFileWrl = "mbt/cube.wrl";
       }
 
       if(!opt_ipath.empty()){
@@ -304,9 +304,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I1, I2;
     vpVideoReader reader;

--- a/example/tracking/mbtEdgeTracking.cpp
+++ b/example/tracking/mbtEdgeTracking.cpp
@@ -80,7 +80,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -248,16 +248,16 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
     if (!opt_modelFile.empty()){
       modelFile = opt_modelFile;
@@ -265,11 +265,11 @@ main(int argc, const char ** argv)
       std::string modelFileCao;
       std::string modelFileWrl;
       if(trackCylinder){
-        modelFileCao = "ViSP-images/mbt/cube_and_cylinder.cao";
-        modelFileWrl = "ViSP-images/mbt/cube_and_cylinder.wrl";
+        modelFileCao = "mbt/cube_and_cylinder.cao";
+        modelFileWrl = "mbt/cube_and_cylinder.wrl";
       }else{
-        modelFileCao = "ViSP-images/mbt/cube.cao";
-        modelFileWrl = "ViSP-images/mbt/cube.wrl";
+        modelFileCao = "mbt/cube.cao";
+        modelFileWrl = "mbt/cube.wrl";
       }
 
       if(!opt_ipath.empty()){
@@ -303,9 +303,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I;
     vpVideoReader reader;

--- a/example/tracking/mbtGenericTracking.cpp
+++ b/example/tracking/mbtGenericTracking.cpp
@@ -83,7 +83,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -253,18 +253,18 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
 #if defined (VISP_HAVE_XML2) && USE_XML
     std::string configFile;
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 #endif
 
     if (!opt_modelFile.empty()){
@@ -273,11 +273,11 @@ main(int argc, const char ** argv)
       std::string modelFileCao;
       std::string modelFileWrl;
       if(trackCylinder){
-        modelFileCao = "ViSP-images/mbt/cube_and_cylinder.cao";
-        modelFileWrl = "ViSP-images/mbt/cube_and_cylinder.wrl";
+        modelFileCao = "mbt/cube_and_cylinder.cao";
+        modelFileWrl = "mbt/cube_and_cylinder.wrl";
       }else{
-        modelFileCao = "ViSP-images/mbt/cube.cao";
-        modelFileWrl = "ViSP-images/mbt/cube.wrl";
+        modelFileCao = "mbt/cube.cao";
+        modelFileWrl = "mbt/cube.wrl";
       }
 
       if(!opt_ipath.empty()){
@@ -311,9 +311,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I1, I2;
     vpVideoReader reader;

--- a/example/tracking/mbtGenericTracking2.cpp
+++ b/example/tracking/mbtGenericTracking2.cpp
@@ -83,7 +83,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -253,18 +253,18 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
 #if defined (VISP_HAVE_XML2) && USE_XML
     std::string configFile;
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 #endif
 
     if (!opt_modelFile.empty()){
@@ -273,11 +273,11 @@ main(int argc, const char ** argv)
       std::string modelFileCao;
       std::string modelFileWrl;
       if(trackCylinder){
-        modelFileCao = "ViSP-images/mbt/cube_and_cylinder.cao";
-        modelFileWrl = "ViSP-images/mbt/cube_and_cylinder.wrl";
+        modelFileCao = "mbt/cube_and_cylinder.cao";
+        modelFileWrl = "mbt/cube_and_cylinder.wrl";
       }else{
-        modelFileCao = "ViSP-images/mbt/cube.cao";
-        modelFileWrl = "ViSP-images/mbt/cube.wrl";
+        modelFileCao = "mbt/cube.cao";
+        modelFileWrl = "mbt/cube.wrl";
       }
 
       if(!opt_ipath.empty()){
@@ -311,9 +311,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     std::map<std::string, const vpImage<unsigned char> *> mapOfImages;
     vpImage<unsigned char> I1, I2, I3;

--- a/example/tracking/mbtGenericTrackingDepth.cpp
+++ b/example/tracking/mbtGenericTrackingDepth.cpp
@@ -463,9 +463,9 @@ int main(int argc, const char ** argv) {
     }
 
     // Get the option values
-    ipath = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/castel");
+    ipath = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/castel");
 
-    std::string dir_path = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth");
+    std::string dir_path = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth");
     if (!vpIoTools::checkDirectory(dir_path)) {
       std::cerr << "ViSP-images does not contain the folder: " << dir_path << "!" << std::endl;
       return EXIT_SUCCESS;
@@ -475,28 +475,28 @@ int main(int argc, const char ** argv) {
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else
-      configFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/chateau.xml");
+      configFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/chateau.xml");
 
     if (!opt_configFile_depth.empty())
       configFile_depth = opt_configFile_depth;
     else
-      configFile_depth = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/chateau_depth.xml");
+      configFile_depth = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/chateau_depth.xml");
 
     std::string modelFile, modelFile_depth;
     if (!opt_modelFile.empty())
       modelFile = opt_modelFile;
     else {
 #if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION == 2 || COIN_MAJOR_VERSION == 3 || COIN_MAJOR_VERSION == 4)
-      modelFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/chateau_gantry.wrl");
+      modelFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/chateau_gantry.wrl");
 #else
-      modelFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/chateau.cao");
+      modelFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/chateau.cao");
 #endif
     }
 
     if (!opt_modelFile_depth.empty())
       modelFile_depth = opt_modelFile_depth;
     else
-      modelFile_depth = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/chateau.cao");
+      modelFile_depth = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/chateau.cao");
 
     std::string vrml_ext = ".wrl";
     bool use_vrml = (modelFile.compare(modelFile.length() - vrml_ext.length(), vrml_ext.length(), vrml_ext) == 0) ||
@@ -514,7 +514,7 @@ int main(int argc, const char ** argv) {
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else
-      initFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/chateau.init");
+      initFile = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/chateau.init");
 
     vpImage<unsigned char> I, I_depth;
     vpImage<uint16_t> I_depth_raw;
@@ -564,7 +564,7 @@ int main(int argc, const char ** argv) {
     loadConfiguration(tracker, configFile, configFile_depth);
 
     vpHomogeneousMatrix depth_M_color;
-    std::string depth_M_color_filename = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "ViSP-images/mbt-depth/castel/depth_M_color.txt");
+    std::string depth_M_color_filename = vpIoTools::createFilePath(!opt_ipath.empty() ? opt_ipath : env_ipath, "mbt-depth/castel/depth_M_color.txt");
     {
       std::ifstream depth_M_color_file(depth_M_color_filename.c_str());
       depth_M_color.load(depth_M_color_file);

--- a/example/tracking/mbtKltMultiTracking.cpp
+++ b/example/tracking/mbtKltMultiTracking.cpp
@@ -80,7 +80,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -234,22 +234,22 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
     if (!opt_modelFile.empty()){
       modelFile = opt_modelFile;
     }else{
-      std::string modelFileCao = "ViSP-images/mbt/cube.cao";
-      std::string modelFileWrl = "ViSP-images/mbt/cube.wrl";
+      std::string modelFileCao = "mbt/cube.cao";
+      std::string modelFileWrl = "mbt/cube.wrl";
 
       if(!opt_ipath.empty()){
         if(cao3DModel){
@@ -282,9 +282,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I1, I2;
     vpVideoReader reader;

--- a/example/tracking/mbtKltTracking.cpp
+++ b/example/tracking/mbtKltTracking.cpp
@@ -78,7 +78,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.ppm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -232,22 +232,22 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;
     else if (!opt_ipath.empty())
-      configFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube.xml");
     else
-      configFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+      configFile = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
     if (!opt_modelFile.empty()){
       modelFile = opt_modelFile;
     }else{
-      std::string modelFileCao = "ViSP-images/mbt/cube.cao";
-      std::string modelFileWrl = "ViSP-images/mbt/cube.wrl";
+      std::string modelFileCao = "mbt/cube.cao";
+      std::string modelFileWrl = "mbt/cube.wrl";
 
       if(!opt_ipath.empty()){
         if(cao3DModel){
@@ -280,9 +280,9 @@ main(int argc, const char ** argv)
     if (!opt_initFile.empty())
       initFile = opt_initFile;
     else if (!opt_ipath.empty())
-      initFile = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(opt_ipath, "mbt/cube");
     else
-      initFile = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+      initFile = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     vpImage<unsigned char> I;
     vpVideoReader reader;

--- a/example/tracking/templateTracker.cpp
+++ b/example/tracking/templateTracker.cpp
@@ -137,7 +137,7 @@ OPTIONS:                                                            Default\n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/cube/image%%04d.pgm\". These \n\
+     \"cube/image%%04d.pgm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -319,9 +319,9 @@ main(int argc, const char ** argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "ViSP-images/mire-2/image.%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mire-2/image.%04d.pgm");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "ViSP-images/mire-2/image.%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mire-2/image.%04d.pgm");
 
     vpImage<unsigned char> I;
     vpVideoReader reader;

--- a/example/tracking/trackDot.cpp
+++ b/example/tracking/trackDot.cpp
@@ -107,7 +107,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mire-2/image.%%04d.pgm\". These \n\
+     \"mire-2/image.%%04d.pgm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -282,11 +282,11 @@ main(int argc, const char ** argv)
       //  terminate called after throwing an instance of 'vpImageException'
       //
       //  The sequence is available on the visp www site
-      //  http://www.irisa.fr/lagadic/visp/visp.html
+      //  https://visp.inria.fr/download/
       //  in the download section. It is named "ViSP-images.tar.gz"
 
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2");
+      dirname = vpIoTools::createFilePath(ipath, "mire-2");
 
       // Build the name of the image file
 

--- a/example/tracking/trackDot2.cpp
+++ b/example/tracking/trackDot2.cpp
@@ -106,7 +106,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mire-2/image.%%04d.pgm\". These \n\
+     \"mire-2/image.%%04d.pgm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -280,11 +280,11 @@ main(int argc, const char ** argv)
       //  terminate called after throwing an instance of 'vpImageException'
       //
       //  The sequence is available on the visp www site
-      //  http://www.irisa.fr/lagadic/visp/visp.html
+      //  https://visp.inria.fr/download/
       //  in the download section. It is named "ViSP-images.tar.gz"
 
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2");
+      dirname = vpIoTools::createFilePath(ipath, "mire-2");
 
       // Build the name of the image file
 

--- a/example/tracking/trackDot2WithAutoDetection.cpp
+++ b/example/tracking/trackDot2WithAutoDetection.cpp
@@ -113,7 +113,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mire-2/image.%%04d.pgm\"\n\
+     \"mire-2/image.%%04d.pgm\"\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -324,11 +324,11 @@ main(int argc, const char ** argv)
       //  terminate called after throwing an instance of 'vpImageException'
       //
       //  The sequence is available on the visp www site
-      //  http://www.irisa.fr/lagadic/visp/visp.html
+      //  https://visp.inria.fr/download/
       //  in the download section. It is named "ViSP-images.tar.gz"
 
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2");
+      dirname = vpIoTools::createFilePath(ipath, "mire-2");
 
       // Build the name of the image file
 

--- a/example/tracking/trackKltOpencv.cpp
+++ b/example/tracking/trackKltOpencv.cpp
@@ -107,7 +107,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/mire-2/image.%%04d.pgm\". These \n\
+     \"mire-2/image.%%04d.pgm\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -286,11 +286,11 @@ main(int argc, const char ** argv)
       //  terminate called after throwing an instance of 'vpImageException'
       //
       //  The sequence is available on the visp www site
-      //  http://www.irisa.fr/lagadic/visp/visp.html
+      //  https://visp.inria.fr/download/
       //  in the download section. It is named "ViSP-images.tar.gz"
 
       // Set the path location of the image sequence
-      dirname = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2");
+      dirname = vpIoTools::createFilePath(ipath, "mire-2");
 
       // Build the name of the image file
 

--- a/example/tracking/trackMeCircle.cpp
+++ b/example/tracking/trackMeCircle.cpp
@@ -95,7 +95,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/circle/circle.pgm\"\n\
+     From this path read \"circle/circle.pgm\"\n\
      image. \n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -218,7 +218,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/circle");
+    dirname = vpIoTools::createFilePath(ipath, "circle");
 
     // Build the name of the image file
     filename = vpIoTools::createFilePath(dirname, "circle.pgm");

--- a/example/tracking/trackMeEllipse.cpp
+++ b/example/tracking/trackMeEllipse.cpp
@@ -99,7 +99,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/ellipse-1/image.%%04d.pgm\"\n\
+     \"ellipse-1/image.%%04d.pgm\"\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -220,7 +220,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/ellipse-1");
+    dirname = vpIoTools::createFilePath(ipath, "ellipse-1");
 
     // Build the name of the image file
     unsigned int iter = 1; // Image number

--- a/example/tracking/trackMeLine.cpp
+++ b/example/tracking/trackMeLine.cpp
@@ -101,7 +101,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/line/image.%%04d.pgm\"\n\
+     From this path read \"line/image.%%04d.pgm\"\n\
      images. \n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -224,7 +224,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/line");
+    dirname = vpIoTools::createFilePath(ipath, "line");
 
     // Build the name of the image file
     unsigned int iter = 1; // Image number

--- a/example/tracking/trackMeNurbs.cpp
+++ b/example/tracking/trackMeNurbs.cpp
@@ -100,7 +100,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read images \n\
-     \"ViSP-images/ellipse-1/image.%%04d.pgm\"\n\
+     \"ellipse-1/image.%%04d.pgm\"\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -114,7 +114,7 @@ OPTIONS:                                               Default\n\
 \n\
   -h\n\
      Print the help.\n",
-	  ipath.c_str());
+    ipath.c_str());
 
   if (badparam)
     fprintf(stdout, "\nERROR: Bad parameter [%s]\n", badparam);
@@ -221,7 +221,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Set the path location of the image sequence
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/ellipse-1/image.%04d.pgm");
+    filename = vpIoTools::createFilePath(ipath, "ellipse-1/image.%04d.pgm");
 
     // Build the name of the image file
     vpVideoReader reader;

--- a/example/video/imageSequenceReader.cpp
+++ b/example/video/imageSequenceReader.cpp
@@ -89,7 +89,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input images path>                                %s\n\
      Set ViSP-images input path.\n\
-     From this path read \"ViSP-images/cube/image.%%04d.pgm\"\n\
+     From this path read \"cube/image.%%04d.pgm\"\n\
      images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -240,7 +240,7 @@ main(int argc, const char ** argv)
 
     if (opt_ppath.empty())
     {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/mire-2/image.%04d.pgm");
+      filename = vpIoTools::createFilePath(ipath, "mire-2/image.%04d.pgm");
     }
     else
     {

--- a/example/video/videoReader.cpp
+++ b/example/video/videoReader.cpp
@@ -90,7 +90,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input video path>                                %s\n\
      Set video input path.\n\
-     From this path read \"ViSP-images/video/video.mpeg\"\n\
+     From this path read \"video/video.mpeg\"\n\
      video.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -235,7 +235,7 @@ main(int argc, const char ** argv)
 
     if (opt_ppath.empty())
     {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/video/cube.mpeg");
+      filename = vpIoTools::createFilePath(ipath, "video/cube.mpeg");
     }
     else
     {

--- a/modules/core/src/camera/vpXmlParserCamera.cpp
+++ b/modules/core/src/camera/vpXmlParserCamera.cpp
@@ -229,7 +229,7 @@ vpXmlParserCamera::save(const vpCameraParameters &cam, const std::string &filena
     xmlNodePtr node_tmp = xmlNewComment((xmlChar*)
                                         "This file stores intrinsic camera parameters used\n"
                                         "   in the vpCameraParameters Class of ViSP available\n"
-                                        "   at http://www.irisa.fr/lagadic/visp/visp.html .\n"
+                                        "   at https://visp.inria.fr/download/ .\n"
                                         "   It can be read with the parse method of\n"
                                         "   the vpXmlParserCamera class.");
     xmlAddChild(node,node_tmp);

--- a/modules/core/src/math/transformation/vpXmlParserHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpXmlParserHomogeneousMatrix.cpp
@@ -163,7 +163,7 @@ vpXmlParserHomogeneousMatrix::save(const vpHomogeneousMatrix &M, const std::stri
     xmlNodePtr node_tmp = xmlNewComment((xmlChar*)
                                         "This file stores homogeneous matrix used\n"
                                         "   in the vpHomogeneousMatrix Class of ViSP available\n"
-                                        "   at http://www.irisa.fr/lagadic/visp/visp.html .\n"
+                                        "   at https://visp.inria.fr/download/ .\n"
                                         "   It can be read with the parse method of\n"
                                         "   the vpXmlParserHomogeneousMatrix class.");
     xmlAddChild(node,node_tmp);

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -1240,11 +1240,15 @@ void vpIoTools::saveConfigFile(const bool &actuallySave)
 std::string vpIoTools::getViSPImagesDataPath()
 {
   std::string data_path;
-  std::string file_to_test("ViSP-images/mbt/cube.cao");
+  std::string file_to_test("mbt/cube.cao");
   std::string filename;
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
   // Test if visp-images-data package is u-installed (Ubuntu and Debian)
-  data_path = "/usr/share/visp-images-data";
+  data_path = "/usr/share/visp-images-data/ViSP-images";
+  filename = data_path + "/" + file_to_test;
+  if (vpIoTools::checkFilename(filename))
+    return data_path;
+  data_path = "/usr/share/visp-images-data/visp-images";
   filename = data_path + "/" + file_to_test;
   if (vpIoTools::checkFilename(filename))
     return data_path;
@@ -1252,6 +1256,14 @@ std::string vpIoTools::getViSPImagesDataPath()
   // Test if VISP_INPUT_IMAGE_PATH env var is set
   try {
     data_path = vpIoTools::getenv("VISP_INPUT_IMAGE_PATH");
+    filename = data_path + "/" + file_to_test;
+    if (vpIoTools::checkFilename(filename))
+      return data_path;
+    data_path = vpIoTools::getenv("VISP_INPUT_IMAGE_PATH") + "/ViSP-images";
+    filename = data_path + "/" + file_to_test;
+    if (vpIoTools::checkFilename(filename))
+      return data_path;
+    data_path = vpIoTools::getenv("VISP_INPUT_IMAGE_PATH") + "/visp-images";
     filename = data_path + "/" + file_to_test;
     if (vpIoTools::checkFilename(filename))
       return data_path;

--- a/modules/core/test/image/testConversion.cpp
+++ b/modules/core/test/image/testConversion.cpp
@@ -83,8 +83,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -316,7 +316,7 @@ main(int argc, const char ** argv)
     //-------------------- .pgm -> .ppm
     std::cout << "** Convert a grey image (.pgm) to a color image (.ppm)" << std::endl;
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     std::cout << "   Load " <<  filename << std::endl;
     vpImageIo::read(Ig, filename) ;
     // Create a color image from the grey
@@ -328,7 +328,7 @@ main(int argc, const char ** argv)
     //-------------------- .ppm -> .pgm
     std::cout << "** Convert a color image (.ppm) to a grey image (.pgm)" << std::endl;
     // Load a color image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "   Load " << filename << std::endl;
     vpImageIo::read(Ic, filename) ;
     // Create a grey image from the color
@@ -354,7 +354,7 @@ main(int argc, const char ** argv)
     ////////////////////////
     std::cout << "** Convert an IplImage to a vpImage<vpRGBa>" << std::endl;
     IplImage* image = NULL; /*!< The image read / acquired */
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 
     /* Read the color image */
 
@@ -370,7 +370,7 @@ main(int argc, const char ** argv)
 
     std::cout << "   Convert result in " << filename << std::endl;
 
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     /* Read the pgm image */
     std::cout << "   Reading the greyscale image with opencv: " << filename << std::endl;
@@ -390,7 +390,7 @@ main(int argc, const char ** argv)
     // Convert a IplImage to a vpImage<unsigned char>
     ////////////////////////////
     std::cout << "** Convert an IplImage to a vpImage<unsigned char>" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 
     /* Read the color image */
 
@@ -407,7 +407,7 @@ main(int argc, const char ** argv)
 
     std::cout << "   Convert result in " << filename << std::endl;
 
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     /* Read the pgm image */
 
@@ -428,7 +428,7 @@ main(int argc, const char ** argv)
     // Convert a vpImage<vpRGBa> to a IplImage
     ////////////////////////////////////
     std::cout << "** Convert a vpImage<vpRGBa> to an IplImage" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 
     /* Read the color image */
 
@@ -450,7 +450,7 @@ main(int argc, const char ** argv)
     // Convert a vpImage<unsigned char> to an IplImage
     ////////////////////////////////////////
     std::cout << "** Convert a vpImage<unsigned char> to an IplImage" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     /* Read the grey image */
 
@@ -485,7 +485,7 @@ main(int argc, const char ** argv)
     ////////////////////////
     std::cout << "** Convert a cv::Mat to a vpImage<vpRGBa>" << std::endl;
     cv::Mat imageMat;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "   Reading the color image with c++ interface of opencv: " << filename << std::endl;
     imageMat = cv::imread(filename, 1);// force to a three channel color image.
     if(imageMat.data == NULL){
@@ -497,7 +497,7 @@ main(int argc, const char ** argv)
     std::cout << "   Resulting image saved in: " << filename << std::endl;
     vpImageIo::write(Ic, filename) ;
 
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     /* Read the pgm image */
 
     std::cout << "   Reading the greyscale image with opencv: " << filename << std::endl;
@@ -515,7 +515,7 @@ main(int argc, const char ** argv)
     // Convert a cv::Mat to a vpImage<unsigned char>
     ////////////////////////////
     std::cout << "** Convert a cv::Mat to a vpImage<nsigned char>" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 
     /* Read the color image */
 
@@ -530,7 +530,7 @@ main(int argc, const char ** argv)
     std::cout << "   Resulting image saved in: " << filename << std::endl;
     vpImageIo::write(Ig, filename) ;
 
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     /* Read the pgm image */
 
@@ -551,7 +551,7 @@ main(int argc, const char ** argv)
     // Convert a vpImage<vpRGBa> to a cv::Mat
     ////////////////////////////////////
     std::cout << "** Convert a vpImage<vpRGBa> to a cv::Mat" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 
     /* Read the color image */
 
@@ -572,7 +572,7 @@ main(int argc, const char ** argv)
     // Convert a vpImage<unsigned char> to a cv::Mat
     ////////////////////////////////////////
     std::cout << "** Convert a vpImage<unsigned char> to a cv::Mat" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     /* Read the grey image */
 
@@ -598,7 +598,7 @@ main(int argc, const char ** argv)
     // Split a vpImage<vpRGBa> to vpImage<unsigned char>
     ////////////////////////////////////
     std::cout << "** Split a vpImage<vpRGBa> to vpImage<unsigned char>" << std::endl;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 
     /* Read the color image */
 
@@ -734,7 +734,7 @@ main(int argc, const char ** argv)
       std::cout << "** Benchmark and test RGBa / RGB / cv::Mat to Grayscale conversion" << std::endl;
       //RGBa to Grayscale
       vpImage<vpRGBa> I_color;
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
       vpImageIo::read(I_color, filename);
 
       vpImage<unsigned char> I_gray_sse(I_color.getHeight(), I_color.getWidth());
@@ -836,7 +836,7 @@ main(int argc, const char ** argv)
 #if (VISP_HAVE_OPENCV_VERSION >= 0x020101)
       //BGR cv::Mat to Grayscale
       std::cout << "\n   BGR cv::Mat to Grayscale" << std::endl;
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
       cv::Mat colorMat = cv::imread(filename);
       std::cout << "   colorMat=" << colorMat.cols << "x" << colorMat.rows << std::endl;
 

--- a/modules/core/test/image/testCrop.cpp
+++ b/modules/core/test/image/testCrop.cpp
@@ -84,7 +84,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -237,7 +237,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> C; // Cropped output image
 
     // Read the input grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I, filename) ;
 

--- a/modules/core/test/image/testCropAdvanced.cpp
+++ b/modules/core/test/image/testCropAdvanced.cpp
@@ -77,7 +77,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -226,7 +226,7 @@ int main(int argc, const char ** argv)
       vpImage<unsigned char> I;
 
       // Read the input grey image from the disk
-      std::string filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+      std::string filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
       std::cout << "Read image: " << filename << std::endl;
       vpImageIo::read(I, filename) ;
       std::cout << "Image size: " << I.getWidth() << " " << I.getHeight() << std::endl;
@@ -312,7 +312,7 @@ int main(int argc, const char ** argv)
       vpImage<vpRGBa> I;
 
       // Read the input color image from the disk
-      std::string filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+      std::string filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
       std::cout << "Read image: " << filename << std::endl;
       vpImageIo::read(I, filename) ;
       std::cout << "Image size: " << I.getWidth() << " " << I.getHeight() << std::endl;

--- a/modules/core/test/image/testImageAddSub.cpp
+++ b/modules/core/test/image/testImageAddSub.cpp
@@ -75,7 +75,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -269,7 +269,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I; // Input image
 
     // Read the input grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     std::cout << "Read image: " << filename << std::endl << std::endl;
     vpImageIo::read(I, filename);
 

--- a/modules/core/test/image/testImageComparison.cpp
+++ b/modules/core/test/image/testImageComparison.cpp
@@ -73,8 +73,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -183,7 +183,7 @@ int main(int argc, const char ** argv) {
     //
 
     //Load grayscale Klimt
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     vpImage<unsigned char> I_Klimt1, I_Klimt2;
     vpImageIo::read(I_Klimt1, filename);
@@ -229,7 +229,7 @@ int main(int argc, const char ** argv) {
 
 
     //Load color Klimt
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
 
     vpImage<vpRGBa> I_color_Klimt1, I_color_Klimt2;
     vpImageIo::read(I_color_Klimt1, filename);

--- a/modules/core/test/image/testImageFilter.cpp
+++ b/modules/core/test/image/testImageFilter.cpp
@@ -72,7 +72,7 @@ namespace {
   OPTIONS:                                               Default\n\
     -i <input image path>                                %s\n\
        Set image input path.\n\
-       From this path read \"ViSP-images/Klimt/Klimt.pgm,\n\
+       From this path read \"Klimt/Klimt.pgm,\n\
        .ppm, .jpeg and .png images.\n\
        Setting the VISP_INPUT_IMAGE_PATH environment\n\
        variable produces the same behaviour than using\n\
@@ -300,7 +300,7 @@ int main(int argc, const char *argv[]) {
 
     //Test on real image
     if (opt_ppath.empty()) {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
       vpImageIo::read(I, filename);
     } else {
       filename = opt_ppath;

--- a/modules/core/test/image/testImageMorphology.cpp
+++ b/modules/core/test/image/testImageMorphology.cpp
@@ -72,8 +72,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -650,7 +650,7 @@ int main(int argc, const char ** argv) {
 
     std::cout << std::endl;
     vpImage<unsigned char> I_Klimt;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I_Klimt, filename);
 
 

--- a/modules/core/test/image/testImageResize.cpp
+++ b/modules/core/test/image/testImageResize.cpp
@@ -79,7 +79,7 @@ namespace {
   OPTIONS:                                               Default\n\
     -i <input image path>                                %s\n\
        Set image input path.\n\
-       From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+       From this path read \"Klimt/Klimt.pgm\"\n\
        image.\n\
        Setting the VISP_INPUT_IMAGE_PATH environment\n\
        variable produces the same behaviour than using\n\
@@ -243,7 +243,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I; // Input image
 
     // Read the input grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I, filename);
 
@@ -290,7 +290,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> I_color; // Input image
 
     // Read the input grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "\nRead image: " << filename << std::endl;
     vpImageIo::read(I_color, filename);
 

--- a/modules/core/test/image/testIoPGM.cpp
+++ b/modules/core/test/image/testIoPGM.cpp
@@ -79,7 +79,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -233,7 +233,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I, filename);
     // Write the content of the image on the disk
@@ -244,7 +244,7 @@ main(int argc, const char ** argv)
     try {
       // Try to load a non existing image (test for exceptions)
       // Load a non existing grey image
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/image-that-does-not-exist.pgm");
+      filename = vpIoTools::createFilePath(ipath, "image-that-does-not-exist.pgm");
       std::cout << "Read image: " << filename << std::endl;
       vpImageIo::read(I, filename) ;
     }

--- a/modules/core/test/image/testIoPPM.cpp
+++ b/modules/core/test/image/testIoPPM.cpp
@@ -80,8 +80,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -236,7 +236,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Load a color image from the disk and convert it to a grey level one
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I, filename);
     // Write the content of the image on the disk
@@ -248,7 +248,7 @@ main(int argc, const char ** argv)
     try
     {
       // Load a non existing grey image
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/image-that-does-not-exist.ppm");
+      filename = vpIoTools::createFilePath(ipath, "image-that-does-not-exist.ppm");
       std::cout << "Read image: " << filename << std::endl;
       vpImageIo::read(I, filename) ;
     }
@@ -273,7 +273,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a color image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(Irgba, filename);
     // Write the content of the color image on the disk
@@ -284,7 +284,7 @@ main(int argc, const char ** argv)
     try {
       // Try to load a non existing image (test for exceptions)
       // Load a non existing color image
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/image-that-does-not-exist.ppm");
+      filename = vpIoTools::createFilePath(ipath, "image-that-does-not-exist.ppm");
       std::cout << "Read image: " << filename << std::endl;
       vpImageIo::read(Irgba, filename) ;
     }

--- a/modules/core/test/image/testPerformanceLUT.cpp
+++ b/modules/core/test/image/testPerformanceLUT.cpp
@@ -77,7 +77,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -298,7 +298,7 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> I_iterate1, I_iterate2, I_lut;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "\nRead image: " << filename << std::endl;
     vpImageIo::read(I_iterate1, filename);
     vpImageIo::read(I_iterate2, filename);
@@ -377,7 +377,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I_iterate_grayscale1, I_lut_grayscale;
 
     // Load a grayscale image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     std::cout << "\nRead image: " << filename << std::endl;
     vpImageIo::read(I_iterate_grayscale1, filename);
     vpImageIo::read(I_lut_grayscale, filename);

--- a/modules/core/test/image/testReadImage.cpp
+++ b/modules/core/test/image/testReadImage.cpp
@@ -79,7 +79,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm,\n\
+     From this path read \"Klimt/Klimt.pgm,\n\
      .ppm, .jpeg and .png images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -190,29 +190,29 @@ main(int argc, const char ** argv)
 
     if (opt_ppath.empty())
     {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
       vpImageIo::read(I,filename);
       printf("Read ppm ok\n");
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
       vpImageIo::read(I,filename);
       printf("Read pgm ok\n");
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.jpeg");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.jpeg");
       vpImageIo::read(I,filename);
       printf("Read jpeg ok\n");
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.png");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.png");
       vpImageIo::read(I,filename);
       printf("Read png ok\n");
 
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
       vpImageIo::read(Irgb,filename);
       printf("Read ppm ok\n");
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
       vpImageIo::read(Irgb,filename);
       printf("Read pgm ok\n");
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.jpeg");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.jpeg");
       vpImageIo::read(Irgb,filename);
       printf("Read jpeg ok\n");
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.png");
+      filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.png");
       vpImageIo::read(Irgb,filename);
       printf("Read png ok\n");
     }

--- a/modules/core/test/image/testUndistortImage.cpp
+++ b/modules/core/test/image/testUndistortImage.cpp
@@ -89,7 +89,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -248,9 +248,9 @@ int main(int argc, const char ** argv)
     cam.initPersProjWithDistortion(600,600,192,144,-0.17,0.17);
     // Read the input grey image from the disk
 #if defined BW
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm") ;
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm") ;
 #elif defined COLOR
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 #endif
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I, filename) ;

--- a/modules/core/test/tools/histogram/testHistogram.cpp
+++ b/modules/core/test/tools/histogram/testHistogram.cpp
@@ -76,7 +76,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.ppm\"\n\
+     From this path read \"Klimt/Klimt.ppm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -247,7 +247,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I, filename);
 

--- a/modules/detection/test/testAprilTag.cpp
+++ b/modules/detection/test/testAprilTag.cpp
@@ -74,7 +74,7 @@ namespace {
   OPTIONS:                                               Default\n\
     -i <input image path>                                %s\n\
        Set image input path.\n\
-       From this path read \"ViSP-images/AprilTag/AprilTag.pgm image.\n\
+       From this path read \"AprilTag/AprilTag.pgm image.\n\
        Setting the VISP_INPUT_IMAGE_PATH environment\n\
        variable produces the same behaviour than using\n\
        this option.\n\
@@ -215,7 +215,7 @@ int main(int argc, const char *argv[]) {
 
     vpImage<unsigned char> I;
     if (opt_ppath.empty()) {
-      filename = vpIoTools::createFilePath(ipath, "ViSP-images/AprilTag/AprilTag.pgm");
+      filename = vpIoTools::createFilePath(ipath, "AprilTag/AprilTag.pgm");
     } else {
       filename = opt_ppath;
     }
@@ -266,7 +266,7 @@ int main(int argc, const char *argv[]) {
     std::map<std::string, TagGroundTruth> mapOfTagsGroundTruth;
     bool use_detection_ground_truth = false;
     {
-      std::string filename_ground_truth = vpIoTools::createFilePath(ipath, "ViSP-images/AprilTag/ground_truth_detection.txt");
+      std::string filename_ground_truth = vpIoTools::createFilePath(ipath, "AprilTag/ground_truth_detection.txt");
       std::ifstream file_ground_truth(filename_ground_truth.c_str());
       if (file_ground_truth.is_open() && opt_ppath.empty()) {
         use_detection_ground_truth = true;
@@ -288,7 +288,7 @@ int main(int argc, const char *argv[]) {
     std::map<std::string, vpPoseVector> mapOfPosesGroundTruth;
     bool use_pose_ground_truth = false;
     {
-      std::string filename_ground_truth = vpIoTools::createFilePath(ipath, "ViSP-images/AprilTag/ground_truth_pose.txt");
+      std::string filename_ground_truth = vpIoTools::createFilePath(ipath, "AprilTag/ground_truth_pose.txt");
       std::ifstream file_ground_truth(filename_ground_truth.c_str());
       if (file_ground_truth.is_open() && opt_ppath.empty()) {
         use_pose_ground_truth = true;

--- a/modules/gui/test/display/testClick.cpp
+++ b/modules/gui/test/display/testClick.cpp
@@ -111,8 +111,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -316,7 +316,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpCTRACE << "Load " <<  filename << std::endl;
     vpImageIo::read(I, filename) ;
 

--- a/modules/gui/test/display/testDisplayScaled.cpp
+++ b/modules/gui/test/display/testDisplayScaled.cpp
@@ -243,7 +243,7 @@ int main(int argc, const char *argv[])
       std::cout << "\nUsage: " << argv[0] << " [-i <image path>] [-c] [-d] [--help]\n" << std::endl;
       std::cout << "\nOptions: " << std::endl;
       std::cout << "  -i <input image path> : set image input path.\n"
-                << "       From this path read \"ViSP-images/Klimt/Klimt.pgm\" image.\n"
+                << "       From this path read \"Klimt/Klimt.pgm\" image.\n"
                 << "       Setting the VISP_INPUT_IMAGE_PATH environment\n"
                 << "       variable produces the same behaviour than using\n"
                 << "       this option." << std::endl;
@@ -290,11 +290,11 @@ int main(int argc, const char *argv[])
       return 0;
     }
     vpImage<unsigned char> I;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpImageIo::read(I, filename);
 
     vpImage<vpRGBa> C;
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImageIo::read(C, filename);
 
     int nbfailure = 0;

--- a/modules/gui/test/display/testMouseEvent.cpp
+++ b/modules/gui/test/display/testMouseEvent.cpp
@@ -133,7 +133,7 @@ SYNOPSIS\n\
  OPTIONS:                                               Default\n\
   -i <test image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/cube/image.%%04d.pgm\"\n\
+     From this path read \"cube/image.%%04d.pgm\"\n\
      images. These images come from ViSP-images-x.y.z.tar.gz\n\
      available on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -393,11 +393,11 @@ main(int argc, const char ** argv)
     //  terminate called after throwing an instance of 'vpImageException'
     //
     //  The sequence is available on the visp www site
-    //  http://www.irisa.fr/lagadic/visp/visp.html
+    //  https://visp.inria.fr/download/
     //  in the download section. It is named "ViSP-images.tar.gz"
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+    dirname = vpIoTools::createFilePath(ipath, "cube");
 
     // Build the name of the image file
 

--- a/modules/gui/test/display/testVideoDevice.cpp
+++ b/modules/gui/test/display/testVideoDevice.cpp
@@ -111,8 +111,8 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
-     and \"ViSP-images/Klimt/Klimt.ppm\" images.\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
+     and \"Klimt/Klimt.ppm\" images.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -313,12 +313,12 @@ main(int argc, const char ** argv)
     vpImage<vpRGBa> Irgba ;
 
     // Load a grey image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.pgm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
     vpCTRACE << "Load " <<  filename << std::endl;
     vpImageIo::read(I, filename) ;
 
     // Load a color image from the disk
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpCTRACE << "Load " <<  filename << std::endl;
     vpImageIo::read(Irgba, filename) ;
 

--- a/modules/tracker/blob/test/tracking/testTrackDot.cpp
+++ b/modules/tracker/blob/test/tracking/testTrackDot.cpp
@@ -95,7 +95,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read image \n\
-     \"ViSP-images/ellipse/ellipse.pgm\"\n\
+     \"ellipse/ellipse.pgm\"\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -219,7 +219,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> I ;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/ellipse");
+    dirname = vpIoTools::createFilePath(ipath, "ellipse");
 
     // Build the name of the image file
     filename = vpIoTools::createFilePath(dirname, "ellipse.pgm");

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
@@ -13,7 +13,7 @@
  * GPL, please contact INRIA about acquiring a ViSP Professional
  * Edition License.
  *
- * See http://www.irisa.fr/lagadic/visp/visp.html for more information.
+ * See https://visp.inria.fr/download/ for more information.
  *
  * This software was developed at:
  * INRIA Rennes - Bretagne Atlantique

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
@@ -13,7 +13,7 @@
  * GPL, please contact INRIA about acquiring a ViSP Professional
  * Edition License.
  *
- * See http://www.irisa.fr/lagadic/visp/visp.html for more information.
+ * See https://visp.inria.fr/download/ for more information.
  *
  * This software was developed at:
  * INRIA Rennes - Bretagne Atlantique

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbKltMultiTracker.h
@@ -13,7 +13,7 @@
  * GPL, please contact INRIA about acquiring a ViSP Professional
  * Edition License.
  *
- * See http://www.irisa.fr/lagadic/visp/visp.html for more information.
+ * See https://visp.inria.fr/download/ for more information.
  *
  * This software was developed at:
  * INRIA Rennes - Bretagne Atlantique

--- a/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
@@ -13,7 +13,7 @@
  * GPL, please contact INRIA about acquiring a ViSP Professional
  * Edition License.
  *
- * See http://www.irisa.fr/lagadic/visp/visp.html for more information.
+ * See https://visp.inria.fr/download/ for more information.
  *
  * This software was developed at:
  * INRIA Rennes - Bretagne Atlantique

--- a/modules/tracker/mbt/src/hybrid/vpMbEdgeKltMultiTracker.cpp
+++ b/modules/tracker/mbt/src/hybrid/vpMbEdgeKltMultiTracker.cpp
@@ -13,7 +13,7 @@
  * GPL, please contact INRIA about acquiring a ViSP Professional
  * Edition License.
  *
- * See http://www.irisa.fr/lagadic/visp/visp.html for more information.
+ * See https://visp.inria.fr/download/ for more information.
  *
  * This software was developed at:
  * INRIA Rennes - Bretagne Atlantique

--- a/modules/tracker/mbt/src/klt/vpMbKltMultiTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltMultiTracker.cpp
@@ -13,7 +13,7 @@
  * GPL, please contact INRIA about acquiring a ViSP Professional
  * Edition License.
  *
- * See http://www.irisa.fr/lagadic/visp/visp.html for more information.
+ * See https://visp.inria.fr/download/ for more information.
  *
  * This software was developed at:
  * INRIA Rennes - Bretagne Atlantique

--- a/modules/vision/test/key-point/testKeyPoint-2.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-2.cpp
@@ -158,7 +158,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> I;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     //Build the name of the image files
     std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");
@@ -183,7 +183,7 @@ int main(int argc, const char ** argv) {
     vpCameraParameters cam;
     vpMbEdgeTracker tracker;
     //Load config for tracker
-    std::string tracker_config_file = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+    std::string tracker_config_file = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
 #ifdef VISP_HAVE_XML2
     tracker.loadConfigFile(tracker_config_file);
@@ -210,11 +210,11 @@ int main(int argc, const char ** argv) {
     tracker.setAngleDisappear(vpMath::rad(89));
 
     //Load CAO model
-    std::string cao_model_file = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.cao");
+    std::string cao_model_file = vpIoTools::createFilePath(env_ipath, "mbt/cube.cao");
     tracker.loadModel(cao_model_file);
 
     //Initialize the pose
-    std::string init_file = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.init");
+    std::string init_file = vpIoTools::createFilePath(env_ipath, "mbt/cube.init");
     if (opt_display && opt_click_allowed) {
       tracker.initClick(I, init_file);
     }

--- a/modules/vision/test/key-point/testKeyPoint-3.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-3.cpp
@@ -159,7 +159,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> Iref, Icur, Imatch;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     //Build the name of the image files
     std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");

--- a/modules/vision/test/key-point/testKeyPoint-4.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-4.cpp
@@ -163,7 +163,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> I, Imatch, Iref;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     //Build the name of the image files
     std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");
@@ -193,7 +193,7 @@ int main(int argc, const char ** argv) {
     vpCameraParameters cam;
     vpMbEdgeTracker tracker;
     //Load config for tracker
-    std::string tracker_config_file = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.xml");
+    std::string tracker_config_file = vpIoTools::createFilePath(env_ipath, "mbt/cube.xml");
 
 #ifdef VISP_HAVE_XML2
     tracker.loadConfigFile(tracker_config_file);
@@ -220,11 +220,11 @@ int main(int argc, const char ** argv) {
     tracker.setAngleDisappear(vpMath::rad(89));
 
     //Load CAO model
-    std::string cao_model_file = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.cao");
+    std::string cao_model_file = vpIoTools::createFilePath(env_ipath, "mbt/cube.cao");
     tracker.loadModel(cao_model_file);
 
     //Initialize the pose
-    std::string init_file = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube.init");
+    std::string init_file = vpIoTools::createFilePath(env_ipath, "mbt/cube.init");
     if (opt_display && opt_click_allowed) {
       tracker.initClick(I, init_file);
     }

--- a/modules/vision/test/key-point/testKeyPoint-5.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-5.cpp
@@ -158,7 +158,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> I;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/Klimt");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "Klimt");
 
     //Build the name of the image files
     std::string filename = vpIoTools::createFilePath(dirname, "/Klimt.png");

--- a/modules/vision/test/key-point/testKeyPoint-6.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-6.cpp
@@ -202,7 +202,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> I;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/Klimt");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "Klimt");
 
     //Build the name of the image files
     std::string filename = vpIoTools::createFilePath(dirname, "/Klimt.png");

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -314,7 +314,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> I;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/Klimt");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "Klimt");
 
     //Build the name of the image files
     std::string img_filename = vpIoTools::createFilePath(dirname, "/Klimt.ppm");

--- a/modules/vision/test/key-point/testKeyPoint.cpp
+++ b/modules/vision/test/key-point/testKeyPoint.cpp
@@ -157,7 +157,7 @@ int main(int argc, const char ** argv) {
     vpImage<unsigned char> Iref, Icur, Imatch;
 
     //Set the path location of the image sequence
-    std::string dirname = vpIoTools::createFilePath(env_ipath, "ViSP-images/mbt/cube");
+    std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
     //Build the name of the image files
     std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");

--- a/modules/vision/test/key-point/testSurfKeyPoint.cpp
+++ b/modules/vision/test/key-point/testSurfKeyPoint.cpp
@@ -91,7 +91,7 @@ OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
      From this path read image \n\
-     \"ViSP-images/ellipse/ellipse.pgm\"\n\
+     \"ellipse/ellipse.pgm\"\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
      this option.\n\
@@ -216,7 +216,7 @@ main(int argc, const char ** argv)
     vpImage<unsigned char> Icur ;
 
     // Set the path location of the image sequence
-    dirname = vpIoTools::createFilePath(ipath, "ViSP-images/cube");
+    dirname = vpIoTools::createFilePath(ipath, "cube");
 
     // Build the name of the image file
     filenameRef = vpIoTools::createFilePath(dirname, "image.0000.pgm");


### PR DESCRIPTION
…to be able to set this var with the name of the folder that contains the data. Previously it was only possible to set this var to ViSP-images parent folder. Now it is possible to set the complete path to the data ie /home/blabla/visp-images-3.1.0.