### PR TITLE
Fix for Win XP inet_ntop() could not be located in WS2_32.dll

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ ViSP 3.2.0 (under development)
   - Bug fixed
     . [#279] Unable to build ViSP with Visual Studio 2010
     . [#281] Segfault in mbtGenericTrackingDepth.cpp when run on big endian arch
+    . [#287] On Win XP inet_ntop() could not be located in WS2_32.dll
 
 ----------------------------------------------
 ViSP 3.1.0 (released December 22nd, 2017)

--- a/modules/core/include/visp3/core/vpClient.h
+++ b/modules/core/include/visp3/core/vpClient.h
@@ -46,6 +46,9 @@
 #include <visp3/core/vpRequest.h>
 #include <visp3/core/vpTime.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 /*!
   \class vpClient
 
@@ -214,4 +217,5 @@ public:
   void stop();
 };
 
+#endif
 #endif

--- a/modules/core/include/visp3/core/vpNetwork.h
+++ b/modules/core/include/visp3/core/vpNetwork.h
@@ -47,21 +47,24 @@
 #include <string.h>
 #include <vector>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <unistd.h>
+#  include <arpa/inet.h>
+#  include <netdb.h>
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
 #else
-#include <io.h>
+#  include <io.h>
 //#  include<winsock.h>
-#include <winsock2.h>
+#  include <winsock2.h>
 //#  pragma comment(lib, "ws2_32.lib") // Done by CMake in main CMakeLists.txt
 #endif
 
 #if defined(__APPLE__) && defined(__MACH__) // Apple OSX and iOS (Darwin)
-#include <TargetConditionals.h>             // To detect OSX or IOS using TARGET_OS_IPHONE or TARGET_OS_IOS macro
+#  include <TargetConditionals.h>             // To detect OSX or IOS using TARGET_OS_IPHONE or TARGET_OS_IOS macro
 #endif
 
 /*!
@@ -495,4 +498,5 @@ template <typename T> int vpNetwork::sendTo(T *object, const unsigned int &dest,
 #endif
 }
 
+#endif
 #endif

--- a/modules/core/include/visp3/core/vpServer.h
+++ b/modules/core/include/visp3/core/vpServer.h
@@ -44,6 +44,9 @@
 #include <visp3/core/vpException.h>
 #include <visp3/core/vpNetwork.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 /*!
   \class vpServer
 
@@ -219,4 +222,5 @@ public:
   void setMaxNumberOfClients(unsigned int &l) { max_clients = l; }
 };
 
+#endif
 #endif

--- a/modules/core/include/visp3/core/vpUDPClient.h
+++ b/modules/core/include/visp3/core/vpUDPClient.h
@@ -38,12 +38,15 @@
 
 #include <visp3/core/vpConfig.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#  include <sys/types.h>
 #else
-#include <winsock2.h>
+#  include <winsock2.h>
 #endif
 
 #include <visp3/core/vpException.h>
@@ -185,4 +188,5 @@ private:
   void init(const std::string &hostname, const int port);
 };
 
+#endif
 #endif

--- a/modules/core/include/visp3/core/vpUDPServer.h
+++ b/modules/core/include/visp3/core/vpUDPServer.h
@@ -38,12 +38,15 @@
 
 #include <visp3/core/vpConfig.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/types.h>
+#  include <netinet/in.h>
+#  include <sys/socket.h>
+#  include <sys/types.h>
 #else
-#include <winsock2.h>
+#  include <winsock2.h>
 #endif
 
 #include <visp3/core/vpException.h>
@@ -217,4 +220,5 @@ private:
   void init(const std::string &hostname, const int port);
 };
 
+#endif
 #endif

--- a/modules/core/src/tools/network/vpClient.cpp
+++ b/modules/core/src/tools/network/vpClient.cpp
@@ -38,6 +38,9 @@
 
 #include <visp3/core/vpClient.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 vpClient::vpClient() : vpNetwork(), numberOfAttempts(0) {}
 
 /*!
@@ -210,3 +213,8 @@ bool vpClient::connectServer(vpNetwork::vpReceptor &serv)
   std::cout << "Connected!" << std::endl;
   return true;
 }
+
+#elif !defined(VISP_BUILD_SHARED_LIBS)
+// Work arround to avoid warning: libvisp_core.a(vpClient.cpp.o) has no symbols
+void dummy_vpClient(){};
+#endif

--- a/modules/core/src/tools/network/vpNetwork.cpp
+++ b/modules/core/src/tools/network/vpNetwork.cpp
@@ -38,6 +38,9 @@
 
 #include <visp3/core/vpNetwork.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 vpNetwork::vpNetwork()
   : emitter(), receptor_list(), readFileDescriptor(), socketMax(0), request_list(), max_size_message(999999),
     separator("[*@*]"), beginning("[*start*]"), end("[*end*]"), param_sep("[*|*]"), currentMessageReceived(), tv(),
@@ -785,3 +788,8 @@ int vpNetwork::_receiveRequestOnceFrom(const unsigned int &receptorEmitting)
 
   return numbytes;
 }
+
+#elif !defined(VISP_BUILD_SHARED_LIBS)
+// Work arround to avoid warning: libvisp_core.a(vpNetwork.cpp.o) has no symbols
+void dummy_vpNetwork(){};
+#endif

--- a/modules/core/src/tools/network/vpServer.cpp
+++ b/modules/core/src/tools/network/vpServer.cpp
@@ -38,6 +38,9 @@
 
 #include <visp3/core/vpServer.h>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 #if defined(__APPLE__) && defined(__MACH__) // Apple OSX and iOS (Darwin)
 #include <TargetConditionals.h>             // To detect OSX or IOS using TARGET_OS_IPHONE or TARGET_OS_IOS macro
 #endif
@@ -284,3 +287,8 @@ bool vpServer::checkForConnections()
   Print the connected clients.
 */
 void vpServer::print() { vpNetwork::print("Client"); }
+
+#elif !defined(VISP_BUILD_SHARED_LIBS)
+// Work arround to avoid warning: libvisp_core.a(vpServer.cpp.o) has no symbols
+void dummy_vpServer(){};
+#endif

--- a/modules/core/src/tools/network/vpUDPClient.cpp
+++ b/modules/core/src/tools/network/vpUDPClient.cpp
@@ -36,6 +36,9 @@
 #include <cstring>
 #include <sstream>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
 #include <arpa/inet.h>
 #include <errno.h>
@@ -224,3 +227,8 @@ int vpUDPClient::send(const std::string &msg)
                 m_serverLength);
 #endif
 }
+
+#elif !defined(VISP_BUILD_SHARED_LIBS)
+// Work arround to avoid warning: libvisp_core.a(vpUDPClient.cpp.o) has no symbols
+void dummy_vpUDPClient(){};
+#endif

--- a/modules/core/src/tools/network/vpUDPServer.cpp
+++ b/modules/core/src/tools/network/vpUDPServer.cpp
@@ -36,18 +36,21 @@
 #include <cstring>
 #include <sstream>
 
+// Only available since Windows 8.1 where inet_atoa() is supported
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
+
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
-#include <arpa/inet.h>
-#include <errno.h>
-#include <netdb.h>
-#include <unistd.h>
-#define DWORD int
-#define WSAGetLastError() strerror(errno)
+#  include <arpa/inet.h>
+#  include <errno.h>
+#  include <netdb.h>
+#  include <unistd.h>
+#  define DWORD int
+#  define WSAGetLastError() strerror(errno)
 #else
-#if defined(__MINGW32__)
-#define _WIN32_WINNT _WIN32_WINNT_VISTA // 0x0600
-#endif
-#include <Ws2tcpip.h>
+#  if defined(__MINGW32__)
+#    define _WIN32_WINNT _WIN32_WINNT_VISTA // 0x0600
+#  endif
+#  include <Ws2tcpip.h>
 #endif
 
 #include <visp3/core/vpUDPServer.h>
@@ -317,3 +320,8 @@ int vpUDPServer::send(const std::string &msg, const std::string &hostname, const
                 m_clientLength);
 #endif
 }
+
+#elif !defined(VISP_BUILD_SHARED_LIBS)
+// Work arround to avoid warning: libvisp_core.a(vpUDPServer.cpp.o) has no symbols
+void dummy_vpUDPServer(){};
+#endif

--- a/modules/core/test/network/testClient.cpp
+++ b/modules/core/test/network/testClient.cpp
@@ -47,6 +47,7 @@
 
 int main()
 {
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
   try {
     std::string servername = "localhost";
     unsigned int port = 35000;
@@ -73,4 +74,7 @@ int main()
     std::cout << "Catch an exception: " << e << std::endl;
     return 1;
   }
+#else
+  std::cout << "This test doesn't work on platform prior to win 8.1" << std::endl;
+#endif
 }

--- a/modules/core/test/network/testClient.cpp
+++ b/modules/core/test/network/testClient.cpp
@@ -76,5 +76,6 @@ int main()
   }
 #else
   std::cout << "This test doesn't work on platform prior to win 8.1" << std::endl;
+  return EXIT_SUCCESS;
 #endif
 }

--- a/modules/core/test/network/testServer.cpp
+++ b/modules/core/test/network/testServer.cpp
@@ -47,6 +47,7 @@
 
 int main()
 {
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
   try {
     int port = 35000;
     vpServer serv(port); // Launch the server on localhost
@@ -76,4 +77,7 @@ int main()
     std::cout << "Catch an exception: " << e << std::endl;
     return 1;
   }
+#else
+  std::cout << "This test doesn't work on platform prior to win 8.1" << std::endl;
+#endif
 }

--- a/modules/core/test/network/testServer.cpp
+++ b/modules/core/test/network/testServer.cpp
@@ -79,5 +79,6 @@ int main()
   }
 #else
   std::cout << "This test doesn't work on platform prior to win 8.1" << std::endl;
+  return EXIT_SUCCESS;
 #endif
 }

--- a/modules/core/test/network/testUDPClient.cpp
+++ b/modules/core/test/network/testUDPClient.cpp
@@ -57,6 +57,7 @@ struct DataType {
 
 int main()
 {
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
   try {
     std::string servername = "127.0.0.1";
     unsigned int port = 50037;
@@ -95,4 +96,8 @@ int main()
     std::cerr << "Catch an exception: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  std::cout << "This test doesn't work on platform prior to win 8.1" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/modules/core/test/network/testUDPServer.cpp
+++ b/modules/core/test/network/testUDPServer.cpp
@@ -60,6 +60,7 @@ struct DataType {
 
 int main()
 {
+#if !(defined(_WIN32) && (_WIN32_WINNT < 0x0603))
   try {
     int port = 50037;
     vpUDPServer server(port);
@@ -114,4 +115,8 @@ int main()
     std::cerr << "Catch an exception: " << e.what() << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  std::cout << "This test doesn't work on platform prior to win 8.1" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }


### PR DESCRIPTION
Make vpNetwork, vpClient, vpServer classes available only since win 8.1 where inet_ntop() is implemented. Closes #287