### PR TITLE
added missing vpPolygon include in example mbot-apriltag-2D-half-vs.cpp

### DIFF
--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-2D-half-vs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-2D-half-vs.cpp
@@ -10,6 +10,7 @@
 #include <visp3/visual_features/vpFeaturePoint.h>
 #include <visp3/vs/vpServo.h>
 #include <visp3/robot/vpUnicycle.h>
+#include <visp3/core/vpPolygon.h>
 
 int main(int argc, const char **argv)
 {


### PR DESCRIPTION
When I build ViSP on Lunar machine, I have the following build error:
/visp/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-2D-half-vs.cpp:215:11: error: ‘vpPolygon’ was not declared in this scope
           vpPolygon polygon(detector.getPolygon(0));

To resolve the issue, I just added the vpPolygon.h header file