### PR TITLE
Change vpColVector and vpRowVector stack(const double &) to stack(double)

### DIFF
--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -262,7 +262,7 @@ public:
     vpArray2D<double>::resize(nrows, ncols, flagNullify);
   }
 
-  void stack(const double &d);
+  void stack(double d);
   void stack(const vpColVector &v);
 
   double sum() const;

--- a/modules/core/include/visp3/core/vpRowVector.h
+++ b/modules/core/include/visp3/core/vpRowVector.h
@@ -235,7 +235,7 @@ public:
     vpArray2D<double>::resize(nrows, ncols, flagNullify);
   }
 
-  void stack(const double &d);
+  void stack(double d);
   void stack(const vpRowVector &v);
 
   double sum() const;

--- a/modules/core/src/math/matrix/vpColVector.cpp
+++ b/modules/core/src/math/matrix/vpColVector.cpp
@@ -898,7 +898,7 @@ vpColVector vpColVector::sort(const vpColVector &v)
   \sa stack(const vpColVector &, const vpColVector &, vpColVector &)
 
 */
-void vpColVector::stack(const double &d)
+void vpColVector::stack(double d)
 {
   this->resize(rowNum + 1, false);
   (*this)[rowNum - 1] = d;

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -673,7 +673,7 @@ void vpRowVector::insert(unsigned int i, const vpRowVector &v)
   \sa stack(const vpRowVector &, const vpRowVector &, vpRowVector &)
 
 */
-void vpRowVector::stack(const double &d)
+void vpRowVector::stack(double d)
 {
   this->resize(colNum + 1, false);
   (*this)[colNum - 1] = d;


### PR DESCRIPTION
I found that the current implementation is not robust to self-stacking :

```
vpColVector d(3);
d[0] = 1; d[1] = 2; d[2] = 3;
d.stack(d[0]); // if you are lucky then d = (1, 2, 3, 1)
```
Passing by value if pretty cheap for a _double_ and solves the problem.
