### PR TITLE
correcting build error in examples when mbt module is not built

### DIFF
--- a/example/tracking/mbtGenericTrackingDepthOnly.cpp
+++ b/example/tracking/mbtGenericTrackingDepthOnly.cpp
@@ -43,7 +43,7 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_DISPLAY)
+#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>


### PR DESCRIPTION
When BUILD_MODULE_visp_mbt is disabled in CMake, a build error occurs in a mbt example. See : https://travis-ci.org/MarcPouliquenInria/ustk/builds/355485512 for example