### PR TITLE
Fix m_theta angle comparison (original code is m_theta != .0)

### DIFF
--- a/modules/core/src/tools/geometry/vpRectOriented.cpp
+++ b/modules/core/src/tools/geometry/vpRectOriented.cpp
@@ -127,8 +127,9 @@ vpRectOriented &vpRectOriented::operator=(const vpRect &rect)
  */
 vpRectOriented::operator vpRect()
 {
-  if (std::fabs(m_theta) <= std::numeric_limits<double>::epsilon())
+  if (std::fabs(m_theta) > std::numeric_limits<double>::epsilon())
     throw(vpException(vpException::badValue, "Cannot convert a vpRectOriented with non-zero orientation to a vpRect"));
+
   return vpRect(m_topLeft, m_bottomRight);
 }
 


### PR DESCRIPTION
See:
https://github.com/lagadic/visp/blob/9164bc6e1fbd5b75ce659701c61431081f342324/modules/core/src/tools/geometry/vpRectOriented.cpp#L130