### PR TITLE
Fix cdash warnings

### DIFF
--- a/modules/core/src/tools/optimization/vpQuadProg.cpp
+++ b/modules/core/src/tools/optimization/vpQuadProg.cpp
@@ -705,4 +705,6 @@ bool vpQuadProg::solveQPi(const vpMatrix &Q, const vpColVector &r,
   }
   return true;
 }
+#else
+void dummy_vpQuadProg(){};
 #endif

--- a/modules/core/test/math/testColVector.cpp
+++ b/modules/core/test/math/testColVector.cpp
@@ -485,7 +485,7 @@ int main()
     std::cout << "** Test conversion to/from std::vector" << std::endl;
     std::vector<double> std_vector(5);
     for (size_t i = 0; i < std_vector.size(); i++) {
-      std_vector[i] = i;
+      std_vector[i] = (double) i;
     }
     vpColVector v(std_vector);
     if (test("v", v, std_vector) == false)

--- a/modules/core/test/math/testRowVector.cpp
+++ b/modules/core/test/math/testRowVector.cpp
@@ -287,7 +287,7 @@ int main()
     std::cout << "** Test conversion to/from std::vector" << std::endl;
     std::vector<double> std_vector(5);
     for (size_t i = 0; i < std_vector.size(); i++) {
-      std_vector[i] = i;
+      std_vector[i] = (double) i;
     }
     vpRowVector v(std_vector);
     if (test("v", v, std_vector) == false)

--- a/modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
@@ -96,7 +96,7 @@ void vpMbtDistanceKltPoints::init(const vpKltOpencv &_tracker, const vpImage<boo
     bool add = false;
 
     // Add points inside visibility mask only
-    if (vpMeTracker::inMask(mask, y_tmp, x_tmp)) {
+    if (vpMeTracker::inMask(mask, (unsigned int) y_tmp, (unsigned int) x_tmp)) {
       if (useScanLine) {
         if ((unsigned int)y_tmp < hiddenface->getMbScanLineRenderer().getPrimitiveIDs().getHeight() &&
           (unsigned int)x_tmp < hiddenface->getMbScanLineRenderer().getPrimitiveIDs().getWidth() &&
@@ -160,7 +160,7 @@ unsigned int vpMbtDistanceKltPoints::computeNbDetectedCurrent(const vpKltOpencv 
 
   for (unsigned int i = 0; i < static_cast<unsigned int>(_tracker.getNbFeatures()); i++) {
     _tracker.getFeature((int)i, id, x, y);
-    if (isTrackedFeature((int)id) && vpMeTracker::inMask(mask, y, x)) {
+    if (isTrackedFeature((int)id) && vpMeTracker::inMask(mask, (unsigned int) y, (unsigned int) x)) {
 #if TARGET_OS_IPHONE
       curPoints[(int)id] = vpImagePoint(static_cast<double>(y), static_cast<double>(x));
       curPointsInd[(int)id] = (int)i;


### PR DESCRIPTION
<details>

> Site: METEOSAT
> Build Name: Windows-amd64-msvc14-Sta-Release-flycap-pylon-gdi-OpenCV3.3.1-lapack-eigen3-xml-OpenMP-zbar-apriltag-sse
> Build Time: 2018-07-18T12:04:07 CEST
> Found 6 Warnings
> Errors are here.
> 
> flag
> Build Log Line	955
> Warning	
>   visp_core.dir\Release\vpMomentAreaNormalized.obj
>   visp_core.dir\Release\vpMomentBasic.obj
>   visp_core.dir\Release\vpMomentCInvariant.obj
>   visp_core.dir\Release\vpMomentCentered.obj
>   visp_core.dir\Release\vpMomentCommon.obj
>   visp_core.dir\Release\vpMomentDatabase.obj
>   visp_core.dir\Release\vpMomentGravityCenter.obj
>   visp_core.dir\Release\vpMomentGravityCenterNormalized.obj
>   visp_core.dir\Release\vpMomentObject.obj
>   visp_core.dir\Release\vpTracker.obj
>  vpQuadProg.obj : warning LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library [C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\visp_core.vcxproj]
>    visp_core.vcxproj -> C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\x64\vc14\staticlib\Release\visp_core320.lib
> FinalizeBuildStatus:
>   Suppression du fichier "visp_core.dir\Release\visp_core.tlog\unsuccessfulbuild".
>   Mise à jour de l'horodatage "visp_core.dir\Release\visp_core.tlog\visp_core.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\visp_core.vcxproj" terminée (cibles par défaut).
> Le projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\ar\visp_ar.vcxproj" (6) génère "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\io\visp_io.vcxproj" (9) sur le noud 1 (cibles par défaut).
> PrepareForBuild:
>   Création du répertoire "visp_io.dir\Release\".
>   Création du répertoire "visp_io.dir\Release\visp_io.tlog\".
> InitializeBuildStatus:
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/modules/core/test/math/testColVector.cpp
> Build Log Line	5067
> Warning	
>   Création du répertoire "testColVector.dir\Release\".
>   Création du répertoire "testColVector.dir\Release\testColVector.tlog\".
> InitializeBuildStatus:
>   Création de "testColVector.dir\Release\testColVector.tlog\unsuccessfulbuild", car "AlwaysCreate" a été spécifié.
> CustomBuild:
>   Building Custom Rule /.../visp-master-code/modules/core/CMakeLists.txt
>   CMake does not need to re-run because /.../12h-00min/modules/core/CMakeFiles/generate.stamp is up-to-date.
> ClCompile:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\CL.exe /c /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\io\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\gui\include" /I"C:\workspace\opencv-3.3.1\build\include" /I"C:\workspace\opencv-3.3.1\build\include\opencv" /I"C:\workspace\eigen-3.3.4\build-vc14\install\include\eigen3" /I"C:\workspace\libxml2-2.9.7\build-vc14\include\libxml2" /I"C:\Program Files (x86)\Visual Leak Detector\include" /nologo /W3 /WX- /MP4 /O2 /Ob2 /D WIN32 /D _WINDOWS /D NDEBUG /D _CRT_SECURE_NO_DEPRECATE /D "CMAKE_INTDIR=\"Release\"" /D _MBCS /Gm- /EHa /MT /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /openmp /Fo"testColVector.dir\Release\\" /Fd"testColVector.dir\Release\vc140.pdb" /Gd /TP /wd4996 /errorReport:queue "C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testColVector.cpp"
>   testColVector.cpp
>  C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testColVector.cpp(488): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testColVector.vcxproj]
>  Link:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\Release\testColVector.exe" /INCREMENTAL:NO /NOLOGO /LIBPATH:"C:\Program Files (x86)\Visual Leak Detector\lib\Win64" ..\..\x64\vc14\staticlib\Release\visp_core320.lib ..\..\x64\vc14\staticlib\Release\visp_io320.lib ..\..\x64\vc14\staticlib\Release\visp_core320.lib ..\..\x64\vc14\staticlib\Release\visp_gui320.lib ..\..\x64\vc14\staticlib\Release\visp_core320.lib winmm.lib ws2_32.lib "C:\workspace\opencv-3.3.1\build\x64\vc14\lib\opencv_world331.lib" "C:\workspace\libxml2-2.9.7\build-vc14\lib\libxml2.lib" ..\..\3rdparty\lib\Release\visp_lapack.lib "C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64\Gdi32.Lib" winmm.lib ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:msvcrt.lib /NODEFAULTLIB:msvcrtd.lib /NODEFAULTLIB:libcmtd.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"/.../12h-00min/modules/core/Release/testColVector.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"/.../12h-00min/modules/core/Release/testColVector.lib" /MACHINE:X64  /machine:x64 testColVector.dir\Release\testColVector.obj
>   testColVector.vcxproj -> C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\Release\testColVector.exe
> FinalizeBuildStatus:
>   Suppression du fichier "testColVector.dir\Release\testColVector.tlog\unsuccessfulbuild".
>   Mise à jour de l'horodatage "testColVector.dir\Release\testColVector.tlog\testColVector.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testColVector.vcxproj" terminée (cibles par défaut).
> Le projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\ALL_BUILD.vcxproj" (1) génère "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\sensor\testComedi.vcxproj" (193) sur le noud 1 (cibles par défaut).
> PrepareForBuild:
>   Création du répertoire "testComedi.dir\Release\".
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/modules/core/test/math/testRowVector.cpp
> Build Log Line	6764
> Warning	
>   Création du répertoire "testRowVector.dir\Release\".
>   Création du répertoire "testRowVector.dir\Release\testRowVector.tlog\".
> InitializeBuildStatus:
>   Création de "testRowVector.dir\Release\testRowVector.tlog\unsuccessfulbuild", car "AlwaysCreate" a été spécifié.
> CustomBuild:
>   Building Custom Rule /.../visp-master-code/modules/core/CMakeLists.txt
>   CMake does not need to re-run because /.../12h-00min/modules/core/CMakeFiles/generate.stamp is up-to-date.
> ClCompile:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\CL.exe /c /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\io\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\gui\include" /I"C:\workspace\opencv-3.3.1\build\include" /I"C:\workspace\opencv-3.3.1\build\include\opencv" /I"C:\workspace\eigen-3.3.4\build-vc14\install\include\eigen3" /I"C:\workspace\libxml2-2.9.7\build-vc14\include\libxml2" /I"C:\Program Files (x86)\Visual Leak Detector\include" /nologo /W3 /WX- /MP4 /O2 /Ob2 /D WIN32 /D _WINDOWS /D NDEBUG /D _CRT_SECURE_NO_DEPRECATE /D "CMAKE_INTDIR=\"Release\"" /D _MBCS /Gm- /EHa /MT /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /openmp /Fo"testRowVector.dir\Release\\" /Fd"testRowVector.dir\Release\vc140.pdb" /Gd /TP /wd4996 /errorReport:queue "C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testRowVector.cpp"
>   testRowVector.cpp
>  C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testRowVector.cpp(290): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testRowVector.vcxproj]
>  Link:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\Release\testRowVector.exe" /INCREMENTAL:NO /NOLOGO /LIBPATH:"C:\Program Files (x86)\Visual Leak Detector\lib\Win64" ..\..\x64\vc14\staticlib\Release\visp_core320.lib ..\..\x64\vc14\staticlib\Release\visp_io320.lib ..\..\x64\vc14\staticlib\Release\visp_core320.lib ..\..\x64\vc14\staticlib\Release\visp_gui320.lib ..\..\x64\vc14\staticlib\Release\visp_core320.lib winmm.lib ws2_32.lib "C:\workspace\opencv-3.3.1\build\x64\vc14\lib\opencv_world331.lib" "C:\workspace\libxml2-2.9.7\build-vc14\lib\libxml2.lib" ..\..\3rdparty\lib\Release\visp_lapack.lib "C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64\Gdi32.Lib" winmm.lib ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /NODEFAULTLIB:atlthunk.lib /NODEFAULTLIB:msvcrt.lib /NODEFAULTLIB:msvcrtd.lib /NODEFAULTLIB:libcmtd.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"/.../12h-00min/modules/core/Release/testRowVector.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"/.../12h-00min/modules/core/Release/testRowVector.lib" /MACHINE:X64  /machine:x64 testRowVector.dir\Release\testRowVector.obj
>   testRowVector.vcxproj -> C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\Release\testRowVector.exe
> FinalizeBuildStatus:
>   Suppression du fichier "testRowVector.dir\Release\testRowVector.tlog\unsuccessfulbuild".
>   Mise à jour de l'horodatage "testRowVector.dir\Release\testRowVector.tlog\testRowVector.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testRowVector.vcxproj" terminée (cibles par défaut).
> Le projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\ALL_BUILD.vcxproj" (1) génère "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testSerialRead.vcxproj" (282) sur le noud 1 (cibles par défaut).
> PrepareForBuild:
>   Création du répertoire "testSerialRead.dir\Release\".
> 
> flag
> Build Log Line	10534
> Warning	
>   Mise à jour de l'horodatage "x64\Release\ALL_BUILD\ALL_BUILD.tlog\ALL_BUILD.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\ALL_BUILD.vcxproj" terminée (cibles par défaut).
> 
> La génération a réussi.
> 
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\ALL_BUILD.vcxproj" (cible par défaut) (1) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\example\ogre-simulator\AROgre.vcxproj" (cible par défaut) (3) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\ar\visp_ar.vcxproj" (cible par défaut) (6) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\visp_core.vcxproj" (cible par défaut) (7) ->
> (Lib cible) -> 
>    vpQuadProg.obj : warning LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library [C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\visp_core.vcxproj]
>  
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\ALL_BUILD.vcxproj" (cible par défaut) (1) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testColVector.vcxproj" (cible par défaut) (192) ->
> (ClCompile cible) -> 
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/C:/Temp/fspindle/soft/Wed-2018-Jul-18/12h-00min/ modules/core/test/math/testColVector.cpp
> Build Log Line	10540
> Warning	
>    C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testColVector.cpp(488): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testColVector.vcxproj]
>  
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\ALL_BUILD.vcxproj" (cible par défaut) (1) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testRowVector.vcxproj" (cible par défaut) (281) ->
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/C:/Temp/fspindle/soft/Wed-2018-Jul-18/12h-00min/ modules/core/test/math/testRowVector.cpp
> Build Log Line	10545
> Warning	
>    C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testRowVector.cpp(290): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\12h-00min\modules\core\testRowVector.vcxproj]
>      3 Avertissement(s)
>     0 Erreur(s)
> 
> Temps écoulé 00:21:19.96

</details>

<details>

> Site: METEOSAT
> Build Name: Windows-amd64-msvc14-Dyn-Release-virtuose-flycap-pylon-gdi-OpenCV3.3.1-lapack-eigen3-xml-OpenMP-zbar-apriltag-sse
> Build Time: 2018-07-18T13:32:24 CEST
> Found 8 Warnings
> Errors are here.
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
> Build Log Line	1417
> Warning	
>   vpMbtMeLine.cpp
>   vpMbtXmlParser.cpp
>   vpMbEdgeKltMultiTracker.cpp
>   vpMbEdgeKltTracker.cpp
>   vpMbtEdgeKltXmlParser.cpp
>   vpMbKltMultiTracker.cpp
>   vpMbKltTracker.cpp
>   vpMbtDistanceKltCylinder.cpp
>   vpMbtDistanceKltPoints.cpp
>   vpMbtKltXmlParser.cpp
>  C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\src\klt\vpMbtDistanceKltPoints.cpp(99): warning C4244: 'argument': conversion from 'float' to 'const unsigned int', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\mbt\visp_mbt.vcxproj]
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
> Build Log Line	1418
> Warning	
>  C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\src\klt\vpMbtDistanceKltPoints.cpp(163): warning C4244: 'argument': conversion from 'float' to 'const unsigned int', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\mbt\visp_mbt.vcxproj]
>    vpMbGenericTracker.cpp
>   vpMbScanLine.cpp
>   vpMbTracker.cpp
>   vpMbXmlParser.cpp
>   vpMbtPolygon.cpp
>   vpMbtXmlGenericParser.cpp
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\CL.exe /c /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\3rdparty\clipper" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\3rdparty\clipper" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\src" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\mbt" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\gui\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\io\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\klt\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\me\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\ar\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\blob\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\visual_features\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\vision\include" /I"C:\workspace\opencv-3.3.1\build\include" /I"C:\workspace\opencv-3.3.1\build\include\opencv" /I"C:\workspace\eigen-3.3.4\build-vc14\install\include\eigen3" /I"C:\workspace\libxml2-2.9.7\build-vc14\include\libxml2" /I"C:\Program Files (x86)\Visual Leak Detector\include" /nologo /W3 /WX- /MP4 /O2 /Ob2 /D WIN32 /D _WINDOWS /D NDEBUG /D visp_EXPORTS /D _CRT_SECURE_NO_DEPRECATE /D "CMAKE_INTDIR=\"Release\"" /D _WINDLL /D _MBCS /Gm- /EHa /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /openmp /Fo"visp_mbt.dir\Release\\" /Fd"visp_mbt.dir\Release\vc140.pdb" /Gd /TP /wd4244 /errorReport:queue "C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\src\depth\vpMbtTukeyEstimator.cpp"
>   vpMbtTukeyEstimator.cpp
> Link:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\x64\vc14\bin\Release\visp_mbt320.dll" /INCREMENTAL:NO /NOLOGO /LIBPATH:"C:\Program Files (x86)\Visual Leak Detector\lib\Win64" ..\..\x64\vc14\lib\Release\visp_gui320.lib ..\..\x64\vc14\lib\Release\visp_klt320.lib ..\..\x64\vc14\lib\Release\visp_ar320.lib ..\..\x64\vc14\lib\Release\visp_vision320.lib winmm.lib ws2_32.lib ..\..\3rdparty\lib\Release\visp_clipper.lib "C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64\Gdi32.Lib" ..\..\x64\vc14\lib\Release\visp_io320.lib ..\..\x64\vc14\lib\Release\visp_visual_features320.lib ..\..\x64\vc14\lib\Release\visp_me320.lib ..\..\x64\vc14\lib\Release\visp_blob320.lib ..\..\x64\vc14\lib\Release\visp_core320.lib "C:\workspace\opencv-3.3.1\build\x64\vc14\lib\opencv_world331.lib" "C:\workspace\libxml2-2.9.7\build-vc14\lib\libxml2.lib" winmm.lib ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /NODEFAULTLIB:libc /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /DEBUG /PDB:"/.../13h-30min/x64/vc14/bin/Release/visp_mbt320.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"/.../13h-30min/x64/vc14/lib/Release/visp_mbt320.lib" /MACHINE:X64  /machine:x64 /DLL visp_mbt.dir\Release\vpMbDepthDenseTracker.obj
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/modules/core/test/math/testColVector.cpp
> Build Log Line	5115
> Warning	
>   Création du répertoire "testColVector.dir\Release\".
>   Création du répertoire "testColVector.dir\Release\testColVector.tlog\".
> InitializeBuildStatus:
>   Création de "testColVector.dir\Release\testColVector.tlog\unsuccessfulbuild", car "AlwaysCreate" a été spécifié.
> CustomBuild:
>   Building Custom Rule /.../visp-master-code/modules/core/CMakeLists.txt
>   CMake does not need to re-run because /.../13h-30min/modules/core/CMakeFiles/generate.stamp is up-to-date.
> ClCompile:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\CL.exe /c /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\io\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\gui\include" /I"C:\workspace\opencv-3.3.1\build\include" /I"C:\workspace\opencv-3.3.1\build\include\opencv" /I"C:\workspace\eigen-3.3.4\build-vc14\install\include\eigen3" /I"C:\workspace\libxml2-2.9.7\build-vc14\include\libxml2" /I"C:\Program Files (x86)\Visual Leak Detector\include" /nologo /W3 /WX- /MP4 /O2 /Ob2 /D WIN32 /D _WINDOWS /D NDEBUG /D _CRT_SECURE_NO_DEPRECATE /D "CMAKE_INTDIR=\"Release\"" /D _MBCS /Gm- /EHa /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /openmp /Fo"testColVector.dir\Release\\" /Fd"testColVector.dir\Release\vc140.pdb" /Gd /TP /errorReport:queue "C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testColVector.cpp"
>   testColVector.cpp
>  C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testColVector.cpp(488): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testColVector.vcxproj]
>  Link:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\Release\testColVector.exe" /INCREMENTAL:NO /NOLOGO /LIBPATH:"C:\Program Files (x86)\Visual Leak Detector\lib\Win64" ..\..\x64\vc14\lib\Release\visp_io320.lib ..\..\x64\vc14\lib\Release\visp_gui320.lib ..\..\x64\vc14\lib\Release\visp_core320.lib winmm.lib ws2_32.lib "C:\workspace\opencv-3.3.1\build\x64\vc14\lib\opencv_world331.lib" "C:\workspace\libxml2-2.9.7\build-vc14\lib\libxml2.lib" "C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64\Gdi32.Lib" winmm.lib ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"/.../13h-30min/modules/core/Release/testColVector.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"/.../13h-30min/modules/core/Release/testColVector.lib" /MACHINE:X64  /machine:x64 testColVector.dir\Release\testColVector.obj
>   testColVector.vcxproj -> C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\Release\testColVector.exe
> FinalizeBuildStatus:
>   Suppression du fichier "testColVector.dir\Release\testColVector.tlog\unsuccessfulbuild".
>   Mise à jour de l'horodatage "testColVector.dir\Release\testColVector.tlog\testColVector.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testColVector.vcxproj" terminée (cibles par défaut).
> Le projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\ALL_BUILD.vcxproj" (1) génère "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\sensor\testComedi.vcxproj" (193) sur le noud 1 (cibles par défaut).
> PrepareForBuild:
>   Création du répertoire "testComedi.dir\Release\".
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/modules/core/test/math/testRowVector.cpp
> Build Log Line	6812
> Warning	
>   Création du répertoire "testRowVector.dir\Release\".
>   Création du répertoire "testRowVector.dir\Release\testRowVector.tlog\".
> InitializeBuildStatus:
>   Création de "testRowVector.dir\Release\testRowVector.tlog\unsuccessfulbuild", car "AlwaysCreate" a été spécifié.
> CustomBuild:
>   Building Custom Rule /.../visp-master-code/modules/core/CMakeLists.txt
>   CMake does not need to re-run because /.../13h-30min/modules/core/CMakeFiles/generate.stamp is up-to-date.
> ClCompile:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\CL.exe /c /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\io\include" /I"C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\gui\include" /I"C:\workspace\opencv-3.3.1\build\include" /I"C:\workspace\opencv-3.3.1\build\include\opencv" /I"C:\workspace\eigen-3.3.4\build-vc14\install\include\eigen3" /I"C:\workspace\libxml2-2.9.7\build-vc14\include\libxml2" /I"C:\Program Files (x86)\Visual Leak Detector\include" /nologo /W3 /WX- /MP4 /O2 /Ob2 /D WIN32 /D _WINDOWS /D NDEBUG /D _CRT_SECURE_NO_DEPRECATE /D "CMAKE_INTDIR=\"Release\"" /D _MBCS /Gm- /EHa /MD /GS /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR /openmp /Fo"testRowVector.dir\Release\\" /Fd"testRowVector.dir\Release\vc140.pdb" /Gd /TP /errorReport:queue "C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testRowVector.cpp"
>   testRowVector.cpp
>  C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testRowVector.cpp(290): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testRowVector.vcxproj]
>  Link:
>   C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\Release\testRowVector.exe" /INCREMENTAL:NO /NOLOGO /LIBPATH:"C:\Program Files (x86)\Visual Leak Detector\lib\Win64" ..\..\x64\vc14\lib\Release\visp_io320.lib ..\..\x64\vc14\lib\Release\visp_gui320.lib ..\..\x64\vc14\lib\Release\visp_core320.lib winmm.lib ws2_32.lib "C:\workspace\opencv-3.3.1\build\x64\vc14\lib\opencv_world331.lib" "C:\workspace\libxml2-2.9.7\build-vc14\lib\libxml2.lib" "C:\Program Files (x86)\Windows Kits\8.1\Lib\winv6.3\um\x64\Gdi32.Lib" winmm.lib ws2_32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTUAC:"level='asInvoker' uiAccess='false'" /manifest:embed /PDB:"/.../13h-30min/modules/core/Release/testRowVector.pdb" /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /IMPLIB:"/.../13h-30min/modules/core/Release/testRowVector.lib" /MACHINE:X64  /machine:x64 testRowVector.dir\Release\testRowVector.obj
>   testRowVector.vcxproj -> C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\Release\testRowVector.exe
> FinalizeBuildStatus:
>   Suppression du fichier "testRowVector.dir\Release\testRowVector.tlog\unsuccessfulbuild".
>   Mise à jour de l'horodatage "testRowVector.dir\Release\testRowVector.tlog\testRowVector.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testRowVector.vcxproj" terminée (cibles par défaut).
> Le projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\ALL_BUILD.vcxproj" (1) génère "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testSerialRead.vcxproj" (282) sur le noud 1 (cibles par défaut).
> PrepareForBuild:
>   Création du répertoire "testSerialRead.dir\Release\".
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/C:/Temp/fspindle/soft/Wed-2018-Jul-18/13h-30min/ modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
> Build Log Line	10581
> Warning	
>   Suppression du fichier "x64\Release\ALL_BUILD\ALL_BUILD.tlog\unsuccessfulbuild".
>   Mise à jour de l'horodatage "x64\Release\ALL_BUILD\ALL_BUILD.tlog\ALL_BUILD.lastbuildstate".
> Génération du projet "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\ALL_BUILD.vcxproj" terminée (cibles par défaut).
> 
> La génération a réussi.
> 
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\ALL_BUILD.vcxproj" (cible par défaut) (1) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\example\ogre-simulator\AROgre.vcxproj" (cible par défaut) (3) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\mbt\visp_mbt.vcxproj" (cible par défaut) (18) ->
> (ClCompile cible) -> 
>    C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\src\klt\vpMbtDistanceKltPoints.cpp(99): warning C4244: 'argument': conversion from 'float' to 'const unsigned int', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\mbt\visp_mbt.vcxproj]
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/C:/Temp/fspindle/soft/Wed-2018-Jul-18/13h-30min/ modules/tracker/mbt/src/klt/vpMbtDistanceKltPoints.cpp
> Build Log Line	10582
> Warning	
>    C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\tracker\mbt\src\klt\vpMbtDistanceKltPoints.cpp(163): warning C4244: 'argument': conversion from 'float' to 'const unsigned int', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\mbt\visp_mbt.vcxproj]
>  
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\ALL_BUILD.vcxproj" (cible par défaut) (1) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testColVector.vcxproj" (cible par défaut) (192) ->
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/C:/Temp/fspindle/soft/Wed-2018-Jul-18/13h-30min/ modules/core/test/math/testColVector.cpp
> Build Log Line	10587
> Warning	
>    C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testColVector.cpp(488): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testColVector.vcxproj]
>  
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\ALL_BUILD.vcxproj" (cible par défaut) (1) ->
> "C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testRowVector.vcxproj" (cible par défaut) (281) ->
> 
> flag
> Repository	https://github.com/lagadic/visp/blob/master/C:/Temp/fspindle/soft/Wed-2018-Jul-18/13h-30min/ modules/core/test/math/testRowVector.cpp
> Build Log Line	10592
> Warning	
>    C:\Temp\fspindle\soft\Wed-2018-Jul-18\visp-master-code\modules\core\test\math\testRowVector.cpp(290): warning C4244: '=': conversion from 'std::size_t' to 'double', possible loss of data [C:\Temp\fspindle\soft\Wed-2018-Jul-18\13h-30min\modules\core\testRowVector.vcxproj]
>      4 Avertissement(s)
>     0 Erreur(s)
> 
> Temps écoulé 00:18:22.35

</details>