### PR TITLE
Fix for OpenCV 4 build and cv::Ptr comparison with NULL

### DIFF
--- a/modules/sensor/test/framegrabber/testPylonGrabber.cpp
+++ b/modules/sensor/test/framegrabber/testPylonGrabber.cpp
@@ -121,7 +121,7 @@ int main()
     filename = outputpath + "/imagetest2.pgm";
     std::cout << "Write image: " << filename << std::endl;
     vpImageIo::write(I, filename);
-  } catch (const GenericException &e) {
+  } catch (const vpException &e) {
     vpCERROR << e.what() << std::endl;
   } catch (const std::exception &e) {
     vpCERROR << e.what() << std::endl;

--- a/modules/vision/src/key-point/vpKeyPoint.cpp
+++ b/modules/vision/src/key-point/vpKeyPoint.cpp
@@ -1921,10 +1921,10 @@ void vpKeyPoint::initDetector(const std::string &detectorName)
   bool detectorInitialized = false;
   if (!usePyramid) {
     //if not null and to avoid warning C4800: forcing value to bool 'true' or 'false' (performance warning)
-    detectorInitialized = !!m_detectors[detectorNameTmp];
+    detectorInitialized = !m_detectors[detectorNameTmp].empty();
   } else {
     //if not null and to avoid warning C4800: forcing value to bool 'true' or 'false' (performance warning)
-    detectorInitialized = !!m_detectors[detectorName];
+    detectorInitialized = !m_detectors[detectorName].empty();
   }
 
   if (!detectorInitialized) {

--- a/modules/vision/src/key-point/vpKeyPoint.cpp
+++ b/modules/vision/src/key-point/vpKeyPoint.cpp
@@ -1920,9 +1920,11 @@ void vpKeyPoint::initDetector(const std::string &detectorName)
 
   bool detectorInitialized = false;
   if (!usePyramid) {
-    detectorInitialized = (m_detectors[detectorNameTmp] != NULL);
+    //if not null and to avoid warning C4800: forcing value to bool 'true' or 'false' (performance warning)
+    detectorInitialized = !!m_detectors[detectorNameTmp];
   } else {
-    detectorInitialized = (m_detectors[detectorName] != NULL);
+    //if not null and to avoid warning C4800: forcing value to bool 'true' or 'false' (performance warning)
+    detectorInitialized = !!m_detectors[detectorName];
   }
 
   if (!detectorInitialized) {
@@ -2069,7 +2071,7 @@ void vpKeyPoint::initExtractor(const std::string &extractorName)
   }
 #endif
 
-  if (m_extractors[extractorName] == NULL) {
+  if (!m_extractors[extractorName]) { //if null
     std::stringstream ss_msg;
     ss_msg << "Fail to initialize the extractor: " << extractorName
            << " or it is not available in OpenCV version: " << std::hex << VISP_HAVE_OPENCV_VERSION << ".";
@@ -2216,7 +2218,7 @@ void vpKeyPoint::initMatcher(const std::string &matcherName)
   }
 #endif
 
-  if (m_matcher == NULL) {
+  if (!m_matcher) { //if null
     std::stringstream ss_msg;
     ss_msg << "Fail to initialize the matcher: " << matcherName
            << " or it is not available in OpenCV version: " << std::hex << VISP_HAVE_OPENCV_VERSION << ".";

--- a/modules/vision/test/key-point/testKeyPoint-2.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-2.cpp
@@ -258,7 +258,7 @@ int main(int argc, const char **argv)
     keypoints.setDetectorParameter("ORB", "nLevels", 1);
 #else
     cv::Ptr<cv::ORB> orb_detector = keypoints.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_detector != NULL) {
+    if (orb_detector) {
       orb_detector->setNLevels(1);
     }
 #endif

--- a/tutorial/bridge/opencv/tutorial-bridge-opencv.cpp
+++ b/tutorial/bridge/opencv/tutorial-bridge-opencv.cpp
@@ -3,7 +3,11 @@
 #include <visp3/core/vpImageConvert.h>
 #include <visp3/io/vpImageIo.h>
 
-#if VISP_HAVE_OPENCV_VERSION >= 0x020300
+#if VISP_HAVE_OPENCV_VERSION >= 0x040000
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+#elif VISP_HAVE_OPENCV_VERSION >= 0x020300
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #endif

--- a/tutorial/detection/object/tutorial-detection-object-mbt2-deprecated.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt2-deprecated.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     keypoint_learning.setDetectorParameter("ORB", "nLevels", 1);
 #else
     cv::Ptr<cv::ORB> orb_learning = keypoint_learning.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_learning != NULL) {
+    if (orb_learning) {
       orb_learning->setNLevels(1);
     }
 #endif
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 #else
     cv::Ptr<cv::ORB> orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
     orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_detector != NULL) {
+    if (orb_detector) {
       orb_detector->setNLevels(1);
     }
 #endif

--- a/tutorial/detection/object/tutorial-detection-object-mbt2.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt2.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     keypoint_learning.setDetectorParameter("ORB", "nLevels", 1);
 #else
     cv::Ptr<cv::ORB> orb_learning = keypoint_learning.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_learning != NULL) {
+    if (orb_learning) {
       orb_learning->setNLevels(1);
     }
 #endif
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 #else
     cv::Ptr<cv::ORB> orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
     orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_detector != NULL) {
+    if (orb_detector) {
       orb_detector->setNLevels(1);
     }
 #endif


### PR DESCRIPTION
Quick test fix, to be validated.

```
C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp(1923): error C2666: 'operator !=': 3 overloads have similar conversions [C:\Temp\fspindle\soft\Sat-2018-Oct-20\13h-30min\modules\vision\visp_vision.vcxproj]
   C:\Program Files (x86)\Windows Kits\10\Include\10.0.14393.0\shared\guiddef.h(197): note: could be 'bool operator !=(const GUID &,const GUID &)' (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  vpPose.cpp
  C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\core\include\visp3/core/vpImagePoint.h(309): note: or       'bool operator !=(const vpImagePoint &,const vpImagePoint &)' (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\core\include\visp3/core/vpColor.h(222): note: or       'bool operator !=(const vpColor &,const vpColor &)' (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\exception(344): note: or       'bool std::operator !=(const std::exception_ptr &,const std::exception_ptr &) throw()' [found using argument-dependent lookup] (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\exception(349): note: or       'bool std::operator !=(std::nullptr_t,const std::exception_ptr &) throw()' [found using argument-dependent lookup] (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\exception(354): note: or       'bool std::operator !=(const std::exception_ptr &,std::nullptr_t) throw()' [found using argument-dependent lookup] (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\system_error(398): note: or       'bool std::operator !=(const std::error_code &,const std::error_code &) noexcept' [found using argument-dependent lookup] (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\system_error(405): note: or       'bool std::operator !=(const std::error_code &,const std::error_condition &) noexcept' [found using argument-dependent lookup] (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
  C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\include\system_error(412): note: or       'bool std::operator !=(const std::error_condition &,const std::error_code &) noexcept' [found using argument-dependent lookup] (compiling source file C:\Temp\fspindle\soft\Sat-2018-Oct-20\visp-master-code\modules\vision\src\key-point\vpKeyPoint.cpp)
```