### PR TITLE
Fix memory leak with MBT and new projection error

### DIFF
--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -4178,32 +4178,7 @@ vpMbGenericTracker::TrackerWrapper::TrackerWrapper(const int trackerType)
 #endif
 }
 
-vpMbGenericTracker::TrackerWrapper::~TrackerWrapper() {
-  vpMbtDistanceLine *l;
-  vpMbtDistanceCylinder *cy;
-  vpMbtDistanceCircle *ci;
-
-  for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_projectionErrorLines.begin(); it != m_projectionErrorLines.end(); ++it) {
-    l = *it;
-    if (l != NULL)
-      delete l;
-    l = NULL;
-  }
-
-  for (std::vector<vpMbtDistanceCylinder *>::const_iterator it = m_projectionErrorCylinders.begin(); it != m_projectionErrorCylinders.end(); ++it) {
-    cy = *it;
-    if (cy != NULL)
-      delete cy;
-    cy = NULL;
-  }
-
-  for (std::vector<vpMbtDistanceCircle *>::const_iterator it = m_projectionErrorCircles.begin(); it != m_projectionErrorCircles.end(); ++it) {
-    ci = *it;
-    if (ci != NULL)
-      delete ci;
-    ci = NULL;
-  }
-}
+vpMbGenericTracker::TrackerWrapper::~TrackerWrapper() { }
 
 // Implemented only for debugging purposes: use TrackerWrapper as a standalone tracker
 void vpMbGenericTracker::TrackerWrapper::computeVVS(const vpImage<unsigned char> *const ptr_I)

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -165,10 +165,32 @@ vpMbTracker::vpMbTracker()
   vpImageFilter::getSobelKernelY(m_SobelY.data, m_projectionErrorKernelSize);
 }
 
-/*!
-  Basic destructor that doest nothing.
-*/
-vpMbTracker::~vpMbTracker() {}
+vpMbTracker::~vpMbTracker() {
+  vpMbtDistanceLine *l;
+  vpMbtDistanceCylinder *cy;
+  vpMbtDistanceCircle *ci;
+
+  for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_projectionErrorLines.begin(); it != m_projectionErrorLines.end(); ++it) {
+    l = *it;
+    if (l != NULL)
+      delete l;
+    l = NULL;
+  }
+
+  for (std::vector<vpMbtDistanceCylinder *>::const_iterator it = m_projectionErrorCylinders.begin(); it != m_projectionErrorCylinders.end(); ++it) {
+    cy = *it;
+    if (cy != NULL)
+      delete cy;
+    cy = NULL;
+  }
+
+  for (std::vector<vpMbtDistanceCircle *>::const_iterator it = m_projectionErrorCircles.begin(); it != m_projectionErrorCircles.end(); ++it) {
+    ci = *it;
+    if (ci != NULL)
+      delete ci;
+    ci = NULL;
+  }
+}
 
 #ifdef VISP_HAVE_MODULE_GUI
 /*!


### PR DESCRIPTION
Fix memory leak with MBT and new projection error when using a tracker other than vpMbGenericTracker.