### PR TITLE
Discussion: remove rand() call in MBT to make the behaviour deterministic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_script:
 
 script: 
   - make
-  - ctest
+  - ctest --output-on-failure
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -93,6 +93,6 @@ build_script:
   - if "%CMAKE_GENERATOR%"=="MinGW Makefiles" cmake --build . --config %configuration% --target install -- -j2
   - dir C:\projects\visp\build\install
   - dir %VISP_DLL_DIR%
-  - if "%CMAKE_GENERATOR%"=="Visual Studio 14 2015 Win64" ctest
+  - if "%CMAKE_GENERATOR%"=="Visual Studio 14 2015 Win64" ctest --output-on-failure
   # Issue with exception on MinGW AppVeyor
-  - if "%CMAKE_GENERATOR%"=="MinGW Makefiles" ctest -E testMatrixException
+  - if "%CMAKE_GENERATOR%"=="MinGW Makefiles" ctest --output-on-failure -E testMatrixException

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
@@ -189,9 +189,9 @@ void vpMbtDistanceLine::buildFrom(vpPoint &_p1, vpPoint &_p2)
   // if((V1-V2).sumSquare()!=0)
   if (std::fabs((V1 - V2).sumSquare()) > std::numeric_limits<double>::epsilon()) {
     vpColVector V3(3);
-    V3[0] = double(rand() % 1000) / 100;
-    V3[1] = double(rand() % 1000) / 100;
-    V3[2] = double(rand() % 1000) / 100;
+    V3[0] = 3.8300000000000001; //double(rand() % 1000) / 100
+    V3[1] = 8.8599999999999994; //double(rand() % 1000) / 100
+    V3[2] = 7.7699999999999996; //double(rand() % 1000) / 100
 
     vpColVector v_tmp1, v_tmp2;
     v_tmp1 = V2 - V1;


### PR DESCRIPTION
Somehow, I would like to discuss about removing the `rand()` calls in MBT.
Each time I forget about these calls. Recently, I spend some time to debug before realizing that the test failures after #354 (and corresponding threshold update: #363, #364) were not due to an issue in the introduced code but rather that the new projection error feature adds a list of `vpMbtDistanceLine`.

Note: I don't know how to properly "fix" the original code, this is just a suggestion.