### PR TITLE
added xml parser for vpRectOriented logging

### DIFF
--- a/modules/core/include/visp3/core/vpXmlParserRectOriented.h
+++ b/modules/core/include/visp3/core/vpXmlParserRectOriented.h
@@ -1,0 +1,101 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2017 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * XML parser to load and save oriented rectangles in a XML file
+ *
+ * Authors:
+ * Marc Pouliquen
+ *
+ *****************************************************************************/
+
+/*!
+  \file vpXmlParserRectOriented.h
+  \brief Declaration of the vpXmlParserRectOriented class.
+  Class vpXmlParserRectOriented allows to load and save oriented rectangles in a file XML
+*/
+
+#ifndef vpXmlParserRectOriented_h
+#define vpXmlParserRectOriented_h
+
+#include <visp3/core/vpConfig.h>
+
+#ifdef VISP_HAVE_XML2
+#include <string>
+#include <visp3/core/vpDebug.h>
+#include <visp3/core/vpRectOriented.h>
+#include <visp3/core/vpXmlParser.h>
+
+/*!
+  \class vpXmlParserRectOriented
+
+  \ingroup group_core_geometry
+
+  \brief XML parser to load and save an oriented rectangle in a file.
+
+  \warning This class is only available if libxml2 is installed and detected by ViSP. Installation instructions are
+  provided herehttps://visp.inria.fr/3rd_xml2.
+*/
+
+class VISP_EXPORT vpXmlParserRectOriented : public vpXmlParser
+{
+
+public:
+  vpXmlParserRectOriented();
+  virtual ~vpXmlParserRectOriented();
+
+  typedef enum {
+    CODE_XML_BAD = -1,
+    CODE_XML_OTHER,
+    CODE_XML_CENTER_I,
+    CODE_XML_CENTER_J,
+    CODE_XML_HEIGHT,
+    CODE_XML_WIDTH,
+    CODE_XML_THETA
+  } vpXmlCodeType;
+
+  typedef enum { SEQUENCE_OK, SEQUENCE_ERROR } vpXmlCodeSequenceType;
+
+  vpRectOriented const getRectangle() { return m_rectangle; }
+  void setRectangle(const vpRectOriented rectangle) { m_rectangle = rectangle; }
+
+private:
+  vpRectOriented m_rectangle;
+  vpImagePoint m_center;
+  double m_height;
+  double m_width;
+  double m_theta;
+
+protected:
+  void readMainClass(xmlDocPtr doc, xmlNodePtr node);
+  void writeMainClass(xmlNodePtr node);
+};
+#endif // VISP_HAVE_XML2
+#endif // vpXmlParserRectOriented_h

--- a/modules/core/include/visp3/core/vpXmlParserRectOriented.h
+++ b/modules/core/include/visp3/core/vpXmlParserRectOriented.h
@@ -60,8 +60,37 @@
 
   \brief XML parser to load and save an oriented rectangle in a file.
 
+  The following example shows how to save an oriented rectangle in an xml file:
+  \code
+#include <visp3/core/vpRectOriented.h>
+#include <visp3/core/vpXmlParserRectOriented.h>
+int main()
+{
+  vpRectOriented rect(vpImagePoint(10, 15), 20, 12, 0.25);
+  vpXmlParserRectOriented parser;
+  parser.setRectangle(rect);
+  std::string filename = "myRectangle.xml";
+  parser.save(filename);
+  return 0;
+}
+  \endcode
+
+  The following example shows how to read an oriented rectangle from an xml file:
+  \code
+#include <visp3/core/vpRectOriented.h>
+#include <visp3/core/vpXmlParserRectOriented.h>
+int main()
+{
+  vpXmlParserRectOriented parser;
+  std::string filename = "myRectangle.xml";
+  parser.parse(filename);
+  vpRectOriented rect = parser.getRectangle();
+  return 0;
+}
+  \endcode
+
   \warning This class is only available if libxml2 is installed and detected by ViSP. Installation instructions are
-  provided herehttps://visp.inria.fr/3rd_xml2.
+  provided here https://visp.inria.fr/3rd_xml2.
 */
 
 class VISP_EXPORT vpXmlParserRectOriented : public vpXmlParser

--- a/modules/core/src/tools/geometry/vpXmlParserRectOriented.cpp
+++ b/modules/core/src/tools/geometry/vpXmlParserRectOriented.cpp
@@ -1,0 +1,114 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2017 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * XML parser to load and save oriented rectangle in a XML file
+ *
+ * Authors:
+ * Marc Pouliquen
+ *
+ *****************************************************************************/
+
+/*!
+  \file vpXmlParserRectOriented.cpp
+  \brief Definition of the vpXmlParserRectOriented class member functions.
+
+*/
+#include <visp3/core/vpXmlParserRectOriented.h>
+#ifdef VISP_HAVE_XML2
+
+/**
+ * Default constructor.
+ */
+vpXmlParserRectOriented::vpXmlParserRectOriented() : m_rectangle(), m_center(), m_height(), m_width(), m_theta()
+{
+  nodeMap["center_i"] = CODE_XML_CENTER_I;
+  nodeMap["center_j"] = CODE_XML_CENTER_J;
+  nodeMap["height"] = CODE_XML_HEIGHT;
+  nodeMap["width"] = CODE_XML_WIDTH;
+  nodeMap["theta"] = CODE_XML_THETA;
+}
+
+/**
+* Destructor.
+*/
+vpXmlParserRectOriented::~vpXmlParserRectOriented() {}
+
+/**
+* Reading method, called by vpXmlParser::parse().
+* @param doc a pointer representing the document
+* @param node : the root node of the document
+*/
+void vpXmlParserRectOriented::readMainClass(xmlDocPtr doc, xmlNodePtr node)
+{
+  for (xmlNodePtr dataNode = node->xmlChildrenNode; dataNode != NULL; dataNode = dataNode->next) {
+    if (dataNode->type == XML_ELEMENT_NODE) {
+      std::map<std::string, int>::iterator iter_data = this->nodeMap.find((char *)dataNode->name);
+      if (iter_data != nodeMap.end()) {
+        switch (iter_data->second) {
+        case CODE_XML_CENTER_I:
+          this->m_center.set_i(xmlReadDoubleChild(doc, dataNode));
+          break;
+        case CODE_XML_CENTER_J:
+          this->m_center.set_j(xmlReadDoubleChild(doc, dataNode));
+          break;
+        case CODE_XML_HEIGHT:
+          this->m_height = xmlReadDoubleChild(doc, dataNode);
+          break;
+        case CODE_XML_WIDTH:
+          this->m_width = xmlReadDoubleChild(doc, dataNode);
+          break;
+        case CODE_XML_THETA:
+          this->m_theta = xmlReadDoubleChild(doc, dataNode);
+          break;
+        default:
+          vpTRACE("unknown tag in readConfigNode : %d, %s", iter_data->second, (iter_data->first).c_str());
+          break;
+        }
+      }
+    }
+  }
+  m_rectangle = vpRectOriented(m_center, m_width, m_height, m_theta);
+}
+
+/**
+* Writing method, called by vpXmlParser::save().
+* @param node : the root node of the document
+*/
+void vpXmlParserRectOriented::writeMainClass(xmlNodePtr node)
+{
+  xmlWriteDoubleChild(node, "center_i", this->m_rectangle.getCenter().get_i());
+  xmlWriteDoubleChild(node, "center_j", this->m_rectangle.getCenter().get_j());
+  xmlWriteDoubleChild(node, "height", this->m_rectangle.getHeight());
+  xmlWriteDoubleChild(node, "width", this->m_rectangle.getWidth());
+  xmlWriteDoubleChild(node, "theta", this->m_rectangle.getOrientation());
+}
+
+#endif // VISP_HAVE_XML2

--- a/modules/core/src/tools/geometry/vpXmlParserRectOriented.cpp
+++ b/modules/core/src/tools/geometry/vpXmlParserRectOriented.cpp
@@ -63,8 +63,8 @@ vpXmlParserRectOriented::~vpXmlParserRectOriented() {}
 
 /**
 * Reading method, called by vpXmlParser::parse().
-* @param doc a pointer representing the document
-* @param node : the root node of the document
+* @param doc : a pointer representing the document.
+* @param node : the root node of the document.
 */
 void vpXmlParserRectOriented::readMainClass(xmlDocPtr doc, xmlNodePtr node)
 {
@@ -100,7 +100,7 @@ void vpXmlParserRectOriented::readMainClass(xmlDocPtr doc, xmlNodePtr node)
 
 /**
 * Writing method, called by vpXmlParser::save().
-* @param node : the root node of the document
+* @param node : the root node of the document.
 */
 void vpXmlParserRectOriented::writeMainClass(xmlNodePtr node)
 {


### PR DESCRIPTION
New class added to save and load vpRectOriented data in xml files.
I use this class to log ground truth position of a ROI in a tracking test of UsTK.