### PR TITLE
update doc

### DIFF
--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -750,11 +750,11 @@ void vpMbTracker::initFromPoints(const vpImage<unsigned char> &I, const std::vec
   in the file initFile. The structure of this file is (without the comments):
   \code
   // The six value of the pose vector
-  0.0000    //  \
-  0.0000    //  |
-  1.0000    //  | Exemple of value for the pose vector where Z = 1 meter
-  0.0000    //  |
-  0.0000    //  |
+  0.1000    //  \
+  0.1000    //  | Exemple of value for the pose vector where 
+  1.0000    //  | X = 0.1 meter
+  0.0000    //  | Y = 0.1 meter
+  0.0000    //  | Z = 1 meter
   0.0000    //  /
   \endcode
 


### PR DESCRIPTION
The original documentation proposes to set the initial position of the object to 0,0,1. This is likely to fail at initialization time when the method "outOfImage" of the class "vpMeTracker" is called to check if the points of the object are within the zone of attention (the image minus some margin).

Proposing an initialization to another value (less close to 0, and therefore within the zone of attention of the tracker) would avoid to run in this error.