### PR TITLE
Fix visp_java brocken build since accepted PR #532

### DIFF
--- a/modules/core/include/visp3/core/vpEigenConversion.h
+++ b/modules/core/include/visp3/core/vpEigenConversion.h
@@ -45,20 +45,9 @@
 namespace vp {
 #ifdef VISP_HAVE_EIGEN3
 /* Eigen to ViSP */
-void eigen2visp(const Eigen::MatrixXd &src, vpMatrix &dst)
-{
-  dst.resize(static_cast<unsigned int>(src.rows()), static_cast<unsigned int>(src.cols()), false, false);
-  Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(&dst.data[0], src.rows(), src.cols()) = src;
-}
+VISP_EXPORT void eigen2visp(const Eigen::MatrixXd &src, vpMatrix &dst);
 
-void eigen2visp(const Eigen::MatrixXd &src, vpHomogeneousMatrix &dst)
-{
-  if (src.rows() != 4 || src.cols() != 4) {
-    throw vpException(vpException::dimensionError, "Input Eigen Matrix must be of size (4,4)!");
-  }
-
-  Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(&dst.data[0], src.rows(), src.cols()) = src;
-}
+VISP_EXPORT void eigen2visp(const Eigen::MatrixXd &src, vpHomogeneousMatrix &dst);
 
 template<typename Type>
 void eigen2visp(const Eigen::Quaternion<Type> &src, vpQuaternionVector &dst)
@@ -72,29 +61,9 @@ void eigen2visp(const Eigen::AngleAxis<Type> &src, vpThetaUVector &dst)
   dst.buildFrom(src.angle() * src.axis()(0), src.angle() * src.axis()(1), src.angle() * src.axis()(2));
 }
 
-void eigen2visp(const Eigen::VectorXd &src, vpColVector &dst)
-{
-  dst.resize(static_cast<unsigned int>(src.rows()));
-#if (VP_VERSION_INT(EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION) < 0x030300)
-  for (Eigen::DenseIndex i = 0; i < src.rows(); i++) {
-#else
-  for (Eigen::Index i = 0; i < src.rows(); i++) {
-#endif
-    dst[static_cast<unsigned int>(i)] = src(i);
-  }
-}
+VISP_EXPORT void eigen2visp(const Eigen::VectorXd &src, vpColVector &dst);
 
-void eigen2visp(const Eigen::RowVectorXd &src, vpRowVector &dst)
-{
-  dst.resize(static_cast<unsigned int>(src.cols()));
-#if (VP_VERSION_INT(EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION) < 0x030300)
-  for (Eigen::DenseIndex i = 0; i < src.cols(); i++) {
-#else
-  for (Eigen::Index i = 0; i < src.cols(); i++) {
-#endif
-    dst[static_cast<unsigned int>(i)] = src(i);
-  }
-}
+VISP_EXPORT void eigen2visp(const Eigen::RowVectorXd &src, vpRowVector &dst);
 
 /* ViSP to Eigen */
 template<typename Derived>
@@ -127,15 +96,9 @@ void visp2eigen(const vpThetaUVector &src, Eigen::AngleAxis<Type> &dst)
   dst.axis()(2) = static_cast<Type>(src.getU()[2]);
 }
 
-void visp2eigen(const vpColVector &src, Eigen::VectorXd &dst)
-{
-  dst = Eigen::VectorXd::Map(src.data, src.size());
-}
+VISP_EXPORT void visp2eigen(const vpColVector &src, Eigen::VectorXd &dst);
 
-void visp2eigen(const vpRowVector &src, Eigen::RowVectorXd &dst)
-{
-  dst = Eigen::RowVectorXd::Map(src.data, src.size());
-}
+VISP_EXPORT void visp2eigen(const vpRowVector &src, Eigen::RowVectorXd &dst);
 #endif
 }
 #endif

--- a/modules/core/src/math/matrix/vpEigenConversion.cpp
+++ b/modules/core/src/math/matrix/vpEigenConversion.cpp
@@ -1,0 +1,91 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * ViSP <--> Eigen conversion.
+ *
+ *****************************************************************************/
+
+
+#include <visp3/core/vpEigenConversion.h>
+
+namespace vp {
+#ifdef VISP_HAVE_EIGEN3
+/* Eigen to ViSP */
+void eigen2visp(const Eigen::MatrixXd &src, vpMatrix &dst)
+{
+  dst.resize(static_cast<unsigned int>(src.rows()), static_cast<unsigned int>(src.cols()), false, false);
+  Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(&dst.data[0], src.rows(), src.cols()) = src;
+}
+
+void eigen2visp(const Eigen::MatrixXd &src, vpHomogeneousMatrix &dst)
+{
+  if (src.rows() != 4 || src.cols() != 4) {
+    throw vpException(vpException::dimensionError, "Input Eigen Matrix must be of size (4,4)!");
+  }
+
+  Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(&dst.data[0], src.rows(), src.cols()) = src;
+}
+
+void eigen2visp(const Eigen::VectorXd &src, vpColVector &dst)
+{
+  dst.resize(static_cast<unsigned int>(src.rows()));
+#if (VP_VERSION_INT(EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION) < 0x030300)
+  for (Eigen::DenseIndex i = 0; i < src.rows(); i++) {
+#else
+  for (Eigen::Index i = 0; i < src.rows(); i++) {
+#endif
+    dst[static_cast<unsigned int>(i)] = src(i);
+  }
+}
+
+void eigen2visp(const Eigen::RowVectorXd &src, vpRowVector &dst)
+{
+  dst.resize(static_cast<unsigned int>(src.cols()));
+#if (VP_VERSION_INT(EIGEN_WORLD_VERSION, EIGEN_MAJOR_VERSION, EIGEN_MINOR_VERSION) < 0x030300)
+  for (Eigen::DenseIndex i = 0; i < src.cols(); i++) {
+#else
+  for (Eigen::Index i = 0; i < src.cols(); i++) {
+#endif
+    dst[static_cast<unsigned int>(i)] = src(i);
+  }
+}
+
+void visp2eigen(const vpColVector &src, Eigen::VectorXd &dst)
+{
+  dst = Eigen::VectorXd::Map(src.data, src.size());
+}
+
+void visp2eigen(const vpRowVector &src, Eigen::RowVectorXd &dst)
+{
+  dst = Eigen::RowVectorXd::Map(src.data, src.size());
+}
+#endif
+}


### PR DESCRIPTION
Follows #532 and commit 5def17b

Create `vpEigenConversion.cpp` file to contain definition of non template `eigen2visp()` and `visp2eigen()` functions.

Otherwise, building `visp_java` module lead to duplicate these functions in `listconverters.cpp.o` and `visp_java.cpp.o`

```
[100%] Linking CXX shared module ../../../lib/libvisp_java321.dylib
duplicate symbol __ZN2vp10eigen2vispERKN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEER19vpHomogeneousMatrix in:
    CMakeFiles/visp_java.dir/__/generator/src/cpp/listconverters.cpp.o
    CMakeFiles/visp_java.dir/__/generator/src/cpp/visp_java.cpp.o
duplicate symbol __ZN2vp10eigen2vispERKN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEER8vpMatrix in:
    CMakeFiles/visp_java.dir/__/generator/src/cpp/listconverters.cpp.o
    CMakeFiles/visp_java.dir/__/generator/src/cpp/visp_java.cpp.o
duplicate symbol __ZN2vp10eigen2vispERKN5Eigen6MatrixIdLi1ELin1ELi1ELi1ELin1EEER11vpRowVector in:
    CMakeFiles/visp_java.dir/__/generator/src/cpp/listconverters.cpp.o
    CMakeFiles/visp_java.dir/__/generator/src/cpp/visp_java.cpp.o
duplicate symbol __ZN2vp10eigen2vispERKN5Eigen6MatrixIdLin1ELi1ELi0ELin1ELi1EEER11vpColVector in:
    CMakeFiles/visp_java.dir/__/generator/src/cpp/listconverters.cpp.o
    CMakeFiles/visp_java.dir/__/generator/src/cpp/visp_java.cpp.o
duplicate symbol __ZN2vp10visp2eigenERK11vpRowVectorRN5Eigen6MatrixIdLi1ELin1ELi1ELi1ELin1EEE in:
    CMakeFiles/visp_java.dir/__/generator/src/cpp/listconverters.cpp.o
    CMakeFiles/visp_java.dir/__/generator/src/cpp/visp_java.cpp.o
duplicate symbol __ZN2vp10visp2eigenERK11vpColVectorRN5Eigen6MatrixIdLin1ELi1ELi0ELin1ELi1EEE in:
    CMakeFiles/visp_java.dir/__/generator/src/cpp/listconverters.cpp.o
    CMakeFiles/visp_java.dir/__/generator/src/cpp/visp_java.cpp.o
ld: 6 duplicate symbols for architecture x86_64
``