### PR TITLE
Fix realsense2 pointcloud segfault

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -39,6 +39,7 @@ ViSP 3.2.0 (under development)
     . [#302] Fix build issue with librealsense 2.9.1 or higher
     . [#324] How to compile ViSP within Visual Studio 2013 on windows 7?
     . [#348] ViSP-third-party.txt is erased after make
+    . [#355] Segmentation fault with vpRealSense2 acquire
 
 ----------------------------------------------
 ViSP 3.1.0 (released December 22nd, 2017)

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -243,10 +243,7 @@ public:
   //! Set all the elements of the array to \e x.
   vpArray2D<Type> &operator=(Type x)
   {
-    for (unsigned int i = 0; i < rowNum; i++)
-      for (unsigned int j = 0; j < colNum; j++)
-        rowPtrs[i][j] = x;
-
+    std::fill(data, data + dsize, x);
     return *this;
   }
 
@@ -256,7 +253,7 @@ public:
   vpArray2D<Type> &operator=(const vpArray2D<Type> &A)
   {
     resize(A.rowNum, A.colNum, false, false);
-    if (data != NULL && A.data != NULL && rowNum * colNum > 0)
+    if (data != NULL && A.data != NULL && data != A.data)
       memcpy(data, A.data, rowNum * colNum * sizeof(Type));
     return *this;
   }

--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -550,7 +550,9 @@ vpMatrix &vpMatrix::operator=(const vpArray2D<double> &A)
 {
   resize(A.getRows(), A.getCols(), false, false);
 
-  memcpy(data, A.data, dsize * sizeof(double));
+  if (data != NULL && A.data != NULL && data != A.data) {
+    memcpy(data, A.data, dsize * sizeof(double));
+  }
 
   return *this;
 }
@@ -558,9 +560,11 @@ vpMatrix &vpMatrix::operator=(const vpArray2D<double> &A)
 #ifdef VISP_HAVE_CPP11_COMPATIBILITY
 vpMatrix &vpMatrix::operator=(const vpMatrix &A)
 {
-  resize(A.getRows(), A.getCols(), false);
+  resize(A.getRows(), A.getCols(), false, false);
 
-  memcpy(data, A.data, dsize * sizeof(double));
+  if (data != NULL && A.data != NULL && data != A.data) {
+    memcpy(data, A.data, dsize * sizeof(double));
+  }
 
   return *this;
 }
@@ -591,10 +595,7 @@ vpMatrix &vpMatrix::operator=(vpMatrix &&other)
 //! Set all the element of the matrix A to \e x.
 vpMatrix &vpMatrix::operator=(double x)
 {
-  for (unsigned int i = 0; i < rowNum; i++)
-    for (unsigned int j = 0; j < colNum; j++)
-      rowPtrs[i][j] = x;
-
+  std::fill(data, data + rowNum*colNum, x);
   return *this;
 }
 
@@ -3847,7 +3848,7 @@ vpRowVector vpMatrix::getRow(const unsigned int i) const
   vpRowVector r;
   r.resize(colNum, false);
 
-  if (r.data != NULL && data != NULL && colNum > 0) {
+  if (r.data != NULL && data != NULL && r.data != data) {
     memcpy(r.data, data + i * colNum, sizeof(double) * colNum);
   }
 
@@ -4505,7 +4506,7 @@ void vpMatrix::stack(const vpRowVector &r)
     unsigned int oldSize = size();
     resize(rowNum + 1, colNum, false, false);
 
-    if (data != NULL && r.data != NULL && r.size() > 0) {
+    if (data != NULL && r.data != NULL && data != r.data) {
       // Copy r in data
       memcpy(data + oldSize, r.data, sizeof(double) * r.size());
     }
@@ -4545,7 +4546,7 @@ void vpMatrix::stack(const vpColVector &c)
     unsigned int oldColNum = colNum;
     resize(rowNum, colNum + 1, false, false);
 
-    if (data != NULL && tmp.data != NULL && c.size() > 0) {
+    if (data != NULL && tmp.data != NULL && data != tmp.data) {
       // Copy c in data
       for (unsigned int i = 0; i < rowNum; i++) {
         memcpy(data + i*colNum, tmp.data + i*oldColNum, sizeof(double) * oldColNum);
@@ -4568,9 +4569,9 @@ void vpMatrix::stack(const vpColVector &c)
 void vpMatrix::insert(const vpMatrix &A, const unsigned int r, const unsigned int c)
 {
   if ((r + A.getRows()) <= rowNum && (c + A.getCols()) <= colNum) {
-    if (A.colNum == colNum && data != NULL && A.data != NULL && A.size() > 0) {
+    if (A.colNum == colNum && data != NULL && A.data != NULL && A.data != data) {
       memcpy(data + r * colNum, A.data, sizeof(double) * A.size());
-    } else if (data != NULL && A.data != NULL && A.colNum > 0) {
+    } else if (data != NULL && A.data != NULL && A.data != data) {
       for (unsigned int i = r; i < (r + A.getRows()); i++) {
         memcpy(data + i * colNum + c, A.data + (i - r) * A.colNum, sizeof(double) * A.colNum);
       }

--- a/modules/core/test/math/testArray2D.cpp
+++ b/modules/core/test/math/testArray2D.cpp
@@ -69,13 +69,12 @@ template <typename Type> bool test(const std::string &s, const vpArray2D<Type> &
 
 int main()
 {
-  int err = 1;
   {
     // test default constructor
     vpArray2D<double> A;
     std::vector<double> bench;
     if (test("A", A, bench) == false)
-      return err;
+      return EXIT_FAILURE;
   }
   {
     // test copy constructor
@@ -89,11 +88,11 @@ int main()
       }
     }
     if (test("A", A, bench) == false)
-      return err;
+      return EXIT_FAILURE;
 
     vpArray2D<double> B(A);
     if (test("B", B, bench) == false)
-      return err;
+      return EXIT_FAILURE;
     std::cout << "Min/Max: " << B.getMinValue() << " " << B.getMaxValue() << std::endl;
   }
   {
@@ -101,17 +100,17 @@ int main()
     vpArray2D<double> A(3, 4, 2.);
     std::vector<double> bench1(12, 2);
     if (test("A", A, bench1) == false)
-      return err;
+      return EXIT_FAILURE;
 
     A.resize(5, 6);
     std::vector<double> bench2(30, 0);
     if (test("A", A, bench2) == false)
-      return err;
+      return EXIT_FAILURE;
 
     A = -2.;
     std::vector<double> bench3(30, -2);
     if (test("A", A, bench3) == false)
-      return err;
+      return EXIT_FAILURE;
   }
 
   // Test with float
@@ -120,7 +119,7 @@ int main()
     vpArray2D<float> A;
     std::vector<float> bench;
     if (test("A", A, bench) == false)
-      return err;
+      return EXIT_FAILURE;
   }
   {
     // test copy constructor
@@ -134,11 +133,11 @@ int main()
       }
     }
     if (test("A", A, bench) == false)
-      return err;
+      return EXIT_FAILURE;
 
     vpArray2D<float> B(A);
     if (test("B", B, bench) == false)
-      return err;
+      return EXIT_FAILURE;
     std::cout << "Min/Max: " << B.getMinValue() << " " << B.getMaxValue() << std::endl;
   }
   {
@@ -146,17 +145,17 @@ int main()
     vpArray2D<float> A(3, 4, 2.);
     std::vector<float> bench1(12, 2);
     if (test("A", A, bench1) == false)
-      return err;
+      return EXIT_FAILURE;
 
     A.resize(5, 6);
     std::vector<float> bench2(30, 0);
     if (test("A", A, bench2) == false)
-      return err;
+      return EXIT_FAILURE;
 
     A = -2.;
     std::vector<float> bench3(30, -2);
     if (test("A", A, bench3) == false)
-      return err;
+      return EXIT_FAILURE;
   }
   {
     // Test Hadamard product

--- a/modules/core/test/math/testMatrix.cpp
+++ b/modules/core/test/math/testMatrix.cpp
@@ -247,17 +247,35 @@ int main(int argc, char *argv[])
       }
     }
 
-    int err = 1;
+    {
+      const double val = 10.0;
+      vpMatrix M, M2(5, 5, val);
+      M.resize(5, 5, false, false);
+      M = val;
+      for (unsigned int i = 0; i < M.getRows(); i++) {
+        for (unsigned int j = 0; j < M.getCols(); j++) {
+          if (!vpMath::equal(M[i][j], val, std::numeric_limits<double>::epsilon())) {
+            std::cerr << "Issue with matrix assignment with value." << std::endl;
+            return EXIT_FAILURE;
+          }
+
+          if (!vpMath::equal(M2[i][j], val, std::numeric_limits<double>::epsilon())) {
+            std::cerr << "Issue with matrix constructor initialized with value." << std::endl;
+            return EXIT_FAILURE;
+          }
+        }
+      }
+    }
     {
       vpColVector c(6, 1);
       vpRowVector r(6, 1);
       std::vector<double> bench(6, 1);
       vpMatrix M1(c);
       if (test("M1", M1, bench) == false)
-        return err;
+        return EXIT_FAILURE;
       vpMatrix M2(r);
       if (test("M2", M2, bench) == false)
-        return err;
+        return EXIT_FAILURE;
     }
     {
       vpMatrix M(4, 5);
@@ -280,7 +298,7 @@ int main(int argc, char *argv[])
       if (vpMatrix::saveMatrix("matrix.mat", M, false, header.c_str()))
         std::cout << "Matrix saved in matrix.mat file" << std::endl;
       else
-        return err;
+        return EXIT_FAILURE;
 
       // Load matrix in text format
       vpMatrix M1;
@@ -288,43 +306,43 @@ int main(int argc, char *argv[])
       if (vpMatrix::loadMatrix("matrix.mat", M1, false, header_))
         std::cout << "Matrix loaded from matrix.mat file with header \"" << header_ << "\": \n" << M1 << std::endl;
       else
-        return err;
+        return EXIT_FAILURE;
       if (header != std::string(header_)) {
         std::cout << "Bad header in matrix.mat" << std::endl;
-        return err;
+        return EXIT_FAILURE;
       }
 
       // Save matrix in binary format
       if (vpMatrix::saveMatrix("matrix.bin", M, true, header.c_str()))
         std::cout << "Matrix saved in matrix.bin file" << std::endl;
       else
-        return err;
+        return EXIT_FAILURE;
 
       // Load matrix in binary format
       if (vpMatrix::loadMatrix("matrix.bin", M1, true, header_))
         std::cout << "Matrix loaded from matrix.bin file with header \"" << header_ << "\": \n" << M1 << std::endl;
       else
-        return err;
+        return EXIT_FAILURE;
       if (header != std::string(header_)) {
         std::cout << "Bad header in matrix.bin" << std::endl;
-        return err;
+        return EXIT_FAILURE;
       }
 
       // Save matrix in YAML format
       if (vpMatrix::saveMatrixYAML("matrix.yml", M, header.c_str()))
         std::cout << "Matrix saved in matrix.yml file" << std::endl;
       else
-        return err;
+        return EXIT_FAILURE;
 
       // Read matrix in YAML format
       vpMatrix M2;
       if (vpMatrix::loadMatrixYAML("matrix.yml", M2, header_))
         std::cout << "Matrix loaded from matrix.yml file with header \"" << header_ << "\": \n" << M2 << std::endl;
       else
-        return err;
+        return EXIT_FAILURE;
       if (header != std::string(header_)) {
         std::cout << "Bad header in matrix.mat" << std::endl;
-        return err;
+        return EXIT_FAILURE;
       }
     }
 

--- a/modules/sensor/src/rgb-depth/realsense/vpRealSense2.cpp
+++ b/modules/sensor/src/rgb-depth/realsense/vpRealSense2.cpp
@@ -355,12 +355,13 @@ void vpRealSense2::getPointcloud(const rs2::depth_frame &depth_frame, std::vecto
 
   // Multi-threading if OpenMP
   // Concurrent writes at different locations are safe
-#pragma omp parallel for schedule(dynamic)
+  #pragma omp parallel for schedule(dynamic)
   for (int i = 0; i < height; i++) {
     auto depth_pixel_index = i * width;
 
     for (int j = 0; j < width; j++, depth_pixel_index++) {
       if (p_depth_frame[depth_pixel_index] == 0) {
+        pointcloud[(size_t)depth_pixel_index].resize(4, false);
         pointcloud[(size_t)depth_pixel_index][0] = m_invalidDepthValue;
         pointcloud[(size_t)depth_pixel_index][1] = m_invalidDepthValue;
         pointcloud[(size_t)depth_pixel_index][2] = m_invalidDepthValue;
@@ -378,6 +379,7 @@ void vpRealSense2::getPointcloud(const rs2::depth_frame &depth_frame, std::vecto
       if (pixels_distance > m_max_Z)
         points[0] = points[1] = points[2] = m_invalidDepthValue;
 
+      pointcloud[(size_t)depth_pixel_index].resize(4, false);
       pointcloud[(size_t)depth_pixel_index][0] = points[0];
       pointcloud[(size_t)depth_pixel_index][1] = points[1];
       pointcloud[(size_t)depth_pixel_index][2] = points[2];


### PR DESCRIPTION
resolves #355 

Add checks before some `memcpy` (overlapping is not check). Referring to the `memcpy` [doc](http://en.cppreference.com/w/cpp/string/byte/memcpy):

> Copies count bytes from the object pointed to by src to the object pointed to by dest. Both objects are reinterpreted as arrays of unsigned char.
> If the objects overlap, the behavior is undefined.
> If either dest or src is a null pointer, the behavior is undefined, even if count is zero.