### PR TITLE
Fix for OpenCV 4 build and cv::Ptr comparison with NULL + for Pylon build

### DIFF
--- a/modules/sensor/test/framegrabber/testPylonGrabber.cpp
+++ b/modules/sensor/test/framegrabber/testPylonGrabber.cpp
@@ -121,7 +121,7 @@ int main()
     filename = outputpath + "/imagetest2.pgm";
     std::cout << "Write image: " << filename << std::endl;
     vpImageIo::write(I, filename);
-  } catch (const GenericException &e) {
+  } catch (const vpException &e) {
     vpCERROR << e.what() << std::endl;
   } catch (const std::exception &e) {
     vpCERROR << e.what() << std::endl;

--- a/modules/vision/src/key-point/vpKeyPoint.cpp
+++ b/modules/vision/src/key-point/vpKeyPoint.cpp
@@ -1920,9 +1920,11 @@ void vpKeyPoint::initDetector(const std::string &detectorName)
 
   bool detectorInitialized = false;
   if (!usePyramid) {
-    detectorInitialized = (m_detectors[detectorNameTmp] != NULL);
+    //if not null and to avoid warning C4800: forcing value to bool 'true' or 'false' (performance warning)
+    detectorInitialized = !m_detectors[detectorNameTmp].empty();
   } else {
-    detectorInitialized = (m_detectors[detectorName] != NULL);
+    //if not null and to avoid warning C4800: forcing value to bool 'true' or 'false' (performance warning)
+    detectorInitialized = !m_detectors[detectorName].empty();
   }
 
   if (!detectorInitialized) {
@@ -2069,7 +2071,7 @@ void vpKeyPoint::initExtractor(const std::string &extractorName)
   }
 #endif
 
-  if (m_extractors[extractorName] == NULL) {
+  if (!m_extractors[extractorName]) { //if null
     std::stringstream ss_msg;
     ss_msg << "Fail to initialize the extractor: " << extractorName
            << " or it is not available in OpenCV version: " << std::hex << VISP_HAVE_OPENCV_VERSION << ".";
@@ -2216,7 +2218,7 @@ void vpKeyPoint::initMatcher(const std::string &matcherName)
   }
 #endif
 
-  if (m_matcher == NULL) {
+  if (!m_matcher) { //if null
     std::stringstream ss_msg;
     ss_msg << "Fail to initialize the matcher: " << matcherName
            << " or it is not available in OpenCV version: " << std::hex << VISP_HAVE_OPENCV_VERSION << ".";

--- a/modules/vision/test/key-point/testKeyPoint-2.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-2.cpp
@@ -258,7 +258,7 @@ int main(int argc, const char **argv)
     keypoints.setDetectorParameter("ORB", "nLevels", 1);
 #else
     cv::Ptr<cv::ORB> orb_detector = keypoints.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_detector != NULL) {
+    if (orb_detector) {
       orb_detector->setNLevels(1);
     }
 #endif

--- a/tutorial/bridge/opencv/tutorial-bridge-opencv.cpp
+++ b/tutorial/bridge/opencv/tutorial-bridge-opencv.cpp
@@ -3,7 +3,11 @@
 #include <visp3/core/vpImageConvert.h>
 #include <visp3/io/vpImageIo.h>
 
-#if VISP_HAVE_OPENCV_VERSION >= 0x020300
+#if VISP_HAVE_OPENCV_VERSION >= 0x040000
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+#elif VISP_HAVE_OPENCV_VERSION >= 0x020300
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 #endif

--- a/tutorial/detection/object/tutorial-detection-object-mbt2-deprecated.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt2-deprecated.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     keypoint_learning.setDetectorParameter("ORB", "nLevels", 1);
 #else
     cv::Ptr<cv::ORB> orb_learning = keypoint_learning.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_learning != NULL) {
+    if (orb_learning) {
       orb_learning->setNLevels(1);
     }
 #endif
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 #else
     cv::Ptr<cv::ORB> orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
     orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_detector != NULL) {
+    if (orb_detector) {
       orb_detector->setNLevels(1);
     }
 #endif

--- a/tutorial/detection/object/tutorial-detection-object-mbt2.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt2.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
     keypoint_learning.setDetectorParameter("ORB", "nLevels", 1);
 #else
     cv::Ptr<cv::ORB> orb_learning = keypoint_learning.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_learning != NULL) {
+    if (orb_learning) {
       orb_learning->setNLevels(1);
     }
 #endif
@@ -198,7 +198,7 @@ int main(int argc, char **argv)
 #else
     cv::Ptr<cv::ORB> orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
     orb_detector = keypoint_detection.getDetector("ORB").dynamicCast<cv::ORB>();
-    if (orb_detector != NULL) {
+    if (orb_detector) {
       orb_detector->setNLevels(1);
     }
 #endif


### PR DESCRIPTION
**Note**: OpenCV 4.0 requires C++11 but it doesn't mean that ViSP should be built with C++11 flag if OpenCV 4.0 is used.

These commits fix build with OpenCV 4.0-beta and Pylon 3rd parties on meteosat computer running Visual 2015 (vc14) when C++11 is enabled (`USE_CPP11=ON`).

ViSP builds also with OpenCV 4.0-beta when c++11 is disabled. This confirms that OpenCV headers don't include specific C++11 headers.