### PR TITLE
Simplify parallel RANSAC pose estimation code

### DIFF
--- a/modules/vision/CMakeLists.txt
+++ b/modules/vision/CMakeLists.txt
@@ -55,3 +55,5 @@ else()
     vp_set_source_file_compile_flag(test/key-point/testKeyPoint-4.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual)
  endif()
 endif()
+
+add_test(testKeyPoint-2-multithreaded testKeyPoint-2 -c ${OPTION_TO_DESACTIVE_DISPLAY} -p)

--- a/modules/vision/include/visp3/vision/vpKeyPoint.h
+++ b/modules/vision/include/visp3/vision/vpKeyPoint.h
@@ -961,6 +961,14 @@ public:
   }
 
   /*!
+    Set filter flag for RANSAC pose estimation.
+  */
+  inline void setRansacFilterFlag(const vpPose::RANSAC_FILTER_FLAGS &flag)
+  {
+    m_ransacFilterFlag = flag;
+  }
+
+  /*!
     Set the maximum number of iterations for the Ransac pose estimation
     method.
 
@@ -973,6 +981,27 @@ public:
     } else {
       throw vpException(vpException::badValue, "The number of iterations must be greater than zero.");
     }
+  }
+
+  /*!
+    Use or not the multithreaded version.
+
+    \note Need C++11
+  */
+  inline void setRansacParallel(const bool parallel)
+  {
+    m_ransacParallel = parallel;
+  }
+
+  /*!
+    Set the number of threads to use if multithreaded RANSAC pose.
+
+    \param nthreads : Number of threads, if 0 the number of CPU threads will be determined
+    \sa setRansacParallel
+  */
+  inline void setRansacParallelNbThreads(const unsigned int nthreads)
+  {
+    m_ransacParallelNbThreads = nthreads;
   }
 
   /*!
@@ -1174,10 +1203,16 @@ private:
   //! Percentage value to determine the number of inliers for the Ransac
   //! method.
   double m_ransacConsensusPercentage;
+  //!Filtering flag for RANSAC and degenerate configuration check
+  vpPose::RANSAC_FILTER_FLAGS m_ransacFilterFlag;
   //! List of inliers.
   std::vector<vpImagePoint> m_ransacInliers;
   //! List of outliers.
   std::vector<vpImagePoint> m_ransacOutliers;
+  //! If true, use parallel RANSAC
+  bool m_ransacParallel;
+  //! Number of threads (if 0, try to determine the number of CPU threads)
+  unsigned int m_ransacParallelNbThreads;
   //! Maximum reprojection error (in pixel for the OpenCV method) to decide if
   //! a point is an inlier or not.
   double m_ransacReprojectionError;

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -79,7 +79,7 @@ void vpPose::init()
   ransacInlierIndex.clear();
   ransacThreshold = 0.0001;
   distanceToPlaneForCoplanarityTest = 0.001;
-  ransacFlags = PREFILTER_DUPLICATE_POINTS;
+  ransacFlag = NO_FILTER;
   listOfPoints.clear();
   useParallelRansac = false;
   nbParallelRansacThreads = 0;
@@ -94,9 +94,9 @@ void vpPose::init()
 vpPose::vpPose()
   : npt(0), listP(), residual(0), lambda(0.25), vvsIterMax(200), c3d(), computeCovariance(false), covarianceMatrix(),
     ransacNbInlierConsensus(4), ransacMaxTrials(1000), ransacInliers(), ransacInlierIndex(), ransacThreshold(0.0001),
-    distanceToPlaneForCoplanarityTest(0.001), ransacFlags(PREFILTER_DUPLICATE_POINTS), listOfPoints(),
+    distanceToPlaneForCoplanarityTest(0.001), ransacFlag(vpPose::NO_FILTER), listOfPoints(),
     useParallelRansac(false),
-    nbParallelRansacThreads(0), // 0 means that OpenMP is used to get the number of CPU threads
+    nbParallelRansacThreads(0), // 0 means that we use C++11 (if available) to get the number of threads
     vvsEpsilon(1e-8)
 {
 }

--- a/modules/vision/src/pose-estimation/vpPoseRansac.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseRansac.cpp
@@ -49,7 +49,6 @@
 #include <iostream>
 #include <limits> // numeric_limits
 #include <map>
-#include <stdlib.h>
 
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpMath.h>
@@ -58,83 +57,13 @@
 #include <visp3/vision/vpPoseException.h>
 
 #if defined(VISP_HAVE_CPP11_COMPATIBILITY)
-#include <unordered_map>
-#endif
-
-#if defined(VISP_HAVE_OPENMP)
-#include <omp.h>
+#include <thread>
 #endif
 
 #define eps 1e-6
 
 namespace
 {
-// For std::map<vpPoint>
-struct ComparePointDuplicate {
-  bool operator()(const vpPoint &point1, const vpPoint &point2) const
-  {
-    if (point1.oP[0] < point2.oP[0])
-      return true;
-    if (point1.oP[0] > point2.oP[0])
-      return false;
-
-    if (point1.oP[1] < point2.oP[1])
-      return true;
-    if (point1.oP[1] > point2.oP[1])
-      return false;
-
-    if (point1.oP[2] < point2.oP[2])
-      return true;
-    if (point1.oP[2] > point2.oP[2])
-      return false;
-
-    if (point1.p[0] < point2.p[0])
-      return true;
-    if (point1.p[0] > point2.p[0])
-      return false;
-
-    if (point1.p[1] < point2.p[1])
-      return true;
-    if (point1.p[1] > point2.p[1])
-      return false;
-
-    return false;
-  }
-};
-
-// For std::map<vpPoint>
-struct ComparePointAlmostDuplicate {
-  bool operator()(const vpPoint &point1, const vpPoint &point2) const
-  {
-    if (point1.oP[0] - point2.oP[0] < -eps)
-      return true;
-    if (point1.oP[0] - point2.oP[0] > eps)
-      return false;
-
-    if (point1.oP[1] - point2.oP[1] < -eps)
-      return true;
-    if (point1.oP[1] - point2.oP[1] > eps)
-      return false;
-
-    if (point1.oP[2] - point2.oP[2] < -eps)
-      return true;
-    if (point1.oP[2] - point2.oP[2] > eps)
-      return false;
-
-    if (point1.p[0] - point2.p[0] < -eps)
-      return true;
-    if (point1.p[0] - point2.p[0] > eps)
-      return false;
-
-    if (point1.p[1] - point2.p[1] < -eps)
-      return true;
-    if (point1.p[1] - point2.p[1] > eps)
-      return false;
-
-    return false;
-  }
-};
-
 // For std::map<vpPoint>
 struct CompareObjectPointDegenerate {
   bool operator()(const vpPoint &point1, const vpPoint &point2) const
@@ -189,45 +118,13 @@ struct FindDegeneratePoint {
 
   vpPoint m_pt;
 };
-
-#if defined(VISP_HAVE_CPP11_COMPATIBILITY)
-// For unordered_map<vpPoint>
-struct HashDuplicate {
-  std::size_t operator()(const vpPoint &point) const
-  {
-    using std::size_t;
-    using std::hash;
-
-    size_t res = 17;
-    res = res * 31 + hash<double>()(point.oP[0]);
-    res = res * 31 + hash<double>()(point.oP[1]);
-    res = res * 31 + hash<double>()(point.oP[2]);
-    res = res * 31 + hash<double>()(point.p[0]);
-    res = res * 31 + hash<double>()(point.p[1]);
-
-    return res;
-  }
-};
-
-// For unordered_map<vpPoint>
-struct ComparePointDuplicateUnorderedMap {
-  bool operator()(const vpPoint &point1, const vpPoint &point2) const
-  {
-    return (std::fabs(point1.oP[0] - point2.oP[0]) < std::numeric_limits<double>::epsilon() &&
-            std::fabs(point1.oP[1] - point2.oP[1]) < std::numeric_limits<double>::epsilon() &&
-            std::fabs(point1.oP[2] - point2.oP[2]) < std::numeric_limits<double>::epsilon() &&
-            std::fabs(point1.p[0] - point2.p[0]) < std::numeric_limits<double>::epsilon() &&
-            std::fabs(point1.p[1] - point2.p[1]) < std::numeric_limits<double>::epsilon());
-  }
-};
-#endif
 }
 
 bool vpPose::RansacFunctor::poseRansacImpl()
 {
-  unsigned int size = (unsigned int)m_listOfUniquePoints.size();
+  const unsigned int size = (unsigned int)m_listOfUniquePoints.size();
+  const unsigned int nbMinRandom = 4;
   int nbTrials = 0;
-  unsigned int nbMinRandom = 4;
 
 #if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
   srand(m_initial_seed);
@@ -236,7 +133,7 @@ bool vpPose::RansacFunctor::poseRansacImpl()
   vpPoint p; // Point used to project using the estimated pose
 
   bool foundSolution = false;
-  while (nbTrials < m_ransacMaxTrials && m_nbInliers < (unsigned int)m_ransacNbInlierConsensus) {
+  while (nbTrials < m_ransacMaxTrials && m_nbInliers < m_ransacNbInlierConsensus) {
     // Hold the list of the index of the inliers (points in the consensus set)
     std::vector<unsigned int> cur_consensus;
     // Hold the list of the index of the outliers
@@ -261,8 +158,7 @@ bool vpPose::RansacFunctor::poseRansacImpl()
     vpPose poseMin;
     for (unsigned int i = 0; i < nbMinRandom;) {
       if ((size_t)std::count(usedPt.begin(), usedPt.end(), true) == usedPt.size()) {
-        // All points was picked once, break otherwise we stay in an infinite
-        // loop
+        // All points was picked once, break otherwise we stay in an infinite loop
         break;
       }
 
@@ -318,15 +214,13 @@ bool vpPose::RansacFunctor::poseRansacImpl()
       poseMin.computePose(vpPose::LAGRANGE, cMo_lagrange);
       r_lagrange = poseMin.computeResidual(cMo_lagrange);
       is_valid_lagrange = true;
-    } catch (...) {
-    }
+    } catch (...) { }
 
     try {
       poseMin.computePose(vpPose::DEMENTHON, cMo_dementhon);
       r_dementhon = poseMin.computeResidual(cMo_dementhon);
       is_valid_dementhon = true;
-    } catch (...) {
-    }
+    } catch (...) { }
 
     // If residual returned is not a number (NAN), set valid to false
     if (vpMath::isNaN(r_lagrange)) {
@@ -373,8 +267,7 @@ bool vpPose::RansacFunctor::poseRansacImpl()
           p.setWorldCoordinates(it->get_oX(), it->get_oY(), it->get_oZ());
           p.track(m_cMo);
 
-          double d = vpMath::sqr(p.get_x() - it->get_x()) + vpMath::sqr(p.get_y() - it->get_y());
-          double error = sqrt(d);
+          double error = sqrt(vpMath::sqr(p.get_x() - it->get_x()) + vpMath::sqr(p.get_y() - it->get_y()));
           if (error < m_ransacThreshold) {
             bool degenerate = false;
             if (m_checkDegeneratePoints) {
@@ -416,17 +309,13 @@ bool vpPose::RansacFunctor::poseRansacImpl()
     }
   }
 
+#ifdef VISP_HAVE_CPP11_COMPATIBILITY
+  if (m_nbInliers >= m_ransacNbInlierConsensus)
+    m_abort = true;
+#endif
+
   return foundSolution;
 }
-
-#if defined(VISP_HAVE_PTHREAD) || (defined(_WIN32) && !defined(WINRT_8_0))
-vpThread::Return vpPose::poseRansacImplThread(vpThread::Args arg)
-{
-  vpPose::RansacFunctor *f = reinterpret_cast<vpPose::RansacFunctor *>(arg);
-  (*f)();
-  return 0;
-}
-#endif
 
 /*!
   Compute the pose using the Ransac approach.
@@ -434,8 +323,12 @@ vpThread::Return vpPose::poseRansacImplThread(vpThread::Args arg)
   \param cMo : Computed pose
   \param func : Pointer to a function that takes in parameter a
   vpHomogeneousMatrix and returns true if the pose check is OK or false
-  otherwise \return True if we found at least 4 points with a reprojection
+  otherwise
+  \return True if we found at least 4 points with a reprojection
   error below ransacThreshold.
+  \note You can enable a multithreaded version if you have C++11 enabled using \e setUseParallelRansac
+  The number of threads used can then be set with \e setNbParallelRansacThreads
+  Filter flag can be used  with \e setRansacFilterFlag
 */
 bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatrix *))
 {
@@ -455,7 +348,6 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
   vpHomogeneousMatrix cMo_lagrange, cMo_dementhon;
 
   if (listOfPoints.size() < 4) {
-    // vpERROR_TRACE("Not enough point to compute the pose");
     throw(vpPoseException(vpPoseException::notInitializedError, "Not enough point to compute the pose"));
   }
 
@@ -463,71 +355,28 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
   std::map<size_t, size_t> mapOfUniquePointIndex;
 
   // Get RANSAC flags
-  bool prefilterDuplicatePoints = (ransacFlags & PREFILTER_DUPLICATE_POINTS) != 0;
-  bool prefilterAlmostDuplicatePoints = (ransacFlags & PREFILTER_ALMOST_DUPLICATE_POINTS) != 0;
-  bool prefilterDegeneratePoints = (ransacFlags & PREFILTER_DEGENERATE_POINTS) != 0;
-  bool checkDegeneratePoints = (ransacFlags & CHECK_DEGENERATE_POINTS) != 0;
+  bool prefilterDegeneratePoints = ransacFlag == PREFILTER_DEGENERATE_POINTS;
+  bool checkDegeneratePoints = ransacFlag == CHECK_DEGENERATE_POINTS;
 
-  if (prefilterDuplicatePoints || prefilterAlmostDuplicatePoints || prefilterDegeneratePoints) {
-    // Prefiltering
-    if (prefilterDuplicatePoints) {
-#if defined(VISP_HAVE_CPP11_COMPATIBILITY)
-      std::unordered_map<vpPoint, size_t, HashDuplicate, ComparePointDuplicateUnorderedMap> filterMap;
-      size_t index_pt = 0;
-      for (std::vector<vpPoint>::const_iterator it_pt = listOfPoints.begin(); it_pt != listOfPoints.end();
-           ++it_pt, index_pt++) {
-        if (filterMap.find(*it_pt) == filterMap.end()) {
-          filterMap[*it_pt] = index_pt;
-
-          listOfUniquePoints.push_back(*it_pt);
-          mapOfUniquePointIndex[listOfUniquePoints.size() - 1] = index_pt;
-        }
+  if (prefilterDegeneratePoints) {
+    // Remove degenerate object points
+    std::map<vpPoint, size_t, CompareObjectPointDegenerate> filterObjectPointMap;
+    size_t index_pt = 0;
+    for (std::vector<vpPoint>::const_iterator it_pt = listOfPoints.begin(); it_pt != listOfPoints.end();
+         ++it_pt, index_pt++) {
+      if (filterObjectPointMap.find(*it_pt) == filterObjectPointMap.end()) {
+        filterObjectPointMap[*it_pt] = index_pt;
       }
-#else
-      std::map<vpPoint, size_t, ComparePointDuplicate> filterMap;
-      size_t index_pt = 0;
-      for (std::vector<vpPoint>::const_iterator it_pt = listOfPoints.begin(); it_pt != listOfPoints.end();
-           ++it_pt, index_pt++) {
-        if (filterMap.find(*it_pt) == filterMap.end()) {
-          filterMap[*it_pt] = index_pt;
+    }
 
-          listOfUniquePoints.push_back(*it_pt);
-          mapOfUniquePointIndex[listOfUniquePoints.size() - 1] = index_pt;
-        }
-      }
-#endif
-    } else if (prefilterAlmostDuplicatePoints) {
-      std::map<vpPoint, size_t, ComparePointAlmostDuplicate> filterMap;
-      size_t index_pt = 0;
-      for (std::vector<vpPoint>::const_iterator it_pt = listOfPoints.begin(); it_pt != listOfPoints.end();
-           ++it_pt, index_pt++) {
-        if (filterMap.find(*it_pt) == filterMap.end()) {
-          filterMap[*it_pt] = index_pt;
+    std::map<vpPoint, size_t, CompareImagePointDegenerate> filterImagePointMap;
+    for (std::map<vpPoint, size_t, CompareObjectPointDegenerate>::const_iterator it = filterObjectPointMap.begin();
+         it != filterObjectPointMap.end(); ++it) {
+      if (filterImagePointMap.find(it->first) == filterImagePointMap.end()) {
+        filterImagePointMap[it->first] = it->second;
 
-          listOfUniquePoints.push_back(*it_pt);
-          mapOfUniquePointIndex[listOfUniquePoints.size() - 1] = index_pt;
-        }
-      }
-    } else {
-      // Remove other degenerate object points
-      std::map<vpPoint, size_t, CompareObjectPointDegenerate> filterObjectPointMap;
-      size_t index_pt = 0;
-      for (std::vector<vpPoint>::const_iterator it_pt = listOfPoints.begin(); it_pt != listOfPoints.end();
-           ++it_pt, index_pt++) {
-        if (filterObjectPointMap.find(*it_pt) == filterObjectPointMap.end()) {
-          filterObjectPointMap[*it_pt] = index_pt;
-        }
-      }
-
-      std::map<vpPoint, size_t, CompareImagePointDegenerate> filterImagePointMap;
-      for (std::map<vpPoint, size_t, CompareObjectPointDegenerate>::const_iterator it = filterObjectPointMap.begin();
-           it != filterObjectPointMap.end(); ++it) {
-        if (filterImagePointMap.find(it->first) == filterImagePointMap.end()) {
-          filterImagePointMap[it->first] = it->second;
-
-          listOfUniquePoints.push_back(it->first);
-          mapOfUniquePointIndex[listOfUniquePoints.size() - 1] = it->second;
-        }
+        listOfUniquePoints.push_back(it->first);
+        mapOfUniquePointIndex[listOfUniquePoints.size() - 1] = it->second;
       }
     }
   } else {
@@ -541,44 +390,22 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
     }
   }
 
-  unsigned int size = (unsigned int)listOfUniquePoints.size();
-  if (size < 4) {
+  if (listOfUniquePoints.size() < 4) {
     throw(vpPoseException(vpPoseException::notInitializedError, "Not enough point to compute the pose"));
   }
 
   bool executeParallelVersion = useParallelRansac;
-
-#if defined(VISP_HAVE_PTHREAD) || (defined(_WIN32) && !defined(WINRT_8_0))
-#define VP_THREAD_OK
-  int nbThreads = 1;
+#ifdef VISP_HAVE_CPP11_COMPATIBILITY
+  unsigned int nbThreads = 1;
+#else
+  executeParallelVersion = false;
 #endif
 
   if (executeParallelVersion) {
-#if !defined(VP_THREAD_OK) && !defined(VISP_HAVE_OPENMP)
-    executeParallelVersion = false;
-    std::cerr << "Pthread or WIN32 API or OpenMP is needed to use the "
-                 "parallel RANSAC version."
-              << std::endl;
-#elif !defined(VP_THREAD_OK)
-// Use OpenMP
-#define PARALLEL_RANSAC_OPEN_MP
-#elif !defined(VISP_HAVE_OPENMP)
+#ifdef VISP_HAVE_CPP11_COMPATIBILITY
     if (nbParallelRansacThreads <= 0) {
-      // Cannot get the number of CPU threads so use the sequential mode
-      executeParallelVersion = false;
-      std::cerr << "OpenMP is needed to get the number of CPU threads so use "
-                   "the sequential mode instead."
-                << std::endl;
-    } else {
-      nbThreads = nbParallelRansacThreads;
-      if (nbThreads == 1) {
-        executeParallelVersion = false;
-      }
-    }
-#elif defined(VP_THREAD_OK) && defined(VISP_HAVE_OPENMP)
-    if (nbParallelRansacThreads <= 0) {
-      // Use OpenMP to get the number of CPU threads
-      nbThreads = omp_get_max_threads();
+      // Get number of CPU threads
+      nbThreads = std::thread::hardware_concurrency();
       if (nbThreads <= 1) {
         nbThreads = 1;
         executeParallelVersion = false;
@@ -590,257 +417,43 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
   bool foundSolution = false;
 
   if (executeParallelVersion) {
-#if defined(PARALLEL_RANSAC_OPEN_MP)
-// List of points picked randomly (minimal sample set, MSS)
-// std::vector<unsigned int> best_randoms; // never used
+#ifdef VISP_HAVE_CPP11_COMPATIBILITY
+    std::vector<std::thread> threadpool;
+    std::vector<RansacFunctor> ransacWorkers;
+    const unsigned int nthreads = std::thread::hardware_concurrency();
 
-// Section of code run in parallel
-// All variables declared before the parallel keyword are shared between the
-// team of threads (if private keyword is not used)  Code in parallel section
-// are duplicated between the team of threads
-#pragma omp parallel
-    {
-#if defined(VISP_HAVE_OPENMP)
-      // Set different seeds for each thread in the team, rand() is not thread
-      // safe
-      unsigned int initial_seed = (unsigned int)omp_get_thread_num(); // same seed each time
-      //(unsigned int) (int(time(NULL)) ^ omp_get_thread_num());
-      if (omp_get_num_threads() == 1) {
-        initial_seed = 0; // Same seed at each run
-      }
-#else
-      unsigned int initial_seed = 0;
-#endif
-
-#if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
-      srand(initial_seed);
-#endif
-
-      unsigned int nbMinRandom = 4;
-
-      // Numbers of points in the best consensus set
-      unsigned int nb_best_inliers = 0;
-
-      // True if we found a consensus set with a size >
-      // ransacNbInlierConsensus
-      bool foundSolutionWithConsensus = false;
-
-      vpPoint p; // Point used to project using the estimated pose
-
-#pragma omp for
-      for (int nbTrials = 0; nbTrials < ransacMaxTrials; nbTrials++) {
-        // Flag to check if a solution has been founded, used to "cancel" the
-        // threads
-        if (!foundSolutionWithConsensus) {
-          // Hold the list of the index of the inliers (points in the
-          // consensus set)
-          std::vector<unsigned int> cur_consensus;
-          // Hold the list of the index of the outliers
-          std::vector<unsigned int> cur_outliers;
-          // Hold the list of the index of the points randomly picked
-          std::vector<unsigned int> cur_randoms;
-          // Hold the list of the current inliers points to avoid to add a
-          // degenerate point if the flag is set
-          std::vector<vpPoint> cur_inliers;
-
-          vpHomogeneousMatrix cMo_lagrange, cMo_dementhon;
-          vpHomogeneousMatrix cMo_tmp;
-
-          // Vector of used points, initialized at false for all points
-          std::vector<bool> usedPt(size, false);
-
-          vpPose poseMin;
-
-          for (unsigned int i = 0; i < nbMinRandom;) {
-            if ((size_t)std::count(usedPt.begin(), usedPt.end(), true) == usedPt.size()) {
-              // All points was picked once, break otherwise we stay in an
-              // infinite loop
-              break;
-            }
-
-// Pick a point randomly
-#if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
-            unsigned int r_ = (unsigned int)rand() % size;
-#else
-            unsigned int r_ = (unsigned int)rand_r(&initial_seed) % size;
-#endif
-
-            while (usedPt[r_]) {
-// If already picked, pick another point randomly
-#if defined(_WIN32) && (defined(_MSC_VER) || defined(__MINGW32__))
-              r_ = (unsigned int)rand() % size;
-#else
-              r_ = (unsigned int)rand_r(&initial_seed) % size;
-#endif
-            }
-            // Mark this point as already picked
-            usedPt[r_] = true;
-            vpPoint pt = listOfUniquePoints[r_];
-
-            bool degenerate = false;
-            if (checkDegeneratePoints) {
-              if (std::find_if(poseMin.listOfPoints.begin(), poseMin.listOfPoints.end(), FindDegeneratePoint(pt)) !=
-                  poseMin.listOfPoints.end()) {
-                degenerate = true;
-              }
-            }
-
-            if (!degenerate) {
-              poseMin.addPoint(pt);
-              cur_randoms.push_back(r_);
-              // Increment the number of points picked
-              i++;
-            }
-          }
-
-          if (poseMin.npt >= nbMinRandom) {
-            // Flags set if pose computation is OK
-            bool is_valid_lagrange = false;
-            bool is_valid_dementhon = false;
-
-            // Set maximum value for residuals
-            double r = DBL_MAX;
-            double r_lagrange = DBL_MAX;
-            double r_dementhon = DBL_MAX;
-
-            try {
-              poseMin.computePose(vpPose::LAGRANGE, cMo_lagrange);
-              r_lagrange = poseMin.computeResidual(cMo_lagrange);
-              is_valid_lagrange = true;
-            } catch (...) {
-            }
-
-            try {
-              poseMin.computePose(vpPose::DEMENTHON, cMo_dementhon);
-              r_dementhon = poseMin.computeResidual(cMo_dementhon);
-              is_valid_dementhon = true;
-            } catch (...) {
-            }
-
-            // If residual returned is not a number (NAN), set valid to false
-            if (vpMath::isNaN(r_lagrange)) {
-              is_valid_lagrange = false;
-              r_lagrange = DBL_MAX;
-            }
-
-            if (vpMath::isNaN(r_dementhon)) {
-              is_valid_dementhon = false;
-              r_dementhon = DBL_MAX;
-            }
-
-            // If at least one pose computation is OK,
-            // we can continue, otherwise pick another random set
-            if (is_valid_lagrange || is_valid_dementhon) {
-              if (r_lagrange < r_dementhon) {
-                r = r_lagrange;
-                cMo_tmp = cMo_lagrange;
-              } else {
-                r = r_dementhon;
-                cMo_tmp = cMo_dementhon;
-              }
-              r = sqrt(r) / (double)nbMinRandom;
-
-              // Filter the pose using some criterion (orientation angles,
-              // translations, etc.)
-              bool isPoseValid = true;
-              if (func != NULL) {
-                isPoseValid = func(&cMo_tmp);
-              }
-
-              if (isPoseValid && r < ransacThreshold) {
-                unsigned int nbInliersCur = 0;
-                unsigned int iter = 0;
-                for (std::vector<vpPoint>::const_iterator it = listOfUniquePoints.begin();
-                     it != listOfUniquePoints.end(); ++it, iter++) {
-                  p.setWorldCoordinates(it->get_oX(), it->get_oY(), it->get_oZ());
-                  p.track(cMo_tmp);
-
-                  double d = vpMath::sqr(p.get_x() - it->get_x()) + vpMath::sqr(p.get_y() - it->get_y());
-                  double error = sqrt(d);
-                  if (error < ransacThreshold) {
-                    bool degenerate = false;
-                    if (checkDegeneratePoints) {
-                      if (std::find_if(cur_inliers.begin(), cur_inliers.end(), FindDegeneratePoint(*it)) !=
-                          cur_inliers.end()) {
-                        degenerate = true;
-                      }
-                    }
-
-                    if (!degenerate) {
-                      // the point is considered as inlier if the error is
-                      // below the threshold
-                      nbInliersCur++;
-                      cur_consensus.push_back(iter);
-                      cur_inliers.push_back(*it);
-                    } else {
-                      cur_outliers.push_back(iter);
-                    }
-                  } else {
-                    cur_outliers.push_back(iter);
-                  }
-                }
-
-#pragma omp critical(update_best_consensus_set)
-                {
-                  if (nbInliersCur > nb_best_inliers) {
-                    foundSolution = true;
-                    best_consensus = cur_consensus;
-                    // best_randoms = cur_randoms; // never used
-                    nb_best_inliers = nbInliersCur;
-
-                    if (nbInliersCur >= ransacNbInlierConsensus) {
-                      foundSolutionWithConsensus = true;
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      nbInliers = best_consensus.size();
-    }
-#elif defined(VP_THREAD_OK)
-    std::vector<vpThread *> threads((size_t)nbThreads);
-    std::vector<RansacFunctor> ransac_func((size_t)nbThreads);
-
-    int splitTrials = ransacMaxTrials / nbThreads;
-    for (size_t i = 0; i < (size_t)nbThreads; i++) {
+    int splitTrials = ransacMaxTrials / nthreads;
+    std::atomic<bool> abort{false};
+    for (size_t i = 0; i < (size_t)nthreads; i++) {
       unsigned int initial_seed = (unsigned int)i; //((unsigned int) time(NULL) ^ i);
-      if (i < (size_t)nbThreads - 1) {
-        ransac_func[i] = RansacFunctor(cMo, ransacNbInlierConsensus, splitTrials, ransacThreshold, initial_seed,
-                                       checkDegeneratePoints, listOfUniquePoints, func);
+      if (i < (size_t)nthreads - 1) {
+        ransacWorkers.emplace_back(cMo, ransacNbInlierConsensus, splitTrials, ransacThreshold, initial_seed,
+                                   checkDegeneratePoints, listOfUniquePoints, func, abort);
       } else {
         int maxTrialsRemainder = ransacMaxTrials - splitTrials * (nbThreads - 1);
-        ransac_func[i] = RansacFunctor(cMo, ransacNbInlierConsensus, maxTrialsRemainder, ransacThreshold, initial_seed,
-                                       checkDegeneratePoints, listOfUniquePoints, func);
+        ransacWorkers.emplace_back(cMo, ransacNbInlierConsensus, maxTrialsRemainder, ransacThreshold, initial_seed,
+                                   checkDegeneratePoints, listOfUniquePoints, func, abort);
       }
-
-      threads[(size_t)i] = new vpThread((vpThread::Fn)poseRansacImplThread, (vpThread::Args)&ransac_func[i]);
     }
 
-    // Get the best pose between the threads
-    vpPose final_pose;
-    for (std::vector<vpPoint>::const_iterator it = listOfPoints.begin(); it != listOfPoints.end(); ++it) {
-      final_pose.addPoint(*it);
+    for (auto& worker : ransacWorkers) {
+      threadpool.emplace_back(&RansacFunctor::operator(), &worker);
     }
 
-    for (size_t i = 0; i < (size_t)nbThreads; i++) {
-      threads[i]->join();
-      delete threads[i];
+    for (auto& th : threadpool) {
+      th.join();
     }
 
     bool successRansac = false;
     size_t best_consensus_size = 0;
-    for (size_t i = 0; i < (size_t)nbThreads; i++) {
-      if (ransac_func[i].getResult()) {
+    for (auto &worker : ransacWorkers) {
+      if (worker.getResult()) {
         successRansac = true;
 
-        if (ransac_func[i].getBestConsensus().size() > best_consensus_size) {
-          nbInliers = ransac_func[i].getNbInliers();
-          best_consensus = ransac_func[i].getBestConsensus();
-          best_consensus_size = ransac_func[i].getBestConsensus().size();
+        if (worker.getBestConsensus().size() > best_consensus_size) {
+          nbInliers = worker.getNbInliers();
+          best_consensus = worker.getBestConsensus();
+          best_consensus_size = worker.getBestConsensus().size();
         }
       }
     }
@@ -849,8 +462,15 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
 #endif
   } else {
     // Sequential RANSAC
+#ifdef VISP_HAVE_CPP11_COMPATIBILITY
+    std::atomic<bool> abort{false};
+#endif
     RansacFunctor sequentialRansac(cMo, ransacNbInlierConsensus, ransacMaxTrials, ransacThreshold, 0,
-                                   checkDegeneratePoints, listOfUniquePoints, func);
+                                   checkDegeneratePoints, listOfUniquePoints, func
+                               #ifdef VISP_HAVE_CPP11_COMPATIBILITY
+                                   , abort
+                               #endif
+                                   );
     sequentialRansac();
     foundSolution = sequentialRansac.getResult();
 
@@ -861,7 +481,7 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
   }
 
   if (foundSolution) {
-    unsigned int nbMinRandom = 4;
+    const unsigned int nbMinRandom = 4;
     //    std::cout << "Nombre d'inliers " << nbInliers << std::endl ;
 
     // Display the random picked points
@@ -915,15 +535,13 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
         pose.computePose(vpPose::LAGRANGE, cMo_lagrange);
         r_lagrange = pose.computeResidual(cMo_lagrange);
         is_valid_lagrange = true;
-      } catch (...) {
-      }
+      } catch (...) { }
 
       try {
         pose.computePose(vpPose::DEMENTHON, cMo_dementhon);
         r_dementhon = pose.computeResidual(cMo_dementhon);
         is_valid_dementhon = true;
-      } catch (...) {
-      }
+      } catch (...) { }
 
       // If residual returned is not a number (NAN), set valid to false
       if (vpMath::isNaN(r_lagrange)) {
@@ -968,14 +586,17 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
 /*!
   Compute the number of RANSAC iterations to ensure with a probability \e p
   that at least one of the random samples of \e s points is free from
-  outliers. \note See: Hartley and Zisserman, Multiple View Geometry in
+  outliers.
+  \note See: Hartley and Zisserman, Multiple View Geometry in
   Computer Vision, p119 (2. How many samples?).
 
   \param probability : Probability that at least one of the random samples is
-  free from outliers (typically p=0.99). \param epsilon : Probability that a
-  selected point is an outlier (between 0 and 1). \param sampleSize : Minimum
-  number of points to estimate the model (4 for a pose estimation). \param
-  maxIterations : Upper bound on the number of iterations or -1 for INT_MAX.
+  free from outliers (typically p=0.99).
+  \param epsilon : Probability that a
+  selected point is an outlier (between 0 and 1).
+  \param sampleSize : Minimum
+  number of points to estimate the model (4 for a pose estimation).
+  \param maxIterations : Upper bound on the number of iterations or -1 for INT_MAX.
   \return The number of RANSAC iterations to ensure with a probability \e p
   that at least one of the random samples of \e s points is free from outliers
   or \p maxIterations if it exceeds the desired upper bound or \e INT_MAX if
@@ -1033,19 +654,25 @@ int vpPose::computeRansacIterations(double probability, double epsilon, const in
   \param p2D : Vector of 2d points (x and y attributes are used).
   \param p3D : Vector of 3d points (oX, oY and oZ attributes are used).
   \param numberOfInlierToReachAConsensus : The minimum number of inlier to
-  have to consider a trial as correct. \param threshold : The maximum error
+  have to consider a trial as correct.
+  \param threshold : The maximum error
   allowed between the 2d points and the reprojection of its associated 3d
-  points by the current pose (in meter). \param ninliers : Number of inliers
-  found for the best solution. \param listInliers : Vector of points (2d and
-  3d) that are inliers for the best solution. \param cMo : The computed pose
-  (best solution). \param maxNbTrials : Maximum number of trials before
+  points by the current pose (in meter).
+  \param ninliers : Number of inliers found for the best solution.
+  \param listInliers : Vector of points (2d and
+  3d) that are inliers for the best solution.
+  \param cMo : The computed pose (best solution).
+  \param maxNbTrials : Maximum number of trials before
   considering a solution fitting the required \e
   numberOfInlierToReachAConsensus and \e threshold cannot be found.
+  \param useParallelRansac : If true, use parallel RANSAC version (if C++11 is available).
+  \param nthreads : Number of threads to use, if 0 the number of CPU threads will be determined.
 */
 void vpPose::findMatch(std::vector<vpPoint> &p2D, std::vector<vpPoint> &p3D,
                        const unsigned int &numberOfInlierToReachAConsensus, const double &threshold,
                        unsigned int &ninliers, std::vector<vpPoint> &listInliers, vpHomogeneousMatrix &cMo,
-                       const int &maxNbTrials)
+                       const int &maxNbTrials,
+                       const bool useParallelRansac, const unsigned int nthreads)
 {
   vpPose pose;
 
@@ -1067,6 +694,10 @@ void vpPose::findMatch(std::vector<vpPoint> &p2D, std::vector<vpPoint> &p3D,
     throw(vpPoseException(vpPoseException::notEnoughPointError, "Not enough point (%d) to compute the pose by ransac",
                           pose.listP.size()));
   } else {
+    pose.setUseParallelRansac(useParallelRansac);
+    pose.setNbParallelRansacThreads(nthreads);
+    //Since we add duplicate points, we need to check for degenerate configuration
+    pose.setRansacFilterFlag(vpPose::CHECK_DEGENERATE_POINTS);
     pose.setRansacMaxTrials(maxNbTrials);
     pose.setRansacNbInliersToReachConsensus(numberOfInlierToReachAConsensus);
     pose.setRansacThreshold(threshold);

--- a/modules/vision/test/key-point/testKeyPoint-2.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-2.cpp
@@ -55,7 +55,7 @@
 #include <visp3/vision/vpKeyPoint.h>
 
 // List of allowed command line options
-#define GETOPTARGS "cdh"
+#define GETOPTARGS "cdph"
 
 void usage(const char *name, const char *badparam);
 bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display);
@@ -74,7 +74,7 @@ void usage(const char *name, const char *badparam)
 Test keypoints matching.\n\
 \n\
 SYNOPSIS\n\
-  %s [-c] [-d] [-h]\n", name);
+  %s [-c] [-d] [-p] [-h]\n", name);
 
   fprintf(stdout, "\n\
 OPTIONS:                                               \n\
@@ -85,6 +85,9 @@ OPTIONS:                                               \n\
 \n\
   -d \n\
      Turn off the display.\n\
+\n\
+  -p \n\
+     Use parallel RANSAC.\n\
 \n\
   -h\n\
      Print the help.\n");
@@ -104,7 +107,8 @@ OPTIONS:                                               \n\
   \return false if the program has to be stopped, true otherwise.
 
 */
-bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display)
+bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display,
+                bool &use_parallel_ransac)
 {
   const char *optarg_;
   int c;
@@ -116,6 +120,9 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display)
       break;
     case 'd':
       display = false;
+      break;
+    case 'p':
+      use_parallel_ransac = true;
       break;
     case 'h':
       usage(argv[0], NULL);
@@ -151,9 +158,10 @@ int main(int argc, const char **argv)
     std::string env_ipath;
     bool opt_click_allowed = true;
     bool opt_display = true;
+    bool use_parallel_ransac = false;
 
     // Read the command line options
-    if (getOptions(argc, argv, opt_click_allowed, opt_display) == false) {
+    if (getOptions(argc, argv, opt_click_allowed, opt_display, use_parallel_ransac) == false) {
       exit(-1);
     }
 
@@ -241,6 +249,7 @@ int main(int argc, const char **argv)
 
     // Init keypoints
     vpKeyPoint keypoints("ORB", "ORB", "BruteForce-Hamming");
+    keypoints.setRansacParallel(use_parallel_ransac);
 #if (VISP_HAVE_OPENCV_VERSION >= 0x020400)
     // Bug when using LSH index with FLANN and OpenCV 2.3.1.
     // see http://code.opencv.org/issues/1741 (Bug #1741)
@@ -348,6 +357,7 @@ int main(int argc, const char **argv)
     bool opt_click = false;
     double error;
     vpMouseButton::vpMouseButtonType button;
+    std::vector<double> times_vec;
     while ((opt_display && !g.end()) || (!opt_display && g.getFrameIndex() < 30)) {
       g.acquire(I);
 
@@ -362,6 +372,8 @@ int main(int argc, const char **argv)
 
       // Match keypoints and estimate the pose
       if (keypoints.matchPoint(I, cam, cMo, error, elapsedTime)) {
+        times_vec.push_back(elapsedTime);
+
         tracker.setCameraParameters(cam);
         tracker.setPose(I, cMo);
 
@@ -425,6 +437,12 @@ int main(int argc, const char **argv)
           }
         }
       }
+    }
+
+    if (!times_vec.empty()) {
+      std::cout << "Computation time, Mean: " << vpMath::getMean(times_vec)
+                << " ms ; Median: " << vpMath::getMedian(times_vec)
+                << " ms ; Std: " << vpMath::getStdev(times_vec) << std::endl;
     }
 
   } catch (const vpException &e) {


### PR DESCRIPTION
Surprisingly it can reduce the computation time to enable the multi-threading version on a real case, e.g. with `testKeyPoint-2`:

| | Sequential version  | Parallel version with 4 threads |
| - | ------------- | ------------- |
| Mean | 24.229 ms  | 17.3893 ms  |
| Median | 26.707 ms  | 17.7639 ms  |
| Std | Std: 7.14888  | 2.88802  |
