### PR TITLE
Fix various issues in mbt

### DIFF
--- a/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
@@ -111,20 +111,20 @@ vpMbEdgeTracker::~vpMbEdgeTracker()
         cy = NULL;
       }
 
+      for (std::list<vpMbtDistanceCircle *>::const_iterator it = circles[i].begin(); it != circles[i].end(); ++it) {
+        ci = *it;
+        if (ci != NULL) {
+          delete ci;
+        }
+        ci = NULL;
+      }
+
       lines[i].clear();
       cylinders[i].clear();
+      circles[i].clear();
     }
   }
-  for (unsigned int i = 0; i < circles.size(); i += 1) {
-    for (std::list<vpMbtDistanceCircle *>::const_iterator it = circles[i].begin(); it != circles[i].end(); ++it) {
-      ci = *it;
-      if (ci != NULL) {
-        delete ci;
-      }
-      ci = NULL;
-    }
-    circles[i].clear();
-  }
+
   cleanPyramid(Ipyramid);
 }
 
@@ -330,7 +330,7 @@ void vpMbEdgeTracker::computeVVSFirstPhase(const vpImage<unsigned char> &_I, con
 
       unsigned int indexFeature = 0;
 
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         if (iter == 0 && l->meline[a] != NULL)
           itListLine = l->meline[a]->getMeList().begin();
 
@@ -583,7 +583,7 @@ void vpMbEdgeTracker::computeVVSFirstPhaseFactor(const vpImage<unsigned char> &I
       }
 
       unsigned int indexFeature = 0;
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         std::list<vpMeSite>::const_iterator itListLine;
         if (l->meline[a] != NULL) {
           itListLine = l->meline[a]->getMeList().begin();
@@ -873,7 +873,7 @@ void vpMbEdgeTracker::computeProjectionError(const vpImage<unsigned char> &_I)
        ++it) {
     vpMbtDistanceLine *l = *it;
     if (l->isVisible() && l->isTracked()) {
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         if (l->meline[a] != NULL) {
           double lineNormGradient;
           unsigned int lineNbFeatures;
@@ -944,7 +944,7 @@ void vpMbEdgeTracker::testTracking()
        ++it) {
     vpMbtDistanceLine *l = *it;
     if (l->isVisible() && l->isTracked()) {
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         if (l->meline[a] != NULL) {
           nbExpectedPoint += (int)l->meline[a]->expecteddensity;
           for (std::list<vpMeSite>::const_iterator itme = l->meline[a]->getMeList().begin();
@@ -1147,10 +1147,7 @@ void vpMbEdgeTracker::init(const vpImage<unsigned char> &I)
   if (clippingFlag > 2)
     cam.computeFov(I.getWidth(), I.getHeight());
 
-  initPyramid(I, Ipyramid);
   visibleFace(I, cMo, a);
-  unsigned int i = (unsigned int)scales.size();
-
   resetMovingEdge();
 
   if (useScanLine) {
@@ -1161,6 +1158,8 @@ void vpMbEdgeTracker::init(const vpImage<unsigned char> &I)
     faces.computeScanLineRender(cam, I.getWidth(), I.getHeight());
   }
 
+  initPyramid(I, Ipyramid);
+  unsigned int i = (unsigned int)scales.size();
   do {
     i--;
     if (scales[i]) {
@@ -1453,11 +1452,11 @@ void vpMbEdgeTracker::initMovingEdge(const vpImage<unsigned char> &I, const vpHo
     if (isvisible) {
       l->setVisible(true);
       l->updateTracked();
-      if (l->meline.size() == 0 && l->isTracked())
+      if (l->meline.empty() && l->isTracked())
         l->initMovingEdge(I, _cMo);
     } else {
       l->setVisible(false);
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         if (l->meline[a] != NULL)
           delete l->meline[a];
         if (a < l->nbFeature.size())
@@ -1547,7 +1546,7 @@ void vpMbEdgeTracker::trackMovingEdge(const vpImage<unsigned char> &I)
        ++it) {
     vpMbtDistanceLine *l = *it;
     if (l->isVisible() && l->isTracked()) {
-      if (l->meline.size() == 0) {
+      if (l->meline.empty()) {
         l->initMovingEdge(I, cMo);
       }
       l->trackMovingEdge(I, cMo);
@@ -1632,7 +1631,7 @@ void vpMbEdgeTracker::updateMovingEdgeWeights()
       l = *it;
       unsigned int indexLine = 0;
       double wmean = 0;
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         if (l->nbFeature[a] > 0) {
           std::list<vpMeSite>::iterator itListLine;
           itListLine = l->meline[a]->getMeList().begin();
@@ -1820,7 +1819,7 @@ void vpMbEdgeTracker::resetMovingEdge()
   for (unsigned int i = 0; i < scales.size(); i += 1) {
     if (scales[i]) {
       for (std::list<vpMbtDistanceLine *>::const_iterator it = lines[i].begin(); it != lines[i].end(); ++it) {
-        for (unsigned int a = 0; a < (*it)->meline.size(); a++) {
+        for (size_t a = 0; a < (*it)->meline.size(); a++) {
           if ((*it)->meline[a] != NULL) {
             delete (*it)->meline[a];
             (*it)->meline[a] = NULL;
@@ -2454,7 +2453,7 @@ unsigned int vpMbEdgeTracker::getNbPoints(const unsigned int level) const
   for (std::list<vpMbtDistanceLine *>::const_iterator it = lines[level].begin(); it != lines[level].end(); ++it) {
     l = *it;
     if (l->isVisible() && l->isTracked()) {
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         if (l->nbFeature[a] != 0)
           for (std::list<vpMeSite>::const_iterator itme = l->meline[a]->getMeList().begin();
                itme != l->meline[a]->getMeList().end(); ++itme) {

--- a/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
@@ -1825,10 +1825,11 @@ void vpMbEdgeTracker::resetMovingEdge()
             delete (*it)->meline[a];
             (*it)->meline[a] = NULL;
           }
-          (*it)->meline.clear();
-          (*it)->nbFeature.clear();
-          (*it)->nbFeatureTotal = 0;
         }
+
+        (*it)->meline.clear();
+        (*it)->nbFeature.clear();
+        (*it)->nbFeatureTotal = 0;
       }
 
       for (std::list<vpMbtDistanceCylinder *>::const_iterator it = cylinders[i].begin(); it != cylinders[i].end();

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
@@ -403,9 +403,8 @@ bool vpMbtDistanceLine::initMovingEdge(const vpImage<unsigned char> &I, const vp
         try {
           melinePt->initTracking(I, ip1, ip2, rho, theta);
           meline.push_back(melinePt);
-          //        nbFeature.push_back((unsigned int)
-          //        melinePt->getMeList().size()); nbFeatureTotal +=
-          //        nbFeature.back();
+          nbFeature.push_back((unsigned int) melinePt->getMeList().size());
+          nbFeatureTotal += nbFeature.back();
         } catch (...) {
           // vpTRACE("the line can't be initialized");
           delete melinePt;

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
@@ -454,13 +454,13 @@ void vpMbtDistanceLine::trackMovingEdge(const vpImage<unsigned char> &I, const v
     try {
       nbFeature.clear();
       nbFeatureTotal = 0;
-      for (unsigned int i = 0; i < meline.size(); i++) {
+      for (size_t i = 0; i < meline.size(); i++) {
         meline[i]->track(I);
         nbFeature.push_back((unsigned int)meline[i]->getMeList().size());
         nbFeatureTotal += (unsigned int)meline[i]->getMeList().size();
       }
     } catch (...) {
-      for (unsigned int i = 0; i < meline.size(); i++) {
+      for (size_t i = 0; i < meline.size(); i++) {
         if (meline[i] != NULL)
           delete meline[i];
       }
@@ -502,7 +502,7 @@ void vpMbtDistanceLine::updateMovingEdge(const vpImage<unsigned char> &I, const 
       }
 
       if (linesLst.size() != meline.size() || linesLst.size() == 0) {
-        for (unsigned int i = 0; i < meline.size(); i++) {
+        for (size_t i = 0; i < meline.size(); i++) {
           if (meline[i] != NULL)
             delete meline[i];
         }
@@ -577,7 +577,7 @@ void vpMbtDistanceLine::updateMovingEdge(const vpImage<unsigned char> &I, const 
             nbFeatureTotal += nbFeature[i];
           }
         } catch (...) {
-          for (unsigned int j = 0; j < meline.size(); j++) {
+          for (size_t j = 0; j < meline.size(); j++) {
             if (meline[j] != NULL)
               delete meline[j];
           }
@@ -590,7 +590,7 @@ void vpMbtDistanceLine::updateMovingEdge(const vpImage<unsigned char> &I, const 
         }
       }
     } else {
-      for (unsigned int i = 0; i < meline.size(); i++) {
+      for (size_t i = 0; i < meline.size(); i++) {
         if (meline[i] != NULL)
           delete meline[i];
       }
@@ -613,7 +613,7 @@ void vpMbtDistanceLine::updateMovingEdge(const vpImage<unsigned char> &I, const 
 */
 void vpMbtDistanceLine::reinitMovingEdge(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo)
 {
-  for (unsigned int i = 0; i < meline.size(); i++) {
+  for (size_t i = 0; i < meline.size(); i++) {
     if (meline[i] != NULL)
       delete meline[i];
   }
@@ -752,7 +752,7 @@ void vpMbtDistanceLine::display(const vpImage<vpRGBa> &I, const vpHomogeneousMat
 */
 void vpMbtDistanceLine::displayMovingEdges(const vpImage<unsigned char> &I)
 {
-  for (unsigned int i = 0; i < meline.size(); i++)
+  for (size_t i = 0; i < meline.size(); i++)
     if (meline[i] != NULL) {
       meline[i]->display(I);
     }
@@ -763,11 +763,11 @@ void vpMbtDistanceLine::displayMovingEdges(const vpImage<unsigned char> &I)
 */
 void vpMbtDistanceLine::initInteractionMatrixError()
 {
-  if (isvisible == true) {
+  if (isvisible) {
     L.resize(nbFeatureTotal, 6);
     error.resize(nbFeatureTotal);
   } else {
-    for (unsigned int i = 0; i < meline.size(); i++) {
+    for (size_t i = 0; i < meline.size(); i++) {
       nbFeature[i] = 0;
       // To be consistent with nbFeature[i] = 0
       std::list<vpMeSite> &me_site_list = meline[i]->getMeList();
@@ -808,7 +808,7 @@ void vpMbtDistanceLine::computeInteractionMatrixError(const vpHomogeneousMatrix 
       double x, y;
       unsigned int j = 0;
 
-      for (unsigned int i = 0; i < meline.size(); i++) {
+      for (size_t i = 0; i < meline.size(); i++) {
         for (std::list<vpMeSite>::const_iterator it = meline[i]->getMeList().begin();
              it != meline[i]->getMeList().end(); ++it) {
           x = (double)it->j;
@@ -834,7 +834,7 @@ void vpMbtDistanceLine::computeInteractionMatrixError(const vpHomogeneousMatrix 
       std::cerr << "Set the corresponding interaction matrix part to zero." << std::endl;
 
       unsigned int j = 0;
-      for (unsigned int i = 0; i < meline.size(); i++) {
+      for (size_t i = 0; i < meline.size(); i++) {
         for (std::list<vpMeSite>::const_iterator it = meline[i]->getMeList().begin();
              it != meline[i]->getMeList().end(); ++it) {
           for (unsigned int k = 0; k < 6; k++) {
@@ -864,7 +864,7 @@ bool vpMbtDistanceLine::closeToImageBorder(const vpImage<unsigned char> &I, cons
   }
   if (isvisible) {
 
-    for (unsigned int i = 0; i < meline.size(); i++) {
+    for (size_t i = 0; i < meline.size(); i++) {
       for (std::list<vpMeSite>::const_iterator it = meline[i]->getMeList().begin(); it != meline[i]->getMeList().end();
            ++it) {
         int i_ = it->i;

--- a/modules/tracker/mbt/src/hybrid/vpMbEdgeKltTracker.cpp
+++ b/modules/tracker/mbt/src/hybrid/vpMbEdgeKltTracker.cpp
@@ -419,7 +419,7 @@ void vpMbEdgeKltTracker::postTrackingMbt(vpColVector &w, const unsigned int lvl)
       unsigned int indexLine = 0;
       double wmean = 0;
 
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         std::list<vpMeSite>::iterator itListLine;
         if (l->nbFeature[a] > 0)
           itListLine = l->meline[a]->getMeList().begin();
@@ -894,7 +894,7 @@ unsigned int vpMbEdgeKltTracker::trackFirstLoop(const vpImage<unsigned char> &I,
       }
 
       unsigned int indexFeature = 0;
-      for (unsigned int a = 0; a < l->meline.size(); a++) {
+      for (size_t a = 0; a < l->meline.size(); a++) {
         std::list<vpMeSite>::const_iterator itListLine;
         if (l->meline[a] != NULL) {
           itListLine = l->meline[a]->getMeList().begin();

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -1948,7 +1948,6 @@ void vpMbTracker::extractFaces(SoVRMLIndexedFaceSet *face_set, vpHomogeneousMatr
                                const std::string &polygonName)
 {
   std::vector<vpPoint> corners;
-  corners.resize(0);
 
   //  SoMFInt32 indexList = _face_set->coordIndex;
   //  int indexListSize = indexList.getNum();

--- a/modules/tracker/me/src/moving-edges/vpMeSite.cpp
+++ b/modules/tracker/me/src/moving-edges/vpMeSite.cpp
@@ -218,26 +218,19 @@ vpMeSite &vpMeSite::operator=(const vpMeSite &m)
 
 vpMeSite *vpMeSite::getQueryList(const vpImage<unsigned char> &I, const int range)
 {
-
-  int k;
-
-  int n;
-  vpMeSite *list_query_pixels;
-  list_query_pixels = NULL;
-
   unsigned int range_ = static_cast<unsigned int>(range);
   // Size of query list includes the point on the line
-  list_query_pixels = new vpMeSite[2 * range_ + 1];
+  vpMeSite *list_query_pixels = new vpMeSite[2 * range_ + 1];
 
   // range : +/- the range within which the pixel's
   // correspondent will be sought
 
   double salpha = sin(alpha);
   double calpha = cos(alpha);
-  n = 0;
+  int n = 0;
   vpImagePoint ip;
 
-  for (k = -range; k <= range; k++) {
+  for (int k = -range; k <= range; k++) {
     double ii = (ifloat + k * salpha);
     double jj = (jfloat + k * calpha);
 
@@ -485,7 +478,6 @@ void vpMeSite::track(const vpImage<unsigned char> &I, const vpMe *me, const bool
   //       delete []likelihood; // modif portage
   //     }
 
-  vpMeSite *list_query_pixels;
   int max_rank = -1;
   //   int max_rank1=-1 ;
   //   int max_rank2 = -1;
@@ -502,7 +494,7 @@ void vpMeSite::track(const vpImage<unsigned char> &I, const vpMe *me, const bool
 
   //  std::cout << i << "  " << j<<"  " << range << "  " << suppress  <<
   //  std::endl ;
-  list_query_pixels = getQueryList(I, (int)range);
+  vpMeSite *list_query_pixels = getQueryList(I, (int)range);
 
   double contraste_max = 1 + me->getMu2();
   double contraste_min = 1 - me->getMu1();


### PR DESCRIPTION
- Invalid write/read:
<details/>

> ==26387== Invalid write of size 4
> ==26387==    at 0x4EE7D65: vpMbtDistanceLine::initInteractionMatrixError() (vpMbtDistanceLine.cpp:772)
> ==26387==    by 0x4EFE2BE: vpMbEdgeTracker::initMbtTracking(unsigned int&, unsigned int&, unsigned int&) (vpMbEdgeTracker.cpp:2292)
> ==26387==    by 0x4EFF80C: vpMbEdgeTracker::computeVVSInit() (vpMbEdgeTracker.cpp:736)
> ==26387==    by 0x4F20EF0: vpMbGenericTracker::TrackerWrapper::initMbtTracking(vpImage<unsigned char> const*) (vpMbGenericTracker.cpp:4641)
> ==26387==    by 0x4F22AF1: vpMbGenericTracker::TrackerWrapper::computeVVSInit(vpImage<unsigned char> const*) (vpMbGenericTracker.cpp:4229)
> ==26387==    by 0x4F2EDB3: vpMbGenericTracker::computeVVSInit(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, vpImage<unsigned char> const*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, vpImage<unsigned char> const*> > >&) (vpMbGenericTracker.cpp:467)
> ==26387==    by 0x4F2CFD5: vpMbGenericTracker::computeVVS(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, vpImage<unsigned char> const*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, vpImage<unsigned char> const*> > >&) (vpMbGenericTracker.cpp:233)
> ==26387==    by 0x4F30A06: vpMbGenericTracker::track(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, vpImage<unsigned char> const*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, vpImage<unsigned char> const*> > >&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> > > >&) (vpMbGenericTracker.cpp:3902)
> ==26387==    by 0x40D7F2: main (tracking_edge_depth_sequential.cpp:393)
> ==26387==  Address 0x3adc4c10 is 0 bytes after a block of size 16 alloc'd
> ==26387==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==26387==    by 0x4EEE47D: allocate (new_allocator.h:104)
> ==26387==    by 0x4EEE47D: allocate (alloc_traits.h:491)
> ==26387==    by 0x4EEE47D: _M_allocate (stl_vector.h:170)
> ==26387==    by 0x4EEE47D: void std::vector<unsigned int, std::allocator<unsigned int> >::_M_emplace_back_aux<unsigned int>(unsigned int&&) (vector.tcc:412)
> ==26387==    by 0x4EE86E0: emplace_back<unsigned int> (vector.tcc:101)
> ==26387==    by 0x4EE86E0: push_back (stl_vector.h:932)
> ==26387==    by 0x4EE86E0: vpMbtDistanceLine::trackMovingEdge(vpImage<unsigned char> const&, vpHomogeneousMatrix const&) (vpMbtDistanceLine.cpp:460)
> ==26387==    by 0x4EFCB94: vpMbEdgeTracker::trackMovingEdge(vpImage<unsigned char> const&) (vpMbEdgeTracker.cpp:1616)
> ==26387==    by 0x4F20404: vpMbGenericTracker::TrackerWrapper::preTracking(vpImage<unsigned char> const*, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> const&) (vpMbGenericTracker.cpp:4831)
> ==26387==    by 0x4F30725: vpMbGenericTracker::preTracking(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, vpImage<unsigned char> const*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, vpImage<unsigned char> const*> > >&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> > > >&) (vpMbGenericTracker.cpp:2198)
> ==26387==    by 0x4F309F7: vpMbGenericTracker::track(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, vpImage<unsigned char> const*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, vpImage<unsigned char> const*> > >&, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const>, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, boost::shared_ptr<pcl::PointCloud<pcl::PointXYZ> const> > > >&) (vpMbGenericTracker.cpp:3899)
</details>

<br/><br/>

- Memory leak:
<details/>

> ==2284== 1,144 (440 direct, 704 indirect) bytes in 1 blocks are definitely lost in loss record 304 of 328
> ==2284==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
> ==2284==    by 0x4EE9D15: vpMbtDistanceLine::initMovingEdge(vpImage<unsigned char> const&, vpHomogeneousMatrix const&) (vpMbtDistanceLine.cpp:381)
> ==2284==    by 0x4EFC361: vpMbEdgeTracker::initMovingEdge(vpImage<unsigned char> const&, vpHomogeneousMatrix const&) (vpMbEdgeTracker.cpp:1457)
> ==2284==    by 0x4F30ACB: vpMbGenericTracker::TrackerWrapper::init(vpImage<unsigned char> const&) (vpMbGenericTracker.cpp:4545)
> ==2284==    by 0x4F1DFBB: vpMbGenericTracker::initFromPose(vpImage<unsigned char> const&, vpImage<unsigned char> const&, vpHomogeneousMatrix const&, vpHomogeneousMatrix const&) (vpMbGenericTracker.cpp:1848)
> ==2284==    by 0x4082D9: main (mbtGenericTrackingDepth.cpp:819)
</details>