### PR TITLE
New class vpRectOriented and new tools for vpImage added

### DIFF
--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -950,7 +950,7 @@ vpImage<Type>::vpImage(vpImage<Type> &&I)
 template <class Type> Type vpImage<Type>::getMaxValue() const
 {
   if (npixels == 0)
-    throw(vpException(vpException::fatalError, "Cannot compute maximum value of an image containg no pixels"));
+    throw(vpException(vpException::fatalError, "Cannot compute maximum value of an empty image"));
   Type m = bitmap[0];
   for (unsigned int i = 0; i < npixels; i++) {
     if (bitmap[i] > m)
@@ -982,7 +982,7 @@ template <class Type> Type vpImage<Type>::getMeanValue() const
 template <class Type> Type vpImage<Type>::getMinValue() const
 {
   if (npixels == 0)
-    throw(vpException(vpException::fatalError, "Cannot compute minimum value of an image containg no pixels"));
+    throw(vpException(vpException::fatalError, "Cannot compute minimum value of an empty image"));
   Type m = bitmap[0];
   for (unsigned int i = 0; i < npixels; i++)
     if (bitmap[i] < m)
@@ -999,7 +999,7 @@ template <class Type> Type vpImage<Type>::getMinValue() const
 template <class Type> void vpImage<Type>::getMinMaxValue(Type &min, Type &max) const
 {
   if (npixels == 0)
-    throw(vpException(vpException::fatalError, "Cannot compute minimum/maximum values of an image containg no pixels"));
+    throw(vpException(vpException::fatalError, "Cannot compute minimum/maximum values of an empty image"));
   min = max = bitmap[0];
   for (unsigned int i = 0; i < npixels; i++) {
     if (bitmap[i] < min)

--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -179,6 +179,8 @@ public:
 
   // Return the maximum value within the bitmap
   Type getMaxValue() const;
+  // Return the mean value of the bitmap
+  Type getMeanValue() const;
   // Return the minumum value within the bitmap
   Type getMinValue() const;
   // Look for the minumum and the maximum value within the bitmap
@@ -218,6 +220,10 @@ public:
   Type getValue(double i, double j) const;
   // Gets the value of a pixel at a location with bilinear interpolation.
   Type getValue(vpImagePoint &ip) const;
+
+  // return image sum (for unsigned char and double template types only)
+  double getSum() const;
+
   /*!
     Get the image width.
 
@@ -943,6 +949,8 @@ vpImage<Type>::vpImage(vpImage<Type> &&I)
 */
 template <class Type> Type vpImage<Type>::getMaxValue() const
 {
+  if (npixels == 0)
+    throw(vpException(vpException::fatalError, "Cannot compute maximum value of an image containg no pixels"));
   Type m = bitmap[0];
   for (unsigned int i = 0; i < npixels; i++) {
     if (bitmap[i] > m)
@@ -952,12 +960,29 @@ template <class Type> Type vpImage<Type>::getMaxValue() const
 }
 
 /*!
+  \brief Return the mean value of the bitmap
+*/
+template <class Type> Type vpImage<Type>::getMeanValue() const
+{
+  double res = 0.0;
+  if ((height == 0) || (width == 0))
+    return 0.0;
+  for (unsigned int i = 0; i < height; ++i)
+    for (unsigned int j = 0; j < width; ++j)
+      res += *(this)[i][j];
+  res /= (height * width);
+  return res;
+}
+
+/*!
   \brief Return the minimum value within the bitmap
 
   \sa getMaxValue()
 */
 template <class Type> Type vpImage<Type>::getMinValue() const
 {
+  if (npixels == 0)
+    throw(vpException(vpException::fatalError, "Cannot compute minimum value of an image containg no pixels"));
   Type m = bitmap[0];
   for (unsigned int i = 0; i < npixels; i++)
     if (bitmap[i] < m)
@@ -973,6 +998,8 @@ template <class Type> Type vpImage<Type>::getMinValue() const
 */
 template <class Type> void vpImage<Type>::getMinMaxValue(Type &min, Type &max) const
 {
+  if (npixels == 0)
+    throw(vpException(vpException::fatalError, "Cannot compute minimum/maximum values of an image containg no pixels"));
   min = max = bitmap[0];
   for (unsigned int i = 0; i < npixels; i++) {
     if (bitmap[i] < min)
@@ -1575,6 +1602,44 @@ template <> inline vpRGBa vpImage<vpRGBa>::getValue(vpImagePoint &ip) const
                   ((double)row[iround][jround + 1].B * rfrac + (double)row[iround + 1][jround + 1].B * rratio) * cratio;
   return vpRGBa((unsigned char)vpMath::round(valueR), (unsigned char)vpMath::round(valueG),
                 (unsigned char)vpMath::round(valueB));
+}
+
+/**
+* Compute the sum of image intensities.
+*/
+template <class Type> inline double vpImage<Type>::getSum() const
+{
+  throw(vpException(vpException::notImplementedError,
+                    "vpImage::getSum is only available for unsigned char and double template types."));
+  return .0;
+}
+
+/**
+* Compute the sum of image intensities.
+*/
+template <> inline double vpImage<unsigned char>::getSum() const
+{
+  double res = 0.0;
+  if ((height == 0) || (width == 0))
+    return 0.0;
+  for (unsigned int i = 0; i < height; ++i)
+    for (unsigned int j = 0; j < width; ++j)
+      res += static_cast<double>((*this)[i][j]);
+  return res;
+}
+
+/**
+* Compute the sum of image intensities.
+*/
+template <> inline double vpImage<double>::getSum() const
+{
+  double res = 0.0;
+  if ((height == 0) || (width == 0))
+    return 0.0;
+  for (unsigned int i = 0; i < height; ++i)
+    for (unsigned int j = 0; j < width; ++j)
+      res += (*this)[i][j];
+  return res;
 }
 
 /*!

--- a/modules/core/include/visp3/core/vpImageTools.h
+++ b/modules/core/include/visp3/core/vpImageTools.h
@@ -57,6 +57,7 @@
 #include <visp3/core/vpImageException.h>
 #include <visp3/core/vpMath.h>
 #include <visp3/core/vpRect.h>
+#include <visp3/core/vpRectOriented.h>
 
 #include <fstream>
 #include <iostream>
@@ -91,6 +92,8 @@ public:
   static void crop(const vpImage<Type> &I, double roi_top, double roi_left, unsigned int roi_height,
                    unsigned int roi_width, vpImage<Type> &crop, unsigned int v_scale = 1, unsigned int h_scale = 1);
 
+  static void columnMean(const vpImage<double> &I, vpRowVector &result);
+
   template <class Type>
   static void crop(const vpImage<Type> &I, const vpImagePoint &topLeft, unsigned int roi_height, unsigned int roi_width,
                    vpImage<Type> &crop, unsigned int v_scale = 1, unsigned int h_scale = 1);
@@ -100,6 +103,9 @@ public:
   template <class Type>
   static void crop(const unsigned char *bitmap, unsigned int width, unsigned int height, const vpRect &roi,
                    vpImage<Type> &crop, unsigned int v_scale = 1, unsigned int h_scale = 1);
+
+  static void extract(const vpImage<unsigned char> &Src, vpImage<unsigned char> &Dst, const vpRectOriented &r);
+  static void extract(const vpImage<unsigned char> &Src, vpImage<double> &Dst, const vpRectOriented &r);
 
   template <class Type> static void flip(const vpImage<Type> &I, vpImage<Type> &newI);
 
@@ -111,6 +117,7 @@ public:
 
   static void imageDifferenceAbsolute(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                                       vpImage<unsigned char> &Idiff);
+  static void imageDifferenceAbsolute(const vpImage<double> &I1, const vpImage<double> &I2, vpImage<double> &Idiff);
   static void imageDifferenceAbsolute(const vpImage<vpRGBa> &I1, const vpImage<vpRGBa> &I2, vpImage<vpRGBa> &Idiff);
 
   static void imageAdd(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2, vpImage<unsigned char> &Ires,
@@ -118,6 +125,12 @@ public:
 
   static void imageSubtract(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                             vpImage<unsigned char> &Ires, const bool saturate = false);
+
+  static double interpolate(const vpImage<unsigned char> &I, vpImagePoint point, vpImageInterpolationType it);
+
+  static double normalizedCorrelation(const vpImage<double> &I1, const vpImage<double> &I2);
+
+  static void normalize(vpImage<double> &I);
 
   template <class Type>
   static void resize(const vpImage<Type> &I, vpImage<Type> &Ires, const unsigned int width, const unsigned int height,

--- a/modules/core/include/visp3/core/vpRectOriented.h
+++ b/modules/core/include/visp3/core/vpRectOriented.h
@@ -54,7 +54,7 @@ class VISP_EXPORT vpRectOriented
 public:
   vpRectOriented();
 
-  vpRectOriented(const vpImagePoint center, const double width, const double height, const double theta = 0);
+  vpRectOriented(const vpImagePoint &center, const double width, const double height, const double theta = 0);
 
   vpRectOriented(const vpRect &rect);
 
@@ -64,10 +64,10 @@ public:
 
   operator vpRect();
 
-  void setCenter(const vpImagePoint center);
+  void setCenter(const vpImagePoint &center);
 
-  void setPoints(const vpImagePoint topLeft, const vpImagePoint topRight, const vpImagePoint bottomLeft,
-                 const vpImagePoint bottomRight);
+  void setPoints(const vpImagePoint &topLeft, const vpImagePoint &topRight, const vpImagePoint &bottomLeft,
+                 const vpImagePoint &bottomRight);
 
   vpImagePoint getCenter() const;
 
@@ -89,7 +89,7 @@ public:
 
   double getOrientation() const;
 
-  bool isInside(vpImagePoint point) const;
+  bool isInside(const vpImagePoint &point) const;
 
 private:
   vpImagePoint m_center;
@@ -100,7 +100,6 @@ private:
   vpImagePoint m_topRight;
   vpImagePoint m_bottomLeft;
   vpImagePoint m_bottomRight;
-  bool isLeft(vpImagePoint pointToTest, vpImagePoint point1, vpImagePoint point2) const;
+  bool isLeft(const vpImagePoint &pointToTest, const vpImagePoint &point1, const vpImagePoint &point2) const;
 };
-
 #endif // vpRectOriented_h

--- a/modules/core/include/visp3/core/vpRectOriented.h
+++ b/modules/core/include/visp3/core/vpRectOriented.h
@@ -1,0 +1,106 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2017 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Defines a (possibly oriented) rectangle in the plane.
+ *
+ * Author:
+ * Pierre Chatelain
+ * Marc Pouliquen
+ *
+ *****************************************************************************/
+
+#ifndef vpRectOriented_h
+#define vpRectOriented_h
+
+/*!
+  \class vpRectOriented
+  \ingroup group_core_geometry
+  \brief Defines an oriented rectangle in the plane.
+*/
+
+#include <visp3/core/vpImagePoint.h>
+#include <visp3/core/vpRect.h>
+
+class VISP_EXPORT vpRectOriented
+{
+public:
+  vpRectOriented();
+
+  vpRectOriented(const vpImagePoint center, const double width, const double height, const double theta = 0);
+
+  vpRectOriented(const vpRect &rect);
+
+  vpRectOriented &operator=(const vpRectOriented &rect);
+
+  vpRectOriented &operator=(const vpRect &rect);
+
+  operator vpRect();
+
+  void setCenter(const vpImagePoint center);
+
+  void setPoints(const vpImagePoint topLeft, const vpImagePoint topRight, const vpImagePoint bottomLeft,
+                 const vpImagePoint bottomRight);
+
+  vpImagePoint getCenter() const;
+
+  vpImagePoint getTopLeft() const;
+
+  vpImagePoint getTopRight() const;
+
+  vpImagePoint getBottomLeft() const;
+
+  vpImagePoint getBottomRight() const;
+
+  void setSize(double width, double height);
+
+  double getWidth() const;
+
+  double getHeight() const;
+
+  void setOrientation(double theta);
+
+  double getOrientation() const;
+
+  bool isInside(vpImagePoint point) const;
+
+private:
+  vpImagePoint m_center;
+  double m_width;
+  double m_height;
+  double m_theta;
+  vpImagePoint m_topLeft;
+  vpImagePoint m_topRight;
+  vpImagePoint m_bottomLeft;
+  vpImagePoint m_bottomRight;
+  bool isLeft(vpImagePoint pointToTest, vpImagePoint point1, vpImagePoint point2) const;
+};
+
+#endif // vpRectOriented_h

--- a/modules/core/src/image/vpImageTools.cpp
+++ b/modules/core/src/image/vpImageTools.cpp
@@ -219,7 +219,7 @@ void vpImageTools::imageDifferenceAbsolute(const vpImage<unsigned char> &I1, con
 }
 
 /*!
-  Compute the difference between the two images I1 and I2
+  Compute the difference between the two images I1 and I2.
 
   \param I1 : The first image.
   \param I2 : The second image.
@@ -453,12 +453,13 @@ double vpImageTools::interpolate(const vpImage<unsigned char> &I, vpImagePoint p
       return v1;
     return (y2 - point.get_j()) * v1 + (point.get_j() - y1) * v2;
   }
-  case INTERPOLATION_CUBIC:
-    std::cerr << "Error: bi-cubic interpolation is not implemented." << std::endl;
-    exit(EXIT_FAILURE);
-  default:
-    std::cerr << "Error: invalid interpolation type (" << it << ")" << std::endl;
-    exit(EXIT_FAILURE);
+  case INTERPOLATION_CUBIC: {
+    throw vpException(vpException::notImplementedError,
+                      "vpImageTools::interpolate(): bi-cubic interpolation is not implemented.");
+  }
+  default: {
+    throw vpException(vpException::notImplementedError, "vpImageTools::interpolate(): invalid interpolation type");
+  }
   }
 }
 
@@ -476,11 +477,13 @@ void vpImageTools::extract(const vpImage<unsigned char> &Src, vpImage<unsigned c
   double y1 = r.getTopLeft().get_j();
   double t = r.getOrientation();
   Dst.resize(x_d, y_d);
-  for (unsigned int x = 0; x < x_d; ++x)
-    for (unsigned int y = 0; y < y_d; ++y)
+  for (unsigned int x = 0; x < x_d; ++x) {
+    for (unsigned int y = 0; y < y_d; ++y) {
       Dst(x, y,
           (unsigned char)interpolate(Src, vpImagePoint(x1 + x * cos(t) + y * sin(t), y1 - x * sin(t) + y * cos(t)),
                                      vpImageTools::INTERPOLATION_LINEAR));
+    }
+  }
 }
 
 /*!
@@ -497,10 +500,12 @@ void vpImageTools::extract(const vpImage<unsigned char> &Src, vpImage<double> &D
   double y1 = r.getTopLeft().get_j();
   double t = r.getOrientation();
   Dst.resize(x_d, y_d);
-  for (unsigned int x = 0; x < x_d; ++x)
-    for (unsigned int y = 0; y < y_d; ++y)
+  for (unsigned int x = 0; x < x_d; ++x) {
+    for (unsigned int y = 0; y < y_d; ++y) {
       Dst(x, y, interpolate(Src, vpImagePoint(x1 + x * cos(t) + y * sin(t), y1 - x * sin(t) + y * cos(t)),
                             vpImageTools::INTERPOLATION_LINEAR));
+    }
+  }
 }
 
 // Reference:

--- a/modules/core/src/tools/geometry/vpRectOriented.cpp
+++ b/modules/core/src/tools/geometry/vpRectOriented.cpp
@@ -52,7 +52,7 @@ vpRectOriented::vpRectOriented()
  * @param height The rectangle height.
  * @param theta The rectangle orientation (rad).
  */
-vpRectOriented::vpRectOriented(const vpImagePoint center, const double width, const double height, const double theta)
+vpRectOriented::vpRectOriented(const vpImagePoint &center, const double width, const double height, const double theta)
 {
   m_center = center;
   m_width = width;
@@ -124,7 +124,6 @@ vpRectOriented &vpRectOriented::operator=(const vpRect &rect)
 }
 
 /** Conversion to vpRect operator.
- * @param rect Rectangle to copy.
  */
 vpRectOriented::operator vpRect()
 {
@@ -137,8 +136,8 @@ vpRectOriented::operator vpRect()
  *  @warning This method doesn't check whether the 4 points actually form a rectangle!
  *  The behaviour is undefined if it is not the case.
  */
-void vpRectOriented::setPoints(const vpImagePoint topLeft, const vpImagePoint topRight, const vpImagePoint bottomLeft,
-                               const vpImagePoint bottomRight)
+void vpRectOriented::setPoints(const vpImagePoint &topLeft, const vpImagePoint &topRight,
+                               const vpImagePoint &bottomLeft, const vpImagePoint &bottomRight)
 {
   m_topLeft = topLeft;
   m_bottomLeft = bottomLeft;
@@ -154,7 +153,7 @@ void vpRectOriented::setPoints(const vpImagePoint topLeft, const vpImagePoint to
 }
 
 /// Set the center of the rectangle.
-void vpRectOriented::setCenter(const vpImagePoint center)
+void vpRectOriented::setCenter(const vpImagePoint &center)
 {
   m_topLeft += center - m_center;
   m_bottomLeft += center - m_center;
@@ -217,7 +216,7 @@ void vpRectOriented::setOrientation(double theta)
 double vpRectOriented::getOrientation() const { return m_theta; }
 
 /// Check whether the point is inside the rectangle.
-bool vpRectOriented::isInside(vpImagePoint point) const
+bool vpRectOriented::isInside(const vpImagePoint &point) const
 {
   if (!isLeft(point, m_topLeft, m_bottomLeft))
     return false;
@@ -230,7 +229,8 @@ bool vpRectOriented::isInside(vpImagePoint point) const
   return true;
 }
 
-bool vpRectOriented::isLeft(vpImagePoint pointToTest, vpImagePoint point1, vpImagePoint point2) const
+bool vpRectOriented::isLeft(const vpImagePoint &pointToTest, const vpImagePoint &point1,
+                            const vpImagePoint &point2) const
 {
   double a = point1.get_j() - point2.get_j();
   double b = point2.get_i() - point1.get_i();

--- a/modules/core/src/tools/geometry/vpRectOriented.cpp
+++ b/modules/core/src/tools/geometry/vpRectOriented.cpp
@@ -1,0 +1,240 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2017 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Defines a (possibly oriented) rectangle in the plane.
+ *
+ * Author:
+ * Pierre Chatelain
+ * Marc Pouliquen
+ *
+ *****************************************************************************/
+#include <visp3/core/vpRectOriented.h>
+
+#include <cmath>
+
+/// Default constructor.
+vpRectOriented::vpRectOriented()
+  : m_center(), m_width(), m_height(), m_theta(), m_topLeft(), m_topRight(), m_bottomLeft(), m_bottomRight()
+{
+}
+
+/** Constructor.
+ * @param center The rectangle center.
+ * @param width The rectangle width.
+ * @param height The rectangle height.
+ * @param theta The rectangle orientation (rad).
+ */
+vpRectOriented::vpRectOriented(const vpImagePoint center, const double width, const double height, const double theta)
+{
+  m_center = center;
+  m_width = width;
+  m_height = height;
+  m_theta = theta;
+  m_topLeft.set_i(m_center.get_i() - m_height * cos(m_theta) / 2.0 - m_width * sin(m_theta) / 2.0);
+  m_topLeft.set_j(m_center.get_j() + m_height * sin(m_theta) / 2.0 - m_width * cos(m_theta) / 2.0);
+  m_bottomLeft.set_i(m_center.get_i() + m_height * cos(m_theta) / 2.0 - m_width * sin(m_theta) / 2.0);
+  m_bottomLeft.set_j(m_center.get_j() - m_height * sin(m_theta) / 2.0 - m_width * cos(m_theta) / 2.0);
+  m_bottomRight.set_i(m_center.get_i() + m_height * cos(m_theta) / 2.0 + m_width * sin(m_theta) / 2.0);
+  m_bottomRight.set_j(m_center.get_j() - m_height * sin(m_theta) / 2.0 + m_width * cos(m_theta) / 2.0);
+  m_topRight.set_i(m_center.get_i() - m_height * cos(m_theta) / 2.0 + m_width * sin(m_theta) / 2.0);
+  m_topRight.set_j(m_center.get_j() + m_height * sin(m_theta) / 2.0 + m_width * cos(m_theta) / 2.0);
+}
+
+/** Copy constructor.
+ * @param rect Rectangle to copy.
+ */
+vpRectOriented::vpRectOriented(const vpRect &rect)
+{
+  m_center = rect.getCenter();
+  m_width = rect.getWidth();
+  m_height = rect.getHeight();
+  m_theta = .0;
+  m_topLeft.set_i(m_center.get_i() - m_height / 2.0);
+  m_topLeft.set_j(m_center.get_j() - m_width / 2.0);
+  m_bottomLeft.set_i(m_center.get_i() + m_height / 2.0);
+  m_bottomLeft.set_j(m_center.get_j() - m_width / 2.0);
+  m_bottomRight.set_i(m_center.get_i() + m_height / 2.0);
+  m_bottomRight.set_j(m_center.get_j() + m_width / 2.0);
+  m_topRight.set_i(m_center.get_i() - m_height / 2.0);
+  m_topRight.set_j(m_center.get_j() + m_width / 2.0);
+}
+
+/** Assignement operator.
+ * @param rectOriented Oriented rectangle to copy.
+ */
+vpRectOriented &vpRectOriented::operator=(const vpRectOriented &rectOriented)
+{
+  m_center = rectOriented.getCenter();
+  m_width = rectOriented.getWidth();
+  m_height = rectOriented.getHeight();
+  m_theta = rectOriented.getOrientation();
+  m_topLeft = rectOriented.getTopLeft();
+  m_bottomLeft = rectOriented.getBottomLeft();
+  m_bottomRight = rectOriented.getBottomRight();
+  m_topRight = rectOriented.getTopRight();
+  return *this;
+}
+
+/** Assignement operator from vpRect.
+ * @param rect Rectangle to copy.
+ */
+vpRectOriented &vpRectOriented::operator=(const vpRect &rect)
+{
+  m_center = rect.getCenter();
+  m_width = rect.getWidth();
+  m_height = rect.getHeight();
+  m_theta = .0;
+  m_topLeft.set_i(m_center.get_i() - m_height / 2.0);
+  m_topLeft.set_j(m_center.get_j() - m_width / 2.0);
+  m_bottomLeft.set_i(m_center.get_i() + m_height / 2.0);
+  m_bottomLeft.set_j(m_center.get_j() - m_width / 2.0);
+  m_bottomRight.set_i(m_center.get_i() + m_height / 2.0);
+  m_bottomRight.set_j(m_center.get_j() + m_width / 2.0);
+  m_topRight.set_i(m_center.get_i() - m_height / 2.0);
+  m_topRight.set_j(m_center.get_j() + m_width / 2.0);
+  return *this;
+}
+
+/** Conversion to vpRect operator.
+ * @param rect Rectangle to copy.
+ */
+vpRectOriented::operator vpRect()
+{
+  if (m_theta != .0)
+    throw(vpException(vpException::badValue, "cannot convert a vpRectOriented with non-zero orientation to a vpRect"));
+  return vpRect(m_topLeft, m_bottomRight);
+}
+
+/** Set the corners of the rectangle.
+ *  @warning This method doesn't check whether the 4 points actually form a rectangle!
+ *  The behaviour is undefined if it is not the case.
+ */
+void vpRectOriented::setPoints(const vpImagePoint topLeft, const vpImagePoint topRight, const vpImagePoint bottomLeft,
+                               const vpImagePoint bottomRight)
+{
+  m_topLeft = topLeft;
+  m_bottomLeft = bottomLeft;
+  m_bottomRight = bottomRight;
+  m_topRight = topRight;
+  m_center.set_i((m_topLeft.get_i() + m_bottomLeft.get_i() + m_bottomRight.get_i() + m_topRight.get_i()) / 4.0);
+  m_center.set_j((m_topLeft.get_j() + m_bottomLeft.get_j() + m_bottomRight.get_j() + m_topRight.get_j()) / 4.0);
+  m_width = sqrt((m_topRight.get_i() - m_topLeft.get_i()) * (m_topRight.get_i() - m_topLeft.get_i()) +
+                 (m_topRight.get_j() - m_topLeft.get_j()) * (m_topRight.get_j() - m_topLeft.get_j()));
+  m_height = sqrt((m_bottomLeft.get_i() - m_topLeft.get_i()) * (m_bottomLeft.get_i() - m_topLeft.get_i()) +
+                  (m_bottomLeft.get_j() - m_topLeft.get_j()) * (m_bottomLeft.get_j() - m_topLeft.get_j()));
+  m_theta = atan2(m_topRight.get_i() - m_topLeft.get_i(), m_topRight.get_j() - m_topLeft.get_j());
+}
+
+/// Set the center of the rectangle.
+void vpRectOriented::setCenter(const vpImagePoint center)
+{
+  m_topLeft += center - m_center;
+  m_bottomLeft += center - m_center;
+  m_bottomRight += center - m_center;
+  m_topRight += center - m_center;
+  m_center = center;
+}
+
+/// Get the rectangle center point.
+vpImagePoint vpRectOriented::getCenter() const { return m_center; }
+
+/// Get the top-left corner.
+vpImagePoint vpRectOriented::getTopLeft() const { return m_topLeft; }
+
+/// Get the top-right corner.
+vpImagePoint vpRectOriented::getTopRight() const { return m_topRight; }
+
+/// Get the bottom-left corner.
+vpImagePoint vpRectOriented::getBottomLeft() const { return m_bottomLeft; }
+
+/// Get the bottom-right corner.
+vpImagePoint vpRectOriented::getBottomRight() const { return m_bottomRight; }
+
+/// Set the size of the rectangle : performs a homothety relatively to the rectangle center.
+void vpRectOriented::setSize(double width, double height)
+{
+  m_width = width;
+  m_height = height;
+  m_topLeft.set_i(m_center.get_i() - m_height * cos(m_theta) / 2.0 - m_width * sin(m_theta) / 2);
+  m_topLeft.set_j(m_center.get_j() + m_height * sin(m_theta) / 2.0 - m_width * cos(m_theta) / 2);
+  m_bottomLeft.set_i(m_center.get_i() + m_height * cos(m_theta) / 2.0 - m_width * sin(m_theta) / 2);
+  m_bottomLeft.set_j(m_center.get_j() - m_height * sin(m_theta) / 2.0 - m_width * cos(m_theta) / 2);
+  m_bottomRight.set_i(m_center.get_i() + m_height * cos(m_theta) / 2.0 + m_width * sin(m_theta) / 2);
+  m_bottomRight.set_j(m_center.get_j() - m_height * sin(m_theta) / 2.0 + m_width * cos(m_theta) / 2);
+  m_topRight.set_i(m_center.get_i() - m_height * cos(m_theta) / 2.0 + m_width * sin(m_theta) / 2);
+  m_topRight.set_j(m_center.get_j() + m_height * sin(m_theta) / 2.0 + m_width * cos(m_theta) / 2);
+}
+
+/// Get the rectangle width.
+double vpRectOriented::getWidth() const { return m_width; }
+
+/// Get the rectangle height.
+double vpRectOriented::getHeight() const { return m_height; }
+
+/// Set the rectangle orientation (rad).
+void vpRectOriented::setOrientation(double theta)
+{
+  m_theta = theta;
+  m_topLeft.set_i(m_center.get_i() - m_height * cos(m_theta) / 2.0 - m_width * sin(m_theta) / 2);
+  m_topLeft.set_j(m_center.get_j() + m_height * sin(m_theta) / 2.0 - m_width * cos(m_theta) / 2);
+  m_bottomLeft.set_i(m_center.get_i() + m_height * cos(m_theta) / 2.0 - m_width * sin(m_theta) / 2);
+  m_bottomLeft.set_j(m_center.get_j() - m_height * sin(m_theta) / 2.0 - m_width * cos(m_theta) / 2);
+  m_bottomRight.set_i(m_center.get_i() + m_height * cos(m_theta) / 2.0 + m_width * sin(m_theta) / 2);
+  m_bottomRight.set_j(m_center.get_j() - m_height * sin(m_theta) / 2.0 + m_width * cos(m_theta) / 2);
+  m_topRight.set_i(m_center.get_i() - m_height * cos(m_theta) / 2.0 + m_width * sin(m_theta) / 2);
+  m_topRight.set_j(m_center.get_j() + m_height * sin(m_theta) / 2.0 + m_width * cos(m_theta) / 2);
+}
+
+/// Get the rectangle orientation (rad).
+double vpRectOriented::getOrientation() const { return m_theta; }
+
+/// Check whether the point is inside the rectangle.
+bool vpRectOriented::isInside(vpImagePoint point) const
+{
+  if (!isLeft(point, m_topLeft, m_bottomLeft))
+    return false;
+  if (!isLeft(point, m_bottomLeft, m_bottomRight))
+    return false;
+  if (!isLeft(point, m_bottomRight, m_topRight))
+    return false;
+  if (!isLeft(point, m_topRight, m_topLeft))
+    return false;
+  return true;
+}
+
+bool vpRectOriented::isLeft(vpImagePoint pointToTest, vpImagePoint point1, vpImagePoint point2) const
+{
+  double a = point1.get_j() - point2.get_j();
+  double b = point2.get_i() - point1.get_i();
+  double c = -(a * point1.get_i() + b * point1.get_j());
+  double d = a * pointToTest.get_i() + b * pointToTest.get_j() + c;
+  return (d > 0);
+}


### PR DESCRIPTION
New class vpRectOriented added: allows to create an oriented recangle (unlike vpRect)
New image tools: mean value, sum of pixels, extraction of oriented rectangular areas, interpolation, correlation
Bug correction:  trying to get min/max values of a vpImage containing no pixels was leading to a segfault