### PR TITLE
Faster vpImage<vpRGBa> to BGR cv::Mat conversion

### DIFF
--- a/modules/core/src/image/vpImageConvert.cpp
+++ b/modules/core/src/image/vpImageConvert.cpp
@@ -885,13 +885,7 @@ int main()
 void vpImageConvert::convert(const vpImage<vpRGBa> &src, cv::Mat &dest)
 {
   cv::Mat vpToMat((int)src.getRows(), (int)src.getCols(), CV_8UC4, (void *)src.bitmap);
-
-  dest = cv::Mat((int)src.getRows(), (int)src.getCols(), CV_8UC3);
-  cv::Mat alpha((int)src.getRows(), (int)src.getCols(), CV_8UC1);
-
-  cv::Mat out[] = {dest, alpha};
-  int from_to[] = {0, 2, 1, 1, 2, 0, 3, 3};
-  cv::mixChannels(&vpToMat, 1, out, 2, from_to, 4);
+  cv::cvtColor(vpToMat, dest, cv::COLOR_RGBA2BGR);
 }
 
 /*!


### PR DESCRIPTION

|                     | 640x360 (old) | 640x360 (new) | x-factor | 1280x720 (old) | 1280x720 (new) | x-factor
| --------------   | -------------        | -------------         | ---------- | -------------           | ----------------------- | ----------
| Mean (ms)   | 0.760124          | 0.258162            | 2.94      | 2.16438             | 0.671958                | 3.22
| Median(ms) | 0.75 ms          | 0.215088          |              | 2.15796                | 0.566895                |
| Std (ms)      | 0.145263        | 0.117033          |              | 0.393432              | 0.215827              |