### PR TITLE
Fix function signature

### DIFF
--- a/modules/tracker/mbt/include/visp3/mbt/vpMbHiddenFaces.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbHiddenFaces.h
@@ -554,12 +554,14 @@ unsigned int vpMbHiddenFaces<PolygonType>::setVisiblePrivate(const vpHomogeneous
   \param angleAppears : Angle used to test the appearance of a face
   \param angleDisappears : Angle used to test the disappearance of a face
   \param changed : True if a face appeared, disappeared or too many points
-  have been lost. False otherwise \param useOgre : True if a Ogre is used to
-  test the visibility, False otherwise. \param not_used : Unused parameter.
+  have been lost. False otherwise
+  \param useOgre : True if a Ogre is used to test the visibility, False otherwise.
+  \param not_used : Unused parameter.
   \param I : Image used to test if a face is entirely projected in the image.
   \param cam : Camera parameters.
   \param cameraPos : Position of the camera. Used only when Ogre is used as
-  3rd party. \param index : Index of the face to consider.
+  3rd party.
+  \param index : Index of the face to consider.
 
   \return Return true if the face is visible.
 */

--- a/modules/tracker/mbt/src/vpMbtPolygon.cpp
+++ b/modules/tracker/mbt/src/vpMbtPolygon.cpp
@@ -98,7 +98,8 @@ vpMbtPolygon::~vpMbtPolygon() {}
   \param alpha : Maximum angle to detect if the face is visible (in rad).
   \param modulo : Indicates if the test should also consider faces that are
   not oriented counter clockwise. If true, the orientation of the face is
-  without importance. \param cam : Camera parameters (intrinsics parameters)
+  without importance.
+  \param cam : Camera parameters (intrinsics parameters)
   \param I : Image used to consider level of detail.
 
   \return Return true if the polygon is visible.

--- a/modules/vision/include/visp3/vision/vpKeyPoint.h
+++ b/modules/vision/include/visp3/vision/vpKeyPoint.h
@@ -369,14 +369,14 @@ public:
 
   bool computePose(const std::vector<cv::Point2f> &imagePoints, const std::vector<cv::Point3f> &objectPoints,
                    const vpCameraParameters &cam, vpHomogeneousMatrix &cMo, std::vector<int> &inlierIndex,
-                   double &elapsedTime, bool (*func)(vpHomogeneousMatrix *) = NULL);
+                   double &elapsedTime, bool (*func)(const vpHomogeneousMatrix &) = NULL);
 
   bool computePose(const std::vector<vpPoint> &objectVpPoints, vpHomogeneousMatrix &cMo, std::vector<vpPoint> &inliers,
-                   double &elapsedTime, bool (*func)(vpHomogeneousMatrix *) = NULL);
+                   double &elapsedTime, bool (*func)(const vpHomogeneousMatrix &) = NULL);
 
   bool computePose(const std::vector<vpPoint> &objectVpPoints, vpHomogeneousMatrix &cMo, std::vector<vpPoint> &inliers,
                    std::vector<unsigned int> &inlierIndex, double &elapsedTime,
-                   bool (*func)(vpHomogeneousMatrix *) = NULL);
+                   bool (*func)(const vpHomogeneousMatrix &) = NULL);
 
   void createImageMatching(vpImage<unsigned char> &IRef, vpImage<unsigned char> &ICurrent,
                            vpImage<unsigned char> &IMatching);
@@ -680,9 +680,9 @@ public:
   unsigned int matchPoint(const vpImage<unsigned char> &I, const vpRect &rectangle);
 
   bool matchPoint(const vpImage<unsigned char> &I, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
-                  bool (*func)(vpHomogeneousMatrix *) = NULL, const vpRect &rectangle = vpRect());
+                  bool (*func)(const vpHomogeneousMatrix &) = NULL, const vpRect &rectangle = vpRect());
   bool matchPoint(const vpImage<unsigned char> &I, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
-                  double &error, double &elapsedTime, bool (*func)(vpHomogeneousMatrix *) = NULL,
+                  double &error, double &elapsedTime, bool (*func)(const vpHomogeneousMatrix &) = NULL,
                   const vpRect &rectangle = vpRect());
 
   bool matchPointAndDetect(const vpImage<unsigned char> &I, vpRect &boundingBox, vpImagePoint &centerOfGravity,
@@ -692,7 +692,7 @@ public:
 
   bool matchPointAndDetect(const vpImage<unsigned char> &I, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
                            double &error, double &elapsedTime, vpRect &boundingBox, vpImagePoint &centerOfGravity,
-                           bool (*func)(vpHomogeneousMatrix *) = NULL, const vpRect &rectangle = vpRect());
+                           bool (*func)(const vpHomogeneousMatrix &) = NULL, const vpRect &rectangle = vpRect());
 
   void reset();
 

--- a/modules/vision/include/visp3/vision/vpPose.h
+++ b/modules/vision/include/visp3/vision/vpPose.h
@@ -159,7 +159,7 @@ private:
     RansacFunctor(const vpHomogeneousMatrix &cMo_, const unsigned int ransacNbInlierConsensus_,
                   const int ransacMaxTrials_, const double ransacThreshold_, const unsigned int initial_seed_,
                   const bool checkDegeneratePoints_, const std::vector<vpPoint> &listOfUniquePoints_,
-                  bool (*func_)(vpHomogeneousMatrix *)
+                  bool (*func_)(const vpHomogeneousMatrix &)
               #ifdef VISP_HAVE_CPP11_COMPATIBILITY
                   , std::atomic<bool> &abort
               #endif
@@ -193,7 +193,7 @@ private:
     bool m_checkDegeneratePoints;
     vpHomogeneousMatrix m_cMo;
     bool m_foundSolution;
-    bool (*m_func)(vpHomogeneousMatrix *);
+    bool (*m_func)(const vpHomogeneousMatrix &);
     unsigned int m_initial_seed;
     std::vector<vpPoint> m_listOfUniquePoints;
     unsigned int m_nbInliers;
@@ -217,7 +217,7 @@ public:
   void addPoints(const std::vector<vpPoint> &lP);
   void clearPoint();
 
-  bool computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatrix *) = NULL);
+  bool computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &) = NULL);
   double computeResidual(const vpHomogeneousMatrix &cMo) const;
   bool coplanar(int &coplanar_plane_type);
   void displayModel(vpImage<unsigned char> &I, vpCameraParameters &cam, vpColor col = vpColor::none);
@@ -228,7 +228,7 @@ public:
   void poseLagrangePlan(vpHomogeneousMatrix &cMo, const int coplanar_plane_type = 0);
   void poseLagrangeNonPlan(vpHomogeneousMatrix &cMo);
   void poseLowe(vpHomogeneousMatrix &cMo);
-  bool poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatrix *) = NULL);
+  bool poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &) = NULL);
   void poseVirtualVSrobust(vpHomogeneousMatrix &cMo);
   void poseVirtualVS(vpHomogeneousMatrix &cMo);
   void printPoint();
@@ -353,7 +353,8 @@ public:
   static void findMatch(std::vector<vpPoint> &p2D, std::vector<vpPoint> &p3D,
                         const unsigned int &numberOfInlierToReachAConsensus, const double &threshold,
                         unsigned int &ninliers, std::vector<vpPoint> &listInliers, vpHomogeneousMatrix &cMo,
-                        const int &maxNbTrials=10000, const bool useParallelRansac=true, const unsigned int nthreads=0);
+                        const int &maxNbTrials=10000, const bool useParallelRansac=true, const unsigned int nthreads=0,
+                        bool (*func)(const vpHomogeneousMatrix &)=NULL);
 };
 
 #endif

--- a/modules/vision/src/key-point/vpKeyPoint.cpp
+++ b/modules/vision/src/key-point/vpKeyPoint.cpp
@@ -785,18 +785,18 @@ void vpKeyPoint::compute3DForPointsOnCylinders(
    Compute the pose using the correspondence between 2D points and 3D points
    using OpenCV function with RANSAC method.
 
-   \param imagePoints : List of 2D points corresponding to the location of the
-   detected keypoints. \param  objectPoints : List of the 3D points in the
-   object frame matched. \param cam : Camera parameters. \param cMo :
-   Homogeneous matrix between the object frame and the camera frame. \param
-   inlierIndex : List of indexes of inliers. \param elapsedTime : Elapsed
-   time. \param func : Function pointer to filter the final pose returned by
-   OpenCV pose estimation method. \return True if the pose has been computed,
-   false otherwise (not enough points, or size list mismatch).
+   \param imagePoints : List of 2D points corresponding to the location of the detected keypoints.
+   \param  objectPoints : List of the 3D points in the object frame matched.
+   \param cam : Camera parameters.
+   \param cMo : Homogeneous matrix between the object frame and the camera frame.
+   \param inlierIndex : List of indexes of inliers.
+   \param elapsedTime : Elapsed time.
+   \param func : Function pointer to filter the final pose returned by OpenCV pose estimation method.
+   \return True if the pose has been computed, false otherwise (not enough points, or size list mismatch).
  */
 bool vpKeyPoint::computePose(const std::vector<cv::Point2f> &imagePoints, const std::vector<cv::Point3f> &objectPoints,
                              const vpCameraParameters &cam, vpHomogeneousMatrix &cMo, std::vector<int> &inlierIndex,
-                             double &elapsedTime, bool (*func)(vpHomogeneousMatrix *))
+                             double &elapsedTime, bool (*func)(const vpHomogeneousMatrix &))
 {
   double t = vpTime::measureTimeMs();
 
@@ -868,7 +868,7 @@ bool vpKeyPoint::computePose(const std::vector<cv::Point2f> &imagePoints, const 
   if (func != NULL) {
     // Check the final pose returned by solvePnPRansac to discard
     // solutions which do not respect the pose criterion.
-    if (!func(&cMo)) {
+    if (!func(cMo)) {
       elapsedTime = (vpTime::measureTimeMs() - t);
       return false;
     }
@@ -882,16 +882,16 @@ bool vpKeyPoint::computePose(const std::vector<cv::Point2f> &imagePoints, const 
    Compute the pose using the correspondence between 2D points and 3D points
    using ViSP function with RANSAC method.
 
-   \param objectVpPoints : List of vpPoint with coordinates expressed in the
-   object and in the camera frame. \param cMo : Homogeneous matrix between the
-   object frame and the camera frame. \param inliers : List of inliers. \param
-   elapsedTime : Elapsed time. \return True if the pose has been computed,
-   false otherwise (not enough points, or size list mismatch). \param func :
-   Function pointer to filter the pose in Ransac pose estimation, if we want
+   \param objectVpPoints : List of vpPoint with coordinates expressed in the object and in the camera frame.
+   \param cMo : Homogeneous matrix between the object frame and the camera frame.
+   \param inliers : List of inliers.
+   \param elapsedTime : Elapsed time.
+   \param func : Function pointer to filter the pose in Ransac pose estimation, if we want
    to eliminate the poses which do not respect some criterion
+   \return True if the pose has been computed, false otherwise (not enough points, or size list mismatch).
  */
 bool vpKeyPoint::computePose(const std::vector<vpPoint> &objectVpPoints, vpHomogeneousMatrix &cMo,
-                             std::vector<vpPoint> &inliers, double &elapsedTime, bool (*func)(vpHomogeneousMatrix *))
+                             std::vector<vpPoint> &inliers, double &elapsedTime, bool (*func)(const vpHomogeneousMatrix &))
 {
   std::vector<unsigned int> inlierIndex;
   return computePose(objectVpPoints, cMo, inliers, inlierIndex, elapsedTime, func);
@@ -901,19 +901,18 @@ bool vpKeyPoint::computePose(const std::vector<vpPoint> &objectVpPoints, vpHomog
    Compute the pose using the correspondence between 2D points and 3D points
    using ViSP function with RANSAC method.
 
-   \param objectVpPoints : List of vpPoint with coordinates expressed in the
-   object and in the camera frame. \param cMo : Homogeneous matrix between the
-   object frame and the camera frame. \param inliers : List of inlier points.
+   \param objectVpPoints : List of vpPoint with coordinates expressed in the object and in the camera frame.
+   \param cMo : Homogeneous matrix between the object frame and the camera frame.
+   \param inliers : List of inlier points.
    \param inlierIndex : List of inlier index.
    \param elapsedTime : Elapsed time.
-   \return True if the pose has been computed, false otherwise (not enough
-   points, or size list mismatch). \param func : Function pointer to filter
-   the pose in Ransac pose estimation, if we want to eliminate the poses which
+   \return True if the pose has been computed, false otherwise (not enough points, or size list mismatch).
+   \param func : Function pointer to filter  the pose in Ransac pose estimation, if we want to eliminate the poses which
    do not respect some criterion
  */
 bool vpKeyPoint::computePose(const std::vector<vpPoint> &objectVpPoints, vpHomogeneousMatrix &cMo,
                              std::vector<vpPoint> &inliers, std::vector<unsigned int> &inlierIndex, double &elapsedTime,
-                             bool (*func)(vpHomogeneousMatrix *))
+                             bool (*func)(const vpHomogeneousMatrix &))
 {
   double t = vpTime::measureTimeMs();
 
@@ -2997,15 +2996,14 @@ unsigned int vpKeyPoint::matchPoint(const vpImage<unsigned char> &I, const vpRec
 
    \param I : Input image
    \param cam : Camera parameters
-   \param cMo : Homogeneous matrix between the object frame and the camera
-   frame \param func : Function pointer to filter the pose in Ransac pose
-   estimation, if we want to eliminate the poses which do not respect some
-   criterion \param rectangle : Rectangle corresponding to the ROI (Region of
-   Interest) to consider \return True if the matching and the pose estimation
-   are OK, false otherwise
+   \param cMo : Homogeneous matrix between the object frame and the camera frame
+   \param func : Function pointer to filter the pose in Ransac pose
+   estimation, if we want to eliminate the poses which do not respect some criterion
+   \param rectangle : Rectangle corresponding to the ROI (Region of Interest) to consider
+   \return True if the matching and the pose estimation are OK, false otherwise
  */
 bool vpKeyPoint::matchPoint(const vpImage<unsigned char> &I, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
-                            bool (*func)(vpHomogeneousMatrix *), const vpRect &rectangle)
+                            bool (*func)(const vpHomogeneousMatrix &), const vpRect &rectangle)
 {
   double error, elapsedTime;
   return matchPoint(I, cam, cMo, error, elapsedTime, func, rectangle);
@@ -3017,18 +3015,17 @@ bool vpKeyPoint::matchPoint(const vpImage<unsigned char> &I, const vpCameraParam
 
    \param I : Input image
    \param cam : Camera parameters
-   \param cMo : Homogeneous matrix between the object frame and the camera
-   frame \param error : Reprojection mean square error (in pixel) between the
+   \param cMo : Homogeneous matrix between the object frame and the camera frame
+   \param error : Reprojection mean square error (in pixel) between the
    2D points and the projection of the 3D points with the estimated pose
    \param elapsedTime : Time to detect, extract, match and compute the pose
    \param func : Function pointer to filter the pose in Ransac pose
-   estimation, if we want to eliminate the poses which do not respect some
-   criterion \param rectangle : Rectangle corresponding to the ROI (Region of
-   Interest) to consider \return True if the matching and the pose estimation
-   are OK, false otherwise
+   estimation, if we want to eliminate the poses which do not respect some criterion
+   \param rectangle : Rectangle corresponding to the ROI (Region of Interest) to consider
+   \return True if the matching and the pose estimation are OK, false otherwise
  */
 bool vpKeyPoint::matchPoint(const vpImage<unsigned char> &I, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
-                            double &error, double &elapsedTime, bool (*func)(vpHomogeneousMatrix *),
+                            double &error, double &elapsedTime, bool (*func)(const vpHomogeneousMatrix &),
                             const vpRect &rectangle)
 {
   // Check if we have training descriptors
@@ -3343,22 +3340,21 @@ bool vpKeyPoint::matchPointAndDetect(const vpImage<unsigned char> &I, vpRect &bo
 
    \param I : Input image
    \param cam : Camera parameters
-   \param cMo : Homogeneous matrix between the object frame and the camera
-   frame \param error : Reprojection mean square error (in pixel) between the
+   \param cMo : Homogeneous matrix between the object frame and the camera frame
+   \param error : Reprojection mean square error (in pixel) between the
    2D points and the projection of the 3D points with the estimated pose
    \param elapsedTime : Time to detect, extract, match and compute the pose
    \param boundingBox : Bounding box that contains the good matches
    \param centerOfGravity : Center of gravity computed from the location of
-   the good matches (could differ of the center of the bounding box) \param
-   func : Function pointer to filter the pose in Ransac pose estimation, if we
-   want to eliminate the poses which do not respect some criterion \param
-   rectangle : Rectangle corresponding to the ROI (Region of Interest) to
-   consider \return True if the matching and the pose estimation are OK, false
-   otherwise.
+   the good matches (could differ of the center of the bounding box)
+   \param func : Function pointer to filter the pose in Ransac pose estimation, if we
+   want to eliminate the poses which do not respect some criterion
+   \param rectangle : Rectangle corresponding to the ROI (Region of Interest) to consider
+   \return True if the matching and the pose estimation are OK, false otherwise.
  */
 bool vpKeyPoint::matchPointAndDetect(const vpImage<unsigned char> &I, const vpCameraParameters &cam,
                                      vpHomogeneousMatrix &cMo, double &error, double &elapsedTime, vpRect &boundingBox,
-                                     vpImagePoint &centerOfGravity, bool (*func)(vpHomogeneousMatrix *),
+                                     vpImagePoint &centerOfGravity, bool (*func)(const vpHomogeneousMatrix &),
                                      const vpRect &rectangle)
 {
   bool isMatchOk = matchPoint(I, cam, cMo, error, elapsedTime, func, rectangle);

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -359,7 +359,7 @@ double vpPose::computeResidual(const vpHomogeneousMatrix &cMo) const
   - vpPose::RANSAC: Robust Ransac aproach (does't need an initialization)
 
 */
-bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatrix *))
+bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &))
 {
   if (npt < 4) {
     vpERROR_TRACE("Not enough point (%d) to compute the pose  ", npt);

--- a/modules/vision/src/pose-estimation/vpPoseRansac.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseRansac.cpp
@@ -250,7 +250,7 @@ bool vpPose::RansacFunctor::poseRansacImpl()
       // translations, etc.)
       bool isPoseValid = true;
       if (m_func != NULL) {
-        isPoseValid = m_func(&cMo_tmp);
+        isPoseValid = m_func(cMo_tmp);
         if (isPoseValid) {
           m_cMo = cMo_tmp;
         }
@@ -330,7 +330,7 @@ bool vpPose::RansacFunctor::poseRansacImpl()
   The number of threads used can then be set with \e setNbParallelRansacThreads
   Filter flag can be used  with \e setRansacFilterFlag
 */
-bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatrix *))
+bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &))
 {
   // Check only for adding / removing problem
   // Do not take into account problem with element modification here
@@ -567,7 +567,7 @@ bool vpPose::poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(vpHomogeneousMatr
         // In some rare cases, the final pose could not respect the pose
         // criterion even  if the 4 minimal points picked respect the pose
         // criterion.
-        if (func != NULL && !func(&cMo)) {
+        if (func != NULL && !func(cMo)) {
           return false;
         }
 
@@ -667,12 +667,15 @@ int vpPose::computeRansacIterations(double probability, double epsilon, const in
   numberOfInlierToReachAConsensus and \e threshold cannot be found.
   \param useParallelRansac : If true, use parallel RANSAC version (if C++11 is available).
   \param nthreads : Number of threads to use, if 0 the number of CPU threads will be determined.
+  \param func : Pointer to a function that takes in parameter a vpHomogeneousMatrix and returns
+  true if the pose check is OK or false otherwise
 */
 void vpPose::findMatch(std::vector<vpPoint> &p2D, std::vector<vpPoint> &p3D,
                        const unsigned int &numberOfInlierToReachAConsensus, const double &threshold,
                        unsigned int &ninliers, std::vector<vpPoint> &listInliers, vpHomogeneousMatrix &cMo,
                        const int &maxNbTrials,
-                       const bool useParallelRansac, const unsigned int nthreads)
+                       const bool useParallelRansac, const unsigned int nthreads,
+                       bool (*func)(const vpHomogeneousMatrix &))
 {
   vpPose pose;
 
@@ -701,7 +704,7 @@ void vpPose::findMatch(std::vector<vpPoint> &p2D, std::vector<vpPoint> &p3D,
     pose.setRansacMaxTrials(maxNbTrials);
     pose.setRansacNbInliersToReachConsensus(numberOfInlierToReachAConsensus);
     pose.setRansacThreshold(threshold);
-    pose.computePose(vpPose::RANSAC, cMo);
+    pose.computePose(vpPose::RANSAC, cMo, func);
     ninliers = pose.getRansacNbInliers();
     listInliers = pose.getRansacInliers();
   }


### PR DESCRIPTION
Fix function signature for function pointer used to check the cMo in RANSAC pose.
This change is not backward compatible but since this functionality is almost not used it should be ok.