### PR TITLE
Fix bug: serial printed as string

### DIFF
--- a/modules/sensor/src/framegrabber/pylon/vpPylonGrabberGigE.cpp
+++ b/modules/sensor/src/framegrabber/pylon/vpPylonGrabberGigE.cpp
@@ -347,7 +347,8 @@ void vpPylonGrabberGigE::setCameraSerial(const std::string &serial)
     }
   }
   throw(vpException(vpException::badValue,
-                    "The camera with serial id %u is not present.", serial));
+                    "The camera with serial id %s is not present.",
+                    serial.c_str()));
 }
 
 /*!
@@ -678,8 +679,8 @@ void vpPylonGrabberGigE::acquire(vpImage<unsigned char> &I)
   // Retrieve an image
   if (!m_camera.RetrieveResult(2000, grabResult)) {
     throw(vpException(vpException::fatalError,
-                      "Cannot retrieve image from camera with serial %u",
-                      getCameraSerial(m_index)));
+                      "Cannot retrieve image from camera with serial %s",
+                      getCameraSerial(m_index).c_str()));
   }
 
   if (grabResult->GrabSucceeded()) {
@@ -709,8 +710,8 @@ void vpPylonGrabberGigE::acquire(vpImage<vpRGBa> &I)
   // Retrieve an image
   if (!m_camera.RetrieveResult(2000, grabResult)) {
     throw(vpException(vpException::fatalError,
-                      "Cannot retrieve image from camera with serial %u",
-                      getCameraSerial(m_index)));
+                      "Cannot retrieve image from camera with serial %s",
+                      getCameraSerial(m_index).c_str()));
   }
 
   if (grabResult->GrabSucceeded()) {

--- a/modules/sensor/src/framegrabber/pylon/vpPylonGrabberUsb.cpp
+++ b/modules/sensor/src/framegrabber/pylon/vpPylonGrabberUsb.cpp
@@ -341,7 +341,8 @@ void vpPylonGrabberUsb::setCameraSerial(const std::string &serial)
     }
   }
   throw(vpException(vpException::badValue,
-                    "The camera with serial id %u is not present.", serial));
+                    "The camera with serial id %s is not present.",
+                    serial.c_str()));
 }
 
 /*!
@@ -665,8 +666,8 @@ void vpPylonGrabberUsb::acquire(vpImage<unsigned char> &I)
   // Retrieve an image
   if (!m_camera.RetrieveResult(2000, grabResult)) {
     throw(vpException(vpException::fatalError,
-                      "Cannot retrieve image from camera with serial %u",
-                      getCameraSerial(m_index)));
+                      "Cannot retrieve image from camera with serial %s",
+                      getCameraSerial(m_index).c_str()));
   }
 
   if (grabResult->GrabSucceeded()) {
@@ -696,8 +697,8 @@ void vpPylonGrabberUsb::acquire(vpImage<vpRGBa> &I)
   // Retrieve an image
   if (!m_camera.RetrieveResult(2000, grabResult)) {
     throw(vpException(vpException::fatalError,
-                      "Cannot retrieve image from camera with serial %u",
-                      getCameraSerial(m_index)));
+                      "Cannot retrieve image from camera with serial %s",
+                      getCameraSerial(m_index).c_str()));
   }
 
   if (grabResult->GrabSucceeded()) {


### PR DESCRIPTION
The serial number in pylon library is stored as a string. When printing
out, it has to be formatted as string characters instead of unsigned
decimal integer.