### PR TITLE
Fix and improve vpImage::getValue()

### DIFF
--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -190,19 +190,16 @@ public:
   void getMinMaxLoc(vpImagePoint *minLoc, vpImagePoint *maxLoc, Type *minVal = NULL, Type *maxVal = NULL) const;
 
   /*!
-
     Get the image number of pixels which corresponds to the image
     width multiplied by the image height.
 
     \return The image number of pixels or image size.
-
 
     \sa getWidth(), getHeight()
    */
   inline unsigned int getNumberOfPixel() const { return npixels; }
 
   /*!
-
     Get the number of rows in the image.
 
     \return The image number of rows, or image height.
@@ -210,6 +207,7 @@ public:
     \sa getHeight()
   */
   inline unsigned int getRows() const { return height; }
+
   /*!
     Get the image size.
 
@@ -224,7 +222,7 @@ public:
   // Gets the value of a pixel at a location with bilinear interpolation.
   Type getValue(double i, double j) const;
   // Gets the value of a pixel at a location with bilinear interpolation.
-  Type getValue(vpImagePoint &ip) const;
+  Type getValue(const vpImagePoint &ip) const;
 
   // Get image pixels sum
   double getSum() const;
@@ -235,7 +233,6 @@ public:
     \return The image width.
 
     \sa getHeight()
-
   */
   inline unsigned int getWidth() const { return width; }
 
@@ -266,15 +263,15 @@ public:
     position and j the column position.
 
     \return Value of the image point (i, j).
-
   */
   inline Type operator()(const unsigned int i, const unsigned int j) const { return bitmap[i * width + j]; }
+
   /*!
     Set the value \e v of an image point with coordinates (i, j), with i the
     row position and j the column position.
-
   */
   inline void operator()(const unsigned int i, const unsigned int j, const Type &v) { bitmap[i * width + j] = v; }
+
   /*!
     Get the value of an image point.
 
@@ -284,7 +281,6 @@ public:
     \return Value of the image point \e ip.
 
     \sa getValue(const vpImagePoint &)
-
   */
   inline Type operator()(const vpImagePoint &ip) const
   {
@@ -293,6 +289,7 @@ public:
 
     return bitmap[i * width + j];
   }
+
   /*!
     Set the value of an image point.
 
@@ -300,7 +297,6 @@ public:
     coordinates are roughly transformed to insigned int coordinates by cast.
 
     \param v : Value to set for the image point.
-
   */
   inline void operator()(const vpImagePoint &ip, const Type &v)
   {
@@ -1129,17 +1125,6 @@ template <class Type> bool vpImage<Type>::operator==(const vpImage<Type> &I)
 */
 template <class Type> bool vpImage<Type>::operator!=(const vpImage<Type> &I)
 {
-  //  if (this->width != I.getWidth())
-  //    return true;
-  //  if (this->height != I.getHeight())
-  //    return true;
-
-  //  for (unsigned int i=0 ; i < npixels ; i++)
-  //  {
-  //    if (bitmap[i] != I.bitmap[i])
-  //      return true;
-  //  }
-  //  return false;
   return !(*this == I);
 }
 
@@ -1322,9 +1307,7 @@ void vpImage<Type>::subsample(unsigned int v_scale, unsigned int h_scale, vpImag
   See halfSizeImage(vpImage<Type> &) for an example of pyramid construction.
 
   \sa subsample()
-
 */
-
 template <class Type> void vpImage<Type>::quarterSizeImage(vpImage<Type> &res) const
 {
   unsigned int h = height / 4;
@@ -1366,7 +1349,6 @@ template <class Type> void vpImage<Type>::quarterSizeImage(vpImage<Type> &res) c
   \endcode
 
   See halfSizeImage(vpImage<Type> &) for an example of pyramid construction.
-
 */
 template <class Type> void vpImage<Type>::doubleSizeImage(vpImage<Type> &res)
 {
@@ -1416,7 +1398,6 @@ template <class Type> void vpImage<Type>::doubleSizeImage(vpImage<Type> &res)
 
   \exception vpImageException::notInTheImage : If (i,j) is out
   of the image.
-
 */
 template <class Type> inline Type vpImage<Type>::getValue(unsigned int i, unsigned int j) const
 {
@@ -1428,13 +1409,11 @@ template <class Type> inline Type vpImage<Type>::getValue(unsigned int i, unsign
 }
 
 /*!
-
   Retrieves pixel value from an image containing values of type \e Type with
   sub-pixel accuracy.
 
   Gets the value of a sub-pixel with coordinates (i,j) with bilinear
-  interpolation. If location is out of bounds, then return the value of the
-  closest pixel.
+  interpolation.
 
   See also vpImageTools::interpolate() for a similar result, but with a choice of the interpolation method.
 
@@ -1445,89 +1424,39 @@ template <class Type> inline Type vpImage<Type>::getValue(unsigned int i, unsign
 
   \exception vpImageException::notInTheImage : If (i,j) is out
   of the image.
-
 */
 template <class Type> Type vpImage<Type>::getValue(double i, double j) const
 {
-  unsigned int iround, jround;
-  double rfrac, cfrac;
-
-  iround = (unsigned int)floor(i);
-  jround = (unsigned int)floor(j);
-
-  if (iround >= height || jround >= width) {
-    throw(vpException(vpImageException::notInTheImage, "Pixel outside the image"));
+  if (i < 0 || j < 0 || i+1 > height || j+1 > width) {
+    throw(vpException(vpImageException::notInTheImage, "Pixel outside of the image"));
+  }
+  if (height * width == 0) {
+    throw vpException(vpImageException::notInitializedError, "Empty image!");
   }
 
-  if (i > height - 1)
-    i = (double)(height - 1);
+  unsigned int iround = static_cast<unsigned int>(floor(i));
+  unsigned int jround = static_cast<unsigned int>(floor(j));
 
-  if (j > width - 1)
-    j = (double)(width - 1);
+  double rratio = i - static_cast<double>(iround);
+  double cratio = j - static_cast<double>(jround);
 
-  double rratio = i - (double)iround;
-  if (rratio < 0)
-    rratio = -rratio;
-  double cratio = j - (double)jround;
-  if (cratio < 0)
-    cratio = -cratio;
+  double rfrac = 1.0 - rratio;
+  double cfrac = 1.0 - cratio;
 
-  rfrac = 1.0f - rratio;
-  cfrac = 1.0f - cratio;
+  unsigned int iround_1 = (std::min)(height - 1, iround + 1);
+  unsigned int jround_1 = (std::min)(width - 1, jround + 1);
 
-  double value = ((double)row[iround][jround] * rfrac + (double)row[iround + 1][jround] * rratio) * cfrac +
-                 ((double)row[iround][jround + 1] * rfrac + (double)row[iround + 1][jround + 1] * rratio) * cratio;
-  return (Type)vpMath::round(value);
-}
+  double value = (static_cast<double>(row[iround][jround]) * rfrac + static_cast<double>(row[iround_1][jround]) * rratio) * cfrac +
+                 (static_cast<double>(row[iround][jround_1]) * rfrac + static_cast<double>(row[iround_1][jround_1]) * rratio) * cratio;
 
-// faster in unsigned char type
-// -O3 improve 50%
-// not -O3 improve 20%
-template <> inline unsigned char vpImage<unsigned char>::getValue(double i, double j) const {
-    const int precision = 65536;
-    int64_t y = (int64_t)(i * precision);
-    int64_t x = (int64_t)(j * precision);
-    int64_t iround, jround;
-
-    iround = y & (~(0xFFFF));
-    jround = x & (~(0xFFFF));
-    int64_t height_ = height << 16;
-    int64_t width_ = width << 16;
-
-    if (iround >= height_ || jround >= width_) {
-        throw(vpException(vpImageException::notInTheImage,
-                          "Pixel outside the image"));
-    }
-
-    if (y > height_ - 1 * precision) y = height_ - 1 * precision;
-
-    if (x > width_ - 1 * precision) x = width_ - 1 * precision;
-
-    int64_t rratio = y - iround;
-    if (rratio < 0) rratio = -rratio;
-    int64_t cratio = x - jround;
-    if (cratio < 0) cratio = -cratio;
-
-    int64_t rfrac = precision - rratio;
-    int64_t cfrac = precision - cratio;
-    int64_t x_ = x >> 16;
-    int64_t y_ = y >> 16;
-    uint16_t up = *(uint16_t *)(bitmap + y_ * width + x_);
-    uint16_t down = *(uint16_t *)(bitmap + (y_ + 1) * width + x_);
-    return (
-        unsigned char)((((up & 0x00FF) * rfrac + (down & 0x00FF) * rratio) *
-                            cfrac +
-                        ((up >> 8) * rfrac + (down >> 8) * rratio) * cratio) >>
-                       32);
+  return static_cast<Type>(vpMath::round(value));
 }
 
 /*!
-
   Retrieves pixel value from an image of double with sub-pixel accuracy.
 
   Gets the value of a sub-pixel with coordinates (i,j) with bilinear
-  interpolation. If location is out of bounds, then return value of
-  closest pixel.
+  interpolation.
 
   See also vpImageTools::interpolate() for a similar result, but with a choice of the interpolation method.
 
@@ -1538,200 +1467,140 @@ template <> inline unsigned char vpImage<unsigned char>::getValue(double i, doub
 
   \exception vpImageException::notInTheImage : If (i,j) is out
   of the image.
-
 */
 template <> inline double vpImage<double>::getValue(double i, double j) const
 {
-  unsigned int iround, jround;
-  double rfrac, cfrac;
-
-  iround = (unsigned int)floor(i);
-  jround = (unsigned int)floor(j);
-
-  if (iround >= height || jround >= width) {
-    throw(vpException(vpImageException::notInTheImage, "Pixel outside the image"));
+  if (i < 0 || j < 0 || i+1 > height || j+1 > width) {
+    throw(vpException(vpImageException::notInTheImage, "Pixel outside of the image"));
+  }
+  if (height * width == 0) {
+    throw vpException(vpImageException::notInitializedError, "Empty image!");
   }
 
-  if (i > height - 1)
-    i = (double)(height - 1);
+  unsigned int iround = static_cast<unsigned int>(floor(i));
+  unsigned int jround = static_cast<unsigned int>(floor(j));
 
-  if (j > width - 1)
-    j = (double)(width - 1);
+  double rratio = i - static_cast<double>(iround);
+  double cratio = j - static_cast<double>(jround);
 
-  double rratio = i - (double)iround;
-  if (rratio < 0)
-    rratio = -rratio;
-  double cratio = j - (double)jround;
-  if (cratio < 0)
-    cratio = -cratio;
+  double rfrac = 1.0 - rratio;
+  double cfrac = 1.0 - cratio;
 
-  rfrac = 1.0f - rratio;
-  cfrac = 1.0f - cratio;
+  unsigned int iround_1 = (std::min)(height - 1, iround + 1);
+  unsigned int jround_1 = (std::min)(width - 1, jround + 1);
 
-  double value = ((double)row[iround][jround] * rfrac + (double)row[iround + 1][jround] * rratio) * cfrac +
-                 ((double)row[iround][jround + 1] * rfrac + (double)row[iround + 1][jround + 1] * rratio) * cratio;
-  return value;
+  return (row[iround][jround] * rfrac + row[iround_1][jround] * rratio) * cfrac +
+         (row[iround][jround_1] * rfrac + row[iround_1][jround_1] * rratio) * cratio;
+}
+
+template <> inline unsigned char vpImage<unsigned char>::getValue(double i, double j) const {
+  if (i < 0 || j < 0 || i+1 > height || j+1 > width) {
+    throw(vpException(vpImageException::notInTheImage, "Pixel outside of the image"));
+  }
+  if (height * width == 0) {
+    throw vpException(vpImageException::notInitializedError, "Empty image!");
+  }
+
+  //Fixed-point arithmetic
+  const int precision = 1 << 16;
+  int64_t y = static_cast<int64_t>(i * precision);
+  int64_t x = static_cast<int64_t>(j * precision);
+
+  int64_t iround = y & (~0xFFFF);
+  int64_t jround = x & (~0xFFFF);
+
+  int64_t rratio = y - iround;
+  int64_t cratio = x - jround;
+
+  int64_t rfrac = precision - rratio;
+  int64_t cfrac = precision - cratio;
+
+  int64_t x_ = x >> 16;
+  int64_t y_ = y >> 16;
+
+  if (y_ + 1 < height && x_ + 1 < width) {
+    uint16_t up = *reinterpret_cast<uint16_t *>(bitmap + y_ * width + x_);
+    uint16_t down = *reinterpret_cast<uint16_t *>(bitmap + (y_ + 1) * width + x_);
+
+    return static_cast<unsigned char>((((up & 0x00FF) * rfrac + (down & 0x00FF) * rratio) * cfrac +
+                                       ((up >> 8) * rfrac + (down >> 8) * rratio) * cratio) >> 32);
+  } else if (y_ + 1 < height) {
+    return static_cast<unsigned char>(((row[y_][x_] * rfrac + row[y_ + 1][x_] * rratio)) >> 16);
+  } else if (x_ + 1 < width) {
+    uint16_t up = *reinterpret_cast<uint16_t *>(bitmap + y_ * width + x_);
+    return static_cast<unsigned char>(((up & 0x00FF) * cfrac + (up >> 8) * cratio) >> 16);
+  } else {
+    return row[y_][x_];
+  }
 }
 
 template <> inline vpRGBa vpImage<vpRGBa>::getValue(double i, double j) const
 {
-  unsigned int iround, jround;
-  double rfrac, cfrac;
-
-  iround = (unsigned int)floor(i);
-  jround = (unsigned int)floor(j);
-
-  if (iround >= height || jround >= width) {
-    throw(vpException(vpImageException::notInTheImage, "Pixel outside the image"));
+  if (i < 0 || j < 0 || i+1 > height || j+1 > width) {
+    throw(vpException(vpImageException::notInTheImage, "Pixel outside of the image"));
+  }
+  if (height * width == 0) {
+    throw vpException(vpImageException::notInitializedError, "Empty image!");
   }
 
-  if (i > height - 1)
-    i = (double)(height - 1);
+  unsigned int iround = static_cast<unsigned int>(floor(i));
+  unsigned int jround = static_cast<unsigned int>(floor(j));
 
-  if (j > width - 1)
-    j = (double)(width - 1);
+  double rratio = i - static_cast<double>(iround);
+  double cratio = j - static_cast<double>(jround);
 
-  double rratio = i - (double)iround;
-  if (rratio < 0)
-    rratio = -rratio;
-  double cratio = j - (double)jround;
-  if (cratio < 0)
-    cratio = -cratio;
+  double rfrac = 1.0 - rratio;
+  double cfrac = 1.0 - cratio;
 
-  rfrac = 1.0f - rratio;
-  cfrac = 1.0f - cratio;
+  unsigned int iround_1 = (std::min)(height - 1, iround + 1);
+  unsigned int jround_1 = (std::min)(width - 1, jround + 1);
 
-  double valueR = ((double)row[iround][jround].R * rfrac + (double)row[iround + 1][jround].R * rratio) * cfrac +
-                  ((double)row[iround][jround + 1].R * rfrac + (double)row[iround + 1][jround + 1].R * rratio) * cratio;
-  double valueG = ((double)row[iround][jround].G * rfrac + (double)row[iround + 1][jround].G * rratio) * cfrac +
-                  ((double)row[iround][jround + 1].G * rfrac + (double)row[iround + 1][jround + 1].G * rratio) * cratio;
-  double valueB = ((double)row[iround][jround].B * rfrac + (double)row[iround + 1][jround].B * rratio) * cfrac +
-                  ((double)row[iround][jround + 1].B * rfrac + (double)row[iround + 1][jround + 1].B * rratio) * cratio;
-  return vpRGBa((unsigned char)vpMath::round(valueR), (unsigned char)vpMath::round(valueG),
-                (unsigned char)vpMath::round(valueB));
+  double valueR = (static_cast<double>(row[iround][jround].R) * rfrac + static_cast<double>(row[iround_1][jround].R) * rratio) * cfrac +
+                  (static_cast<double>(row[iround][jround_1].R) * rfrac + static_cast<double>(row[iround_1][jround_1].R) * rratio) * cratio;
+  double valueG = (static_cast<double>(row[iround][jround].G) * rfrac + static_cast<double>(row[iround_1][jround].G) * rratio) * cfrac +
+                  (static_cast<double>(row[iround][jround_1].G) * rfrac + static_cast<double>(row[iround_1][jround_1].G) * rratio) * cratio;
+  double valueB = (static_cast<double>(row[iround][jround].B) * rfrac + static_cast<double>(row[iround_1][jround].B) * rratio) * cfrac +
+                  (static_cast<double>(row[iround][jround_1].B) * rfrac + static_cast<double>(row[iround_1][jround_1].B) * rratio) * cratio;
+
+  return vpRGBa(static_cast<unsigned char>(vpMath::round(valueR)),
+                static_cast<unsigned char>(vpMath::round(valueG)),
+                static_cast<unsigned char>(vpMath::round(valueB)));
 }
 
 /*!
+  Retrieves pixel value from an image containing values of type \e Type with
+  sub-pixel accuracy.
 
-Retrieves pixel value from an image containing values of type \e Type with
-sub-pixel accuracy.
+  Gets the value of a sub-pixel with coordinates (i,j) with bilinear
+  interpolation.
 
-Gets the value of a sub-pixel with coordinates (i,j) with bilinear
-interpolation. If location is out of bounds, then return the value of the
-closest pixel.
+  See also vpImageTools::interpolate() for a similar result, but with a choice of the interpolation method.
 
-See also vpImageTools::interpolate() for a similar result, but with a choice of the interpolation method.
+  \param ip : Sub-pixel coordinates of a point in the image.
 
-\param ip : Sub-pixel coordinates of a point in the image.
+  \return Interpolated sub-pixel value from the four neighbours.
 
-\return Interpolated sub-pixel value from the four neighbours.
-
-\exception vpImageException::notInTheImage : If the image point \e ip is out
-of the image.
-
+  \exception vpImageException::notInTheImage : If the image point \e ip is out
+  of the image.
 */
-template <class Type> inline Type vpImage<Type>::getValue(vpImagePoint &ip) const
+template <class Type> inline Type vpImage<Type>::getValue(const vpImagePoint &ip) const
 {
-  unsigned int iround, jround;
-  double rfrac, cfrac;
-
-  iround = (unsigned int)floor(ip.get_i());
-  jround = (unsigned int)floor(ip.get_j());
-
-  if (iround >= height || jround >= width) {
-    throw(vpException(vpImageException::notInTheImage, "Pixel outside the image"));
-  }
-
-  if (ip.get_i() > height - 1)
-    ip.set_i((double)(height - 1));
-
-  if (ip.get_j() > width - 1)
-    ip.set_j((double)(width - 1));
-
-  double rratio = ip.get_i() - (double)iround;
-  if (rratio < 0)
-    rratio = -rratio;
-  double cratio = ip.get_j() - (double)jround;
-  if (cratio < 0)
-    cratio = -cratio;
-
-  rfrac = 1.0f - rratio;
-  cfrac = 1.0f - cratio;
-
-  double value = ((double)row[iround][jround] * rfrac + (double)row[iround + 1][jround] * rratio) * cfrac +
-                 ((double)row[iround][jround + 1] * rfrac + (double)row[iround + 1][jround + 1] * rratio) * cratio;
-  return (Type)vpMath::round(value);
+  return getValue(ip.get_i(), ip.get_j());
 }
 
-template <> inline double vpImage<double>::getValue(vpImagePoint &ip) const
+template <> inline double vpImage<double>::getValue(const vpImagePoint &ip) const
 {
-  unsigned int iround, jround;
-  double rfrac, cfrac;
-
-  iround = (unsigned int)floor(ip.get_i());
-  jround = (unsigned int)floor(ip.get_j());
-
-  if (iround >= height || jround >= width) {
-    throw(vpException(vpImageException::notInTheImage, "Pixel outside the image"));
-  }
-
-  if (ip.get_i() > height - 1)
-    ip.set_i((double)(height - 1));
-
-  if (ip.get_j() > width - 1)
-    ip.set_j((double)(width - 1));
-
-  double rratio = ip.get_i() - (double)iround;
-  if (rratio < 0)
-    rratio = -rratio;
-  double cratio = ip.get_j() - (double)jround;
-  if (cratio < 0)
-    cratio = -cratio;
-
-  rfrac = 1.0f - rratio;
-  cfrac = 1.0f - cratio;
-
-  double value = ((double)row[iround][jround] * rfrac + (double)row[iround + 1][jround] * rratio) * cfrac +
-                 ((double)row[iround][jround + 1] * rfrac + (double)row[iround + 1][jround + 1] * rratio) * cratio;
-  return value;
+  return getValue(ip.get_i(), ip.get_j());
 }
 
-template <> inline vpRGBa vpImage<vpRGBa>::getValue(vpImagePoint &ip) const
+template <> inline unsigned char vpImage<unsigned char>::getValue(const vpImagePoint &ip) const
 {
-  unsigned int iround, jround;
-  double rfrac, cfrac;
+  return getValue(ip.get_i(), ip.get_j());
+}
 
-  iround = (unsigned int)floor(ip.get_i());
-  jround = (unsigned int)floor(ip.get_j());
-
-  if (iround >= height || jround >= width) {
-    throw(vpException(vpImageException::notInTheImage, "Pixel outside the image"));
-  }
-
-  if (ip.get_i() > height - 1)
-    ip.set_i((double)(height - 1));
-
-  if (ip.get_j() > width - 1)
-    ip.set_j((double)(width - 1));
-
-  double rratio = ip.get_i() - (double)iround;
-  if (rratio < 0)
-    rratio = -rratio;
-  double cratio = ip.get_j() - (double)jround;
-  if (cratio < 0)
-    cratio = -cratio;
-
-  rfrac = 1.0f - rratio;
-  cfrac = 1.0f - cratio;
-
-  double valueR = ((double)row[iround][jround].R * rfrac + (double)row[iround + 1][jround].R * rratio) * cfrac +
-                  ((double)row[iround][jround + 1].R * rfrac + (double)row[iround + 1][jround + 1].R * rratio) * cratio;
-  double valueG = ((double)row[iround][jround].G * rfrac + (double)row[iround + 1][jround].G * rratio) * cfrac +
-                  ((double)row[iround][jround + 1].G * rfrac + (double)row[iround + 1][jround + 1].G * rratio) * cratio;
-  double valueB = ((double)row[iround][jround].B * rfrac + (double)row[iround + 1][jround].B * rratio) * cfrac +
-                  ((double)row[iround][jround + 1].B * rfrac + (double)row[iround + 1][jround + 1].B * rratio) * cratio;
-  return vpRGBa((unsigned char)vpMath::round(valueR), (unsigned char)vpMath::round(valueG),
-                (unsigned char)vpMath::round(valueB));
+template <> inline vpRGBa vpImage<vpRGBa>::getValue(const vpImagePoint &ip) const
+{
+  return getValue(ip.get_i(), ip.get_j());
 }
 
 /**

--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -1482,7 +1482,7 @@ template <class Type> Type vpImage<Type>::getValue(double i, double j) const
 // faster in unsigned char type
 // -O3 improve 50%
 // not -O3 improve 20%
-template <class Type>
+template <>
 unsigned char vpImage<unsigned char>::getValue(double i, double j) const {
     const int precision = 65536;
     int64_t y = (int64_t)(i * precision);

--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -59,6 +59,7 @@
 #include <iostream>
 #include <math.h>
 #include <string.h>
+#include <inttypes.h>
 
 class vpDisplay;
 

--- a/modules/core/include/visp3/core/vpImage.h
+++ b/modules/core/include/visp3/core/vpImage.h
@@ -1483,8 +1483,7 @@ template <class Type> Type vpImage<Type>::getValue(double i, double j) const
 // faster in unsigned char type
 // -O3 improve 50%
 // not -O3 improve 20%
-template <>
-unsigned char vpImage<unsigned char>::getValue(double i, double j) const {
+template <> inline unsigned char vpImage<unsigned char>::getValue(double i, double j) const {
     const int precision = 65536;
     int64_t y = (int64_t)(i * precision);
     int64_t x = (int64_t)(j * precision);

--- a/modules/core/test/image/testImageGetValue.cpp
+++ b/modules/core/test/image/testImageGetValue.cpp
@@ -1,0 +1,312 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test for vpImagePoint::getValue().
+ *
+ *****************************************************************************/
+ /*!
+   \example testImageGetValue.cpp
+
+   \brief Test for vpImagePoint::getValue().
+ */
+
+#include <iostream>
+#include <visp3/core/vpImage.h>
+
+namespace
+{
+template<typename PixelType> PixelType checkPixelAccess(unsigned int height, unsigned int width, double v, double u) {
+  vpImage<PixelType> I(height, width);
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth(); j++) {
+      I[i][j] = static_cast<PixelType>(i * I.getWidth() + j);
+    }
+  }
+
+  return I.getValue(v,u);
+}
+
+template<> vpRGBa checkPixelAccess(unsigned int height, unsigned int width, double v, double u) {
+  vpImage<vpRGBa> I(height, width);
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth(); j++) {
+      I[i][j] = vpRGBa(static_cast<unsigned char>(i * I.getWidth() + j),
+                       static_cast<unsigned char>(i * I.getWidth() + j),
+                       static_cast<unsigned char>(i * I.getWidth() + j));
+    }
+  }
+
+  return I.getValue(v,u);
+}
+
+double randomDouble(double a, double b) {
+  double random = (static_cast<double>(rand())) / static_cast<double>(RAND_MAX);
+  double diff = b - a;
+  double r = random * diff;
+  return a + r;
+}
+
+unsigned char randomPixelValue() {
+  const int min = 0, max = 255;
+  return static_cast<unsigned char>((rand() % (max - min + 1) + min));
+}
+
+template <class PixelType> PixelType getValue(const vpImage<PixelType> &I, double i, double j, bool roundValue) {
+  if (i < 0 || j < 0 || i+1 > I.getHeight() || j+1 > I.getWidth()) {
+    throw(vpException(vpImageException::notInTheImage, "Pixel outside of the image"));
+  }
+  if (I.getHeight() * I.getWidth() == 0) {
+    throw vpException(vpImageException::notInitializedError, "Empty image!");
+  }
+
+  unsigned int iround = static_cast<unsigned int>(floor(i));
+  unsigned int jround = static_cast<unsigned int>(floor(j));
+
+  double rratio = i - static_cast<double>(iround);
+  double cratio = j - static_cast<double>(jround);
+
+  double rfrac = 1.0 - rratio;
+  double cfrac = 1.0 - cratio;
+
+  unsigned int iround_1 = (std::min)(I.getHeight() - 1, iround + 1);
+  unsigned int jround_1 = (std::min)(I.getWidth() - 1, jround + 1);
+
+  double value = (static_cast<double>(I[iround][jround]) * rfrac + static_cast<double>(I[iround_1][jround]) * rratio) * cfrac +
+                 (static_cast<double>(I[iround][jround_1]) * rfrac + static_cast<double>(I[iround_1][jround_1]) * rratio) * cratio;
+
+  return static_cast<PixelType>(roundValue ? vpMath::round(value) : value);
+}
+} // namespace
+
+int main() {
+  //Test out of image memory access
+  //vpImage::getValue(double, double)
+  {
+    //unsigned char
+    std::cout << "checkPixelAccess<unsigned char>(3, 4, 2, 3): "
+              << static_cast<unsigned int>(checkPixelAccess<unsigned char>(3, 4, 2, 3)) << std::endl;
+    try {
+      std::cout << "checkPixelAccess<unsigned char>(3, 4, -2, -3): "
+                << static_cast<unsigned int>(checkPixelAccess<unsigned char>(3, 4, -2, -3)) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+    try {
+      std::cout << "checkPixelAccess<unsigned char>(3, 4, 3, 4): "
+                << static_cast<unsigned int>(checkPixelAccess<unsigned char>(3, 4, 3, 4)) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+
+    //vpRGBa
+    std::cout << "checkPixelAccess<vpRGBa>(3, 4, 2, 3): " << checkPixelAccess<vpRGBa>(3, 4, 2, 3) << std::endl;
+    try {
+      std::cout << "checkPixelAccess<vpRGBa>(3, 4, -2, -3): " << checkPixelAccess<vpRGBa>(3, 4, -2, -3) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+    try {
+      std::cout << "checkPixelAccess<vpRGBa>(3, 4, 3, 4): " << checkPixelAccess<vpRGBa>(3, 4, 3, 4) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+
+    //int
+    std::cout << "checkPixelAccess<int>(3, 4, 2, 3): " << checkPixelAccess<int>(3, 4, 2, 3) << std::endl;
+    try {
+      std::cout << "checkPixelAccess<int>(3, 4, -2, -3): " << checkPixelAccess<int>(3, 4, -2, -3) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+    try {
+      std::cout << "checkPixelAccess<int>(3, 4, 3, 4): " << checkPixelAccess<int>(3, 4, 3, 4) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+
+    //double
+    std::cout << "checkPixelAccess<double>(3, 4, 2, 3): " << checkPixelAccess<double>(3, 4, 2, 3) << std::endl;
+    try {
+      std::cout << "checkPixelAccess<double>(3, 4, -2, -3): " << checkPixelAccess<double>(3, 4, -2, -3) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+    try {
+      std::cout << "checkPixelAccess<double>(3, 4, 3, 4): " << checkPixelAccess<double>(3, 4, 3, 4) << std::endl;
+      std::cerr << "Out of image access exception should have been thrown" << std::endl;
+      return EXIT_FAILURE;
+    } catch (...) { std::cout << "\n"; }
+  }
+
+  //Test difference between double bilinear interpolation and fixed-point interpolation
+  srand(0);
+
+  {
+    vpImage<unsigned char> I(480, 640);
+    for (unsigned int i = 0; i < I.getHeight(); i++) {
+      for (unsigned int j = 0; j < I.getWidth(); j++) {
+        I[i][j] = randomPixelValue();
+      }
+    }
+
+    double diff_round = 0.0, diff = 0.0;
+    vpImage<unsigned char> I1(480, 640);
+    for (unsigned int i = 0; i < I.getHeight(); i++) {
+      for (unsigned int j = 0; j < I.getWidth(); j++) {
+        double idx1 = randomDouble(0, I.getHeight() - 1);
+        double idx2 = randomDouble(0, I.getWidth() - 1);
+        unsigned char val1 = I.getValue(idx1, idx2);
+        unsigned char val2 = getValue<unsigned char>(I, idx1, idx2, true);
+        unsigned char val3 = getValue<unsigned char>(I, idx1, idx2, false);
+
+        diff_round += std::fabs(val1 - val2);
+        diff += std::fabs(val1 - val3);
+      }
+    }
+
+    double meanDiffRound = diff_round / I.getSize();
+    double meanDiff = diff / I.getSize();
+    std::cout << "diff_round: " << diff_round << " ; meanDiffRound: " << meanDiffRound << std::endl;
+    std::cout << "diff: " << diff << " ; meanDiff: " << meanDiff << std::endl;
+    const double maxInterpolationErrorDiff = 1.0;
+    if (std::fabs(meanDiffRound) > maxInterpolationErrorDiff) {
+      std::cerr << "Too much pixel difference between fixed-point vpImage::getValue(double, double) and old method."
+                << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  //Test performance double bilinear interpolation + round vs fixed-point interpolation
+  {
+    vpImage<unsigned char> I(1080, 1920);
+    for (unsigned int i = 0; i < I.getHeight(); i++) {
+      for (unsigned int j = 0; j < I.getWidth(); j++) {
+        I[i][j] = randomPixelValue();
+      }
+    }
+
+    std::vector<std::pair<double, double> > indexes;
+    for (int cpt = 0; cpt < 1000000; cpt++) {
+      double idx1 = randomDouble(0, I.getHeight() - 1);
+      double idx2 = randomDouble(0, I.getWidth() - 1);
+      indexes.push_back(std::pair<double, double>(idx1, idx2));
+    }
+
+    int sum1 = 0;
+    double t_optim = vpTime::measureTimeMs();
+    for (size_t cpt = 0; cpt < indexes.size(); cpt++) {
+      double idx1 = indexes[cpt].first;
+      double idx2 = indexes[cpt].second;
+      sum1 += I.getValue(idx1, idx2);
+    }
+    t_optim = vpTime::measureTimeMs() - t_optim;
+    std::cout << "\nFixed-point vpImage::getValue(double, double), sum1: " << sum1 << " in " << t_optim << " ms" << std::endl;
+
+    int sum2 = 0;
+    double t_old = vpTime::measureTimeMs();
+    for (size_t cpt = 0; cpt < indexes.size(); cpt++) {
+      double idx1 = indexes[cpt].first;
+      double idx2 = indexes[cpt].second;
+      sum2 += getValue(I, idx1, idx2, true);
+    }
+    t_old = vpTime::measureTimeMs() - t_old;
+    std::cout << "Old method, sum2: " << sum2 << " in " << t_old << " ms" << std::endl;
+    std::cout << "Speed-up: " << t_old / t_optim << "X" << std::endl;
+  }
+
+  //Test performance double bilinear interpolation + round vs fixed-point interpolation
+  {
+    vpImage<unsigned char> I(1080, 1920);
+    for (unsigned int i = 0; i < I.getHeight(); i++) {
+      for (unsigned int j = 0; j < I.getWidth(); j++) {
+        I[i][j] = randomPixelValue();
+      }
+    }
+
+    std::vector<std::pair<double, double> > indexes;
+    for (int cpt = 0; cpt < 1000000; cpt++) {
+      double idx1 = randomDouble(0, I.getHeight() - 1);
+      double idx2 = randomDouble(0, I.getWidth() - 1);
+      indexes.push_back(std::pair<double, double>(idx1, idx2));
+    }
+
+    int sum1 = 0;
+    double t_optim = vpTime::measureTimeMs();
+    for (size_t cpt = 0; cpt < indexes.size(); cpt++) {
+      double idx1 = indexes[cpt].first;
+      double idx2 = indexes[cpt].second;
+      sum1 += I.getValue(idx1, idx2);
+    }
+    t_optim = vpTime::measureTimeMs() - t_optim;
+    std::cout << "\nFixed-point vpImage::getValue(double, double), sum1: " << sum1 << " in " << t_optim << " ms" << std::endl;
+
+    int sum2 = 0;
+    double t_old = vpTime::measureTimeMs();
+    for (size_t cpt = 0; cpt < indexes.size(); cpt++) {
+      double idx1 = indexes[cpt].first;
+      double idx2 = indexes[cpt].second;
+      sum2 += getValue(I, idx1, idx2, false);
+    }
+    t_old = vpTime::measureTimeMs() - t_old;
+    std::cout << "Old method (without vpMath::round()), sum2: " << sum2 << " in " << t_old << " ms" << std::endl;
+    std::cout << "Speed-up: " << t_old / t_optim << "X" << std::endl;
+  }
+
+  //Check that getValue() still returns correct values
+  {
+    vpImage<unsigned char> I(480, 640);
+    for (unsigned int i = 0; i < I.getHeight(); i++) {
+      for (unsigned int j = 0; j < I.getWidth(); j++) {
+        I[i][j] = randomPixelValue();
+      }
+    }
+
+    vpImage<unsigned char> I_copy(480, 640);
+    for (unsigned int i = 0; i < I_copy.getHeight(); i++) {
+      double y = static_cast<double>(i);
+
+      for (unsigned int j = 0; j < I_copy.getWidth(); j++) {
+        double x = static_cast<double>(j);
+
+        I_copy[i][j] = I.getValue(y, x);
+      }
+    }
+
+    bool same = (I == I_copy);
+    std::cout << "\nCheck that getValue returns correct results for integer coordinates\n(I == I_copy)? " << same << std::endl;
+    if (!same) {
+      std::cerr << "Issue with vpImage::getValue(double, double)!" << std::endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Resolves #521 

Continue work of #516

Improvement when using fixed-point arithmetic is around 1.5X but the old code will round the result whereas the new code will cast the result, otherwise around 1.2X when using cast with both methods.

Difference is around 0.5 pixel difference between old and new method.