### PR TITLE
Fix vpMomentAlpha computation

### DIFF
--- a/modules/core/include/visp3/core/vpMomentAlpha.h
+++ b/modules/core/include/visp3/core/vpMomentAlpha.h
@@ -56,7 +56,7 @@ parallel to the object.
 
   In general the value of the moment is computed in \f$ [-\pi/2 .. \pi/2] \f$
 interval by the formula \f$ \alpha = \frac{1}{2}
-arctan(\frac{2\mu_{11}}{\mu_{20}-\mu_{02}}) \f$.
+\mathrm{atan2}(2\mu_{11}, \mu_{20}-\mu_{02}) \f$.
 
   To obtain a \f$ [-\pi .. \pi] \f$ precision for non symetric object, you
 have to specify a reference information. This reference information is an

--- a/modules/core/include/visp3/core/vpMomentAlpha.h
+++ b/modules/core/include/visp3/core/vpMomentAlpha.h
@@ -55,8 +55,10 @@
 parallel to the object.
 
   In general the value of the moment is computed in \f$ [-\pi/2 .. \pi/2] \f$
-interval by the formula \f$ \alpha = \frac{1}{2}
-arctan(\frac{2\mu_{11}}{\mu_{20}-\mu_{02}}) \f$.
+interval by the formula \f$ \alpha = \frac{1}{2} \mathrm{sgn}(\mu_{11})
+\arccos(\frac{\mu_{20}-\mu_{02}}{\sqrt{(2\mu_{11})^2 + (\mu_{20}-\mu_{02})^2}}) \f$.
+See http://homepages.inf.ed.ac.uk/rbf/CVonline/LOCAL_COPIES/OWENS/LECT2/node3.html
+for explanation.
 
   To obtain a \f$ [-\pi .. \pi] \f$ precision for non symetric object, you
 have to specify a reference information. This reference information is an

--- a/modules/core/include/visp3/core/vpMomentAlpha.h
+++ b/modules/core/include/visp3/core/vpMomentAlpha.h
@@ -55,10 +55,8 @@
 parallel to the object.
 
   In general the value of the moment is computed in \f$ [-\pi/2 .. \pi/2] \f$
-interval by the formula \f$ \alpha = \frac{1}{2} \mathrm{sgn}(\mu_{11})
-\arccos(\frac{\mu_{20}-\mu_{02}}{\sqrt{(2\mu_{11})^2 + (\mu_{20}-\mu_{02})^2}}) \f$.
-See http://homepages.inf.ed.ac.uk/rbf/CVonline/LOCAL_COPIES/OWENS/LECT2/node3.html
-for explanation.
+interval by the formula \f$ \alpha = \frac{1}{2}
+arctan(\frac{2\mu_{11}}{\mu_{20}-\mu_{02}}) \f$.
 
   To obtain a \f$ [-\pi .. \pi] \f$ precision for non symetric object, you
 have to specify a reference information. This reference information is an

--- a/modules/core/src/tracking/moments/vpMomentAlpha.cpp
+++ b/modules/core/src/tracking/moments/vpMomentAlpha.cpp
@@ -82,9 +82,7 @@ void vpMomentAlpha::compute()
   if (!found_moment_centered)
     throw vpException(vpException::notInitialized, "vpMomentCentered not found");
 
-  double t = momentCentered.get(2, 0) - momentCentered.get(0, 2);
-  t = t / sqrt(4.0 * momentCentered.get(1, 1) * momentCentered.get(1, 1) + t * t);
-  double alpha = 0.5 * copysign(1, momentCentered.get(1, 1)) * acos(t);
+  double alpha = 0.5 * atan2(2 * momentCentered.get(1, 1), momentCentered.get(2, 0) - momentCentered.get(0, 2));
 
   std::vector<double> rotMu(4);
   // std::vector<double> realMu(4);

--- a/modules/core/src/tracking/moments/vpMomentAlpha.cpp
+++ b/modules/core/src/tracking/moments/vpMomentAlpha.cpp
@@ -82,10 +82,9 @@ void vpMomentAlpha::compute()
   if (!found_moment_centered)
     throw vpException(vpException::notInitialized, "vpMomentCentered not found");
 
-  double t = 2.0 * momentCentered.get(1, 1) / (momentCentered.get(2, 0) - momentCentered.get(0, 2));
-  // double alpha = 0.5 * atan2(2.0 * momentCentered.get(1, 1),
-  // (momentCentered.get(2, 0) - momentCentered.get(0, 2)));
-  double alpha = 0.5 * atan(t);
+  double t = momentCentered.get(2, 0) - momentCentered.get(0, 2);
+  t = t / sqrt(4.0 * momentCentered.get(1, 1) * momentCentered.get(1, 1) + t * t);
+  double alpha = 0.5 * copysign(1, momentCentered.get(1, 1)) * acos(t);
 
   std::vector<double> rotMu(4);
   // std::vector<double> realMu(4);


### PR DESCRIPTION
Since `atan()` returns angle in [-pi/2, pi/2], the current computed
angle is actually within [-pi/4, pi/4]. And the result is either the
major axis or the minor axis which is not specified.

This patch will always give out the angle of the major axis. A span of
[-pi/2, pi/2] is achieved by considering both sine and cosine of
2*alpha.

Please see http://homepages.inf.ed.ac.uk/rbf/CVonline/LOCAL_COPIES/OWENS/LECT2/node3.html for details.

`copysign()` of C++11 is used, and both clang and gcc don't complain
about it when `USE_CXX11` is switched off. If required by older
compilers, I'll add fixes for C++ standards before C++11.
![sine-cosine](https://user-images.githubusercontent.com/1014277/49499871-34dfa180-f8aa-11e8-993a-1c475f6fdd05.png)