### PR TITLE
MBT: add possibility to display the model with another render engine

### DIFF
--- a/modules/tracker/mbt/include/visp3/mbt/vpMbDepthDenseTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbDepthDenseTracker.h
@@ -59,6 +59,11 @@ public:
 
   virtual inline vpColVector getError() const { return m_error_depthDense; }
 
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false);
+
   virtual inline vpColVector getRobustWeights() const { return m_w_depthDense; }
 
   virtual void init(const vpImage<unsigned char> &I);
@@ -116,8 +121,6 @@ public:
 protected:
   //! Set of faces describing the object used only for display with scan line.
   vpMbHiddenFaces<vpMbtPolygon> m_depthDenseHiddenFacesDisplay;
-  //! Dummy image used to compute the visibility
-  vpImage<unsigned char> m_depthDenseI_dummyVisibility;
   //! List of current active (visible and features extracted) faces
   std::vector<vpMbtFaceDepthDense *> m_depthDenseListOfActiveFaces;
   //! Nb features

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
@@ -64,6 +64,11 @@ public:
 
   virtual inline vpColVector getError() const { return m_error_depthNormal; }
 
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false);
+
   virtual inline vpColVector getRobustWeights() const { return m_w_depthNormal; }
 
   virtual void init(const vpImage<unsigned char> &I);
@@ -121,8 +126,6 @@ protected:
   vpMbtFaceDepthNormal::vpFeatureEstimationType m_depthNormalFeatureEstimationMethod;
   //! Set of faces describing the object used only for display with scan line.
   vpMbHiddenFaces<vpMbtPolygon> m_depthNormalHiddenFacesDisplay;
-  //! Dummy image used to compute the visibility
-  vpImage<unsigned char> m_depthNormalI_dummyVisibility;
   //! List of current active (visible and with features extracted) faces
   std::vector<vpMbtFaceDepthNormal *> m_depthNormalListOfActiveFaces;
   //! List of desired features
@@ -143,6 +146,8 @@ protected:
   bool m_depthNormalUseRobust;
   //! (s - s*)
   vpColVector m_error_depthNormal;
+  //! Display features
+  std::vector<std::vector<double> > m_featuresToBeDisplayedDepthNormal;
   //! Interaction matrix
   vpMatrix m_L_depthNormal;
   //! Robust
@@ -163,6 +168,8 @@ protected:
   void computeVVS();
   virtual void computeVVSInit();
   virtual void computeVVSInteractionMatrixAndResidu();
+
+  virtual std::vector<std::vector<double> > getFeaturesForDisplayDepthNormal();
 
   virtual void initCircle(const vpPoint &p1, const vpPoint &p2, const vpPoint &p3, const double radius,
                           const int idFace = 0, const std::string &name = "");

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
@@ -133,7 +133,16 @@ public:
   virtual void display(const std::map<std::string, const vpImage<vpRGBa> *> &mapOfImages,
                        const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
                        const std::map<std::string, vpCameraParameters> &mapOfCameraParameters, const vpColor &col,
-                       const unsigned int thickness = 1, const bool displayFullModel = false);
+                       const unsigned int thickness = 1, const bool displayFullModel = false);  
+
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int, unsigned int,
+                                                               const vpHomogeneousMatrix &,
+                                                               const vpCameraParameters &,
+                                                               const bool =false)
+  {
+    std::cerr << "Not implemented. Deprecated class." << std::endl;
+    return std::vector<std::vector<double> >();
+  }
 
   virtual std::vector<std::string> getCameraNames() const;
 
@@ -386,7 +395,7 @@ protected:
   // Same thing as computeVVS
   using vpMbKltMultiTracker::postTracking;
 
-  virtual void postTracking(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages, const unsigned int lvl);
+  virtual void postTracking(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages);
 
   virtual void reinit(/*const vpImage<unsigned char>& I*/);
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltTracker.h
@@ -260,6 +260,11 @@ public:
 
   virtual inline vpColVector getError() const { return m_error_hybrid; }
 
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false);
+
   virtual inline vpColVector getRobustWeights() const { return m_w_hybrid; }
 
   /*!

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
@@ -132,6 +132,15 @@ public:
                        const std::map<std::string, vpCameraParameters> &mapOfCameraParameters, const vpColor &col,
                        const unsigned int thickness = 1, const bool displayFullModel = false);
 
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int, unsigned int,
+                                                               const vpHomogeneousMatrix &,
+                                                               const vpCameraParameters &,
+                                                               const bool =false)
+  {
+    std::cerr << "Not implemented. Deprecated class." << std::endl;
+    return std::vector<std::vector<double> >();
+  }
+
   virtual std::vector<std::string> getCameraNames() const;
 
   virtual void getCameraParameters(vpCameraParameters &camera) const;

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeTracker.h
@@ -342,6 +342,8 @@ protected:
   vpColVector m_weightedError_edge;
   //! Robust
   vpRobust m_robust_edge;
+  //! Display features
+  std::vector<std::vector<double> > m_featuresToBeDisplayedEdge;
 
 public:
   vpMbEdgeTracker();
@@ -350,14 +352,19 @@ public:
   /** @name Inherited functionalities from vpMbEdgeTracker */
   //@{
 
-  void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
-               const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false);
-  void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
-               const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false);
+  virtual void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                       const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false);
+  virtual void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                       const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false);
 
   void getLline(std::list<vpMbtDistanceLine *> &linesList, const unsigned int level = 0) const;
   void getLcircle(std::list<vpMbtDistanceCircle *> &circlesList, const unsigned int level = 0) const;
   void getLcylinder(std::list<vpMbtDistanceCylinder *> &cylindersList, const unsigned int level = 0) const;
+
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false);
 
   /*!
     Get the moving edge parameters.
@@ -521,9 +528,10 @@ protected:
   virtual void computeVVSWeights();
   using vpMbTracker::computeVVSWeights;
 
-  void displayFeaturesOnImage(const vpImage<unsigned char> &I, const unsigned int lvl);
-  void displayFeaturesOnImage(const vpImage<vpRGBa> &I, const unsigned int lvl);
+  void displayFeaturesOnImage(const vpImage<unsigned char> &I);
+  void displayFeaturesOnImage(const vpImage<vpRGBa> &I);
   void downScale(const unsigned int _scale);
+  virtual std::vector<std::vector<double> > getFeaturesForDisplayEdge();
   virtual void init(const vpImage<unsigned char> &I);
   virtual void initCircle(const vpPoint &p1, const vpPoint &p2, const vpPoint &p3, const double radius,
                           const int idFace = 0, const std::string &name = "");

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -144,6 +144,9 @@ public:
   virtual std::list<vpMbtDistanceKltPoints *> &getFeaturesKlt();
 #endif
 
+  virtual std::vector<std::vector<double> > getFeaturesForDisplay();
+  virtual void getFeaturesForDisplay(std::map<std::string, std::vector<std::vector<double> > > &mapOfFeatures);
+
   virtual double getGoodMovingEdgesRatioThreshold() const;
 
 #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
@@ -173,6 +176,16 @@ public:
   virtual void getLline(std::list<vpMbtDistanceLine *> &linesList, const unsigned int level = 0) const;
   virtual void getLline(const std::string &cameraName, std::list<vpMbtDistanceLine *> &linesList,
                         const unsigned int level = 0) const;
+
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false);
+  virtual void getModelForDisplay(std::map<std::string, std::vector<std::vector<double> > > &mapOfModels,
+                                  unsigned int width, unsigned int height,
+                                  const vpHomogeneousMatrix &cMo,
+                                  const vpCameraParameters &cam,
+                                  const bool displayFullModel=false);
 
   virtual vpMe getMovingEdge() const;
   virtual void getMovingEdge(vpMe &me1, vpMe &me2) const;
@@ -503,6 +516,13 @@ private:
                          const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false);
     virtual void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                          const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false);
+
+    virtual std::vector<std::vector<double> > getFeaturesForDisplay();
+
+    virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                                 const vpHomogeneousMatrix &cMo,
+                                                                 const vpCameraParameters &cam,
+                                                                 const bool displayFullModel=false);
 
     virtual void init(const vpImage<unsigned char> &I);
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbHiddenFaces.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbHiddenFaces.h
@@ -88,7 +88,7 @@ private:
 
   unsigned int setVisiblePrivate(const vpHomogeneousMatrix &cMo, const double &angleAppears,
                                  const double &angleDisappears, bool &changed, bool useOgre = false,
-                                 bool not_used = false, const vpImage<unsigned char> &I = vpImage<unsigned char>(),
+                                 bool not_used = false, unsigned int width=0, unsigned int height=0,
                                  const vpCameraParameters &cam = vpCameraParameters());
 
 public:
@@ -101,7 +101,7 @@ public:
   void addPolygon(PolygonType *p);
 
   bool computeVisibility(const vpHomogeneousMatrix &cMo, const double &angleAppears, const double &angleDisappears,
-                         bool &changed, bool useOgre, bool not_used, const vpImage<unsigned char> &I,
+                         bool &changed, bool useOgre, bool not_used, unsigned int width, unsigned int height,
                          const vpCameraParameters &cam, const vpTranslationVector &cameraPos, unsigned int index);
 
   void computeClippedPolygons(const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam);
@@ -254,16 +254,16 @@ public:
   inline void setOgreShowConfigDialog(const bool showConfigDialog) { ogreShowConfigDialog = showConfigDialog; }
 #endif
 
-  unsigned int setVisible(const vpImage<unsigned char> &I, const vpCameraParameters &cam,
+  unsigned int setVisible(unsigned int width, unsigned int height, const vpCameraParameters &cam,
                           const vpHomogeneousMatrix &cMo, const double &angle, bool &changed);
-  unsigned int setVisible(const vpImage<unsigned char> &I, const vpCameraParameters &cam,
+  unsigned int setVisible(unsigned int width, unsigned int height, const vpCameraParameters &cam,
                           const vpHomogeneousMatrix &cMo, const double &angleAppears, const double &angleDisappears,
                           bool &changed);
   unsigned int setVisible(const vpHomogeneousMatrix &cMo, const double &angleAppears, const double &angleDisappears,
                           bool &changed);
 
 #ifdef VISP_HAVE_OGRE
-  unsigned int setVisibleOgre(const vpImage<unsigned char> &I, const vpCameraParameters &cam,
+  unsigned int setVisibleOgre(unsigned int width, unsigned int height, const vpCameraParameters &cam,
                               const vpHomogeneousMatrix &cMo, const double &angleAppears, const double &angleDisappears,
                               bool &changed);
   unsigned int setVisibleOgre(const vpHomogeneousMatrix &cMo, const double &angleAppears, const double &angleDisappears,
@@ -522,7 +522,7 @@ void vpMbHiddenFaces<PolygonType>::computeScanLineQuery(const vpPoint &a, const 
 template <class PolygonType>
 unsigned int vpMbHiddenFaces<PolygonType>::setVisiblePrivate(const vpHomogeneousMatrix &cMo, const double &angleAppears,
                                                              const double &angleDisappears, bool &changed, bool useOgre,
-                                                             bool not_used, const vpImage<unsigned char> &I,
+                                                             bool not_used, unsigned int width, unsigned int height,
                                                              const vpCameraParameters &cam)
 {
   nbVisiblePolygon = 0;
@@ -541,7 +541,7 @@ unsigned int vpMbHiddenFaces<PolygonType>::setVisiblePrivate(const vpHomogeneous
 
   for (unsigned int i = 0; i < Lpol.size(); i++) {
     // std::cout << "Calling poly: " << i << std::endl;
-    if (computeVisibility(cMo, angleAppears, angleDisappears, changed, useOgre, not_used, I, cam, cameraPos, i))
+    if (computeVisibility(cMo, angleAppears, angleDisappears, changed, useOgre, not_used, width, height, cam, cameraPos, i))
       nbVisiblePolygon++;
   }
   return nbVisiblePolygon;
@@ -568,7 +568,7 @@ unsigned int vpMbHiddenFaces<PolygonType>::setVisiblePrivate(const vpHomogeneous
 template <class PolygonType>
 bool vpMbHiddenFaces<PolygonType>::computeVisibility(const vpHomogeneousMatrix &cMo, const double &angleAppears,
                                                      const double &angleDisappears, bool &changed, bool useOgre,
-                                                     bool not_used, const vpImage<unsigned char> &I,
+                                                     bool not_used, unsigned int width, unsigned int height,
                                                      const vpCameraParameters &cam,
                                                      const vpTranslationVector &cameraPos, unsigned int index)
 {
@@ -591,15 +591,15 @@ bool vpMbHiddenFaces<PolygonType>::computeVisibility(const vpHomogeneousMatrix &
       if (!testDisappear) {
         if (useOgre)
 #ifdef VISP_HAVE_OGRE
-          testDisappear = ((!Lpol[i]->isVisible(cMo, angleDisappears, true, cam, I)) || !isVisibleOgre(cameraPos, i));
+          testDisappear = ((!Lpol[i]->isVisible(cMo, angleDisappears, true, cam, width, height)) || !isVisibleOgre(cameraPos, i));
 #else
         {
           (void)cameraPos; // Avoid warning
-          testDisappear = (!Lpol[i]->isVisible(cMo, angleDisappears, false, cam, I));
+          testDisappear = (!Lpol[i]->isVisible(cMo, angleDisappears, false, cam, width, height));
         }
 #endif
         else
-          testDisappear = (!Lpol[i]->isVisible(cMo, angleDisappears, false, cam, I));
+          testDisappear = (!Lpol[i]->isVisible(cMo, angleDisappears, false, cam, width, height));
       }
 
       // test if the face is still visible
@@ -621,12 +621,12 @@ bool vpMbHiddenFaces<PolygonType>::computeVisibility(const vpHomogeneousMatrix &
       if (testAppear) {
         if (useOgre)
 #ifdef VISP_HAVE_OGRE
-          testAppear = ((Lpol[i]->isVisible(cMo, angleAppears, true, cam, I)) && isVisibleOgre(cameraPos, i));
+          testAppear = ((Lpol[i]->isVisible(cMo, angleAppears, true, cam, width, height)) && isVisibleOgre(cameraPos, i));
 #else
-          testAppear = (Lpol[i]->isVisible(cMo, angleAppears, false, cam, I));
+          testAppear = (Lpol[i]->isVisible(cMo, angleAppears, false, cam, width, height));
 #endif
         else
-          testAppear = (Lpol[i]->isVisible(cMo, angleAppears, false, cam, I));
+          testAppear = (Lpol[i]->isVisible(cMo, angleAppears, false, cam, width, height));
       }
 
       if (testAppear) {
@@ -657,11 +657,11 @@ bool vpMbHiddenFaces<PolygonType>::computeVisibility(const vpHomogeneousMatrix &
   \return Return the number of visible polygons
 */
 template <class PolygonType>
-unsigned int vpMbHiddenFaces<PolygonType>::setVisible(const vpImage<unsigned char> &I, const vpCameraParameters &cam,
+unsigned int vpMbHiddenFaces<PolygonType>::setVisible(unsigned int width, unsigned int height, const vpCameraParameters &cam,
                                                       const vpHomogeneousMatrix &cMo, const double &angle,
                                                       bool &changed)
 {
-  return setVisible(I, cam, cMo, angle, angle, changed);
+  return setVisible(width, height, cam, cMo, angle, angle, changed);
 }
 
 /*!
@@ -677,11 +677,11 @@ unsigned int vpMbHiddenFaces<PolygonType>::setVisible(const vpImage<unsigned cha
   \return Return the number of visible polygons
 */
 template <class PolygonType>
-unsigned int vpMbHiddenFaces<PolygonType>::setVisible(const vpImage<unsigned char> &I, const vpCameraParameters &cam,
+unsigned int vpMbHiddenFaces<PolygonType>::setVisible(unsigned int width, unsigned int height, const vpCameraParameters &cam,
                                                       const vpHomogeneousMatrix &cMo, const double &angleAppears,
                                                       const double &angleDisappears, bool &changed)
 {
-  return setVisiblePrivate(cMo, angleAppears, angleDisappears, changed, false, true, I, cam);
+  return setVisiblePrivate(cMo, angleAppears, angleDisappears, changed, false, true, width, height, cam);
 }
 
 /*!
@@ -766,12 +766,12 @@ template <class PolygonType> void vpMbHiddenFaces<PolygonType>::displayOgre(cons
   \return Return the number of visible polygons
 */
 template <class PolygonType>
-unsigned int vpMbHiddenFaces<PolygonType>::setVisibleOgre(const vpImage<unsigned char> &I,
+unsigned int vpMbHiddenFaces<PolygonType>::setVisibleOgre(unsigned int width, unsigned int height,
                                                           const vpCameraParameters &cam, const vpHomogeneousMatrix &cMo,
                                                           const double &angleAppears, const double &angleDisappears,
                                                           bool &changed)
 {
-  return setVisiblePrivate(cMo, angleAppears, angleDisappears, changed, true, true, I, cam);
+  return setVisiblePrivate(cMo, angleAppears, angleDisappears, changed, true, true, width, height, cam);
 }
 
 /*!

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbKltMultiTracker.h
@@ -130,6 +130,15 @@ public:
                        const std::map<std::string, vpCameraParameters> &mapOfCameraParameters, const vpColor &col,
                        const unsigned int thickness = 1, const bool displayFullModel = false);
 
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int, unsigned int,
+                                                               const vpHomogeneousMatrix &,
+                                                               const vpCameraParameters &,
+                                                               const bool =false)
+  {
+    std::cerr << "Not implemented. Deprecated class." << std::endl;
+    return std::vector<std::vector<double> >();
+  }
+
   virtual std::vector<std::string> getCameraNames() const;
 
   virtual void getCameraParameters(vpCameraParameters &camera) const;

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbKltTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbKltTracker.h
@@ -279,6 +279,8 @@ protected:
   vpColVector m_weightedError_klt;
   //! Robust
   vpRobust m_robust_klt;
+  //! Display features
+  std::vector<std::vector<double> > m_featuresToBeDisplayedKlt;
 
 public:
   vpMbKltTracker();
@@ -347,6 +349,11 @@ public:
   virtual inline vpColVector getError() const { return m_error_klt; }
 
   virtual inline vpColVector getRobustWeights() const { return m_w_klt; }
+
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false);
 
   virtual void loadConfigFile(const std::string &configFile);
 
@@ -486,6 +493,8 @@ protected:
   void computeVVS();
   virtual void computeVVSInit();
   virtual void computeVVSInteractionMatrixAndResidu();
+
+  virtual std::vector<std::vector<double> > getFeaturesForDisplayKlt();
 
   virtual void init(const vpImage<unsigned char> &I);
   virtual void initFaceFromCorners(vpMbtPolygon &polygon);

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
@@ -687,6 +687,11 @@ public:
   virtual void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                        const vpColor &col, const unsigned int thickness = 1, const bool displayFullModel = false) = 0;
 
+  virtual std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                               const vpHomogeneousMatrix &cMo,
+                                                               const vpCameraParameters &cam,
+                                                               const bool displayFullModel=false)=0;
+
   /*!
     Initialise the tracking.
 
@@ -894,7 +899,7 @@ protected:
 
   void projectionErrorInitMovingEdge(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &_cMo);
   void projectionErrorResetMovingEdges();
-  void projectionErrorVisibleFace(const vpImage<unsigned char> &_I, const vpHomogeneousMatrix &_cMo);
+  void projectionErrorVisibleFace(unsigned int width, unsigned int height, const vpHomogeneousMatrix &_cMo);
 
   void removeComment(std::ifstream &fileId);
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCircle.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCircle.h
@@ -160,6 +160,12 @@ public:
   */
   inline double getMeanWeight() const { return wmean; }
 
+  std::vector<std::vector<double> > getFeaturesForDisplay();
+
+  std::vector<double> getModelForDisplay(const vpHomogeneousMatrix &cMo,
+                                         const vpCameraParameters &cam,
+                                         const bool displayFullModel = false);
+
   /*!
     Get the name of the circle.
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCylinder.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCylinder.h
@@ -183,6 +183,13 @@ public:
   */
   inline double getMeanWeight2() const { return wmean2; }
 
+  std::vector<std::vector<double> > getFeaturesForDisplay();
+
+  std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                       const vpHomogeneousMatrix &cMo,
+                                                       const vpCameraParameters &cam,
+                                                       const bool displayFullModel = false);
+
   /*!
     Get the name of the cylinder.
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltCylinder.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltCylinder.h
@@ -182,6 +182,10 @@ public:
   */
   inline unsigned int getCurrentNumberPoints() const { return nbPointsCur; }
 
+  std::vector<std::vector<double> > getFeaturesForDisplay();
+
+  std::vector<std::vector<double> > getModelForDisplay(const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam);
+
   inline bool hasEnoughPoints() const { return enoughPoints; }
 
   /*!

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltPoints.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltPoints.h
@@ -149,6 +149,11 @@ public:
   void displayPrimitive(const vpImage<unsigned char> &_I);
   void displayPrimitive(const vpImage<vpRGBa> &_I);
 
+  std::vector<std::vector<double> > getFeaturesForDisplay();
+
+  std::vector<std::vector<double> > getModelForDisplay(const vpCameraParameters &cam,
+                                                       const bool displayFullModel = false);
+
   /*!
     Get the camera parameters of the face.
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceLine.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceLine.h
@@ -170,6 +170,13 @@ public:
   */
   inline double getMeanWeight() const { return wmean; }
 
+  std::vector<std::vector<double> > getFeaturesForDisplay();
+
+  std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                       const vpHomogeneousMatrix &cMo,
+                                                       const vpCameraParameters &cam,
+                                                       const bool displayFullModel = false);
+
   /*!
     Get the name of the line.
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthDense.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthDense.h
@@ -123,6 +123,11 @@ public:
   void displayFeature(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                       const double scale = 0.05, const unsigned int thickness = 1);
 
+  std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                       const vpHomogeneousMatrix &cMo,
+                                                       const vpCameraParameters &cam,
+                                                       const bool displayFullModel = false);
+
   inline unsigned int getNbFeatures() const { return (unsigned int)(m_pointCloudFace.size() / 3); }
 
   inline bool isTracked() const { return m_isTrackedDepthDenseFace; }

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
@@ -134,6 +134,14 @@ public:
   void displayFeature(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                       const double scale = 0.05, const unsigned int thickness = 1);
 
+  std::vector<std::vector<double> > getFeaturesForDisplay(const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                                                          const double scale = 0.05);
+
+  std::vector<std::vector<double> > getModelForDisplay(unsigned int width, unsigned int height,
+                                                       const vpHomogeneousMatrix &cMo,
+                                                       const vpCameraParameters &cam,
+                                                       const bool displayFullModel = false);
+
   inline bool isTracked() const { return m_isTrackedDepthNormalFace; }
 
   inline bool isVisible() const { return m_polygon->isvisible; }

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtPolygon.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtPolygon.h
@@ -111,7 +111,7 @@ public:
   inline bool isPolygonOriented() { return hasOrientation; }
   virtual bool isVisible(const vpHomogeneousMatrix &cMo, const double alpha, const bool &modulo = false,
                          const vpCameraParameters &cam = vpCameraParameters(),
-                         const vpImage<unsigned char> &I = vpImage<unsigned char>());
+                         unsigned int width=0, unsigned int height=0);
   bool isVisible() const { return isvisible; }
 
   vpMbtPolygon &operator=(const vpMbtPolygon &mbtp);

--- a/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
@@ -54,11 +54,11 @@
 
 vpMbDepthNormalTracker::vpMbDepthNormalTracker()
   : m_depthNormalFeatureEstimationMethod(vpMbtFaceDepthNormal::ROBUST_FEATURE_ESTIMATION),
-    m_depthNormalHiddenFacesDisplay(), m_depthNormalI_dummyVisibility(), m_depthNormalListOfActiveFaces(),
+    m_depthNormalHiddenFacesDisplay(), m_depthNormalListOfActiveFaces(),
     m_depthNormalListOfDesiredFeatures(), m_depthNormalFaces(), m_depthNormalPclPlaneEstimationMethod(2),
     m_depthNormalPclPlaneEstimationRansacMaxIter(200), m_depthNormalPclPlaneEstimationRansacThreshold(0.001),
     m_depthNormalSamplingStepX(2), m_depthNormalSamplingStepY(2), m_depthNormalUseRobust(false), m_error_depthNormal(),
-    m_L_depthNormal(), m_robust_depthNormal(), m_w_depthNormal(), m_weightedError_depthNormal()
+    m_featuresToBeDisplayedDepthNormal(), m_L_depthNormal(), m_robust_depthNormal(), m_w_depthNormal(), m_weightedError_depthNormal()
 #if DEBUG_DISPLAY_DEPTH_NORMAL
     ,
     m_debugDisp_depthNormal(NULL), m_debugImage_depthNormal()
@@ -131,20 +131,16 @@ void vpMbDepthNormalTracker::addFace(vpMbtPolygon &polygon, const bool alreadyCl
 
 void vpMbDepthNormalTracker::computeVisibility(const unsigned int width, const unsigned int height)
 {
-  m_depthNormalI_dummyVisibility.resize(height, width);
-
   bool changed = false;
-  faces.setVisible(m_depthNormalI_dummyVisibility, cam, cMo, angleAppears, angleDisappears, changed);
+  faces.setVisible(width, height, cam, cMo, angleAppears, angleDisappears, changed);
 
   if (useScanLine) {
     //    if (clippingFlag <= 2) {
-    //      cam.computeFov(m_depthNormalI_dummyVisibility.getWidth(),
-    //      m_depthNormalI_dummyVisibility.getHeight());
+    //      cam.computeFov(width, height);
     //    }
 
     faces.computeClippedPolygons(cMo, cam);
-    faces.computeScanLineRender(cam, m_depthNormalI_dummyVisibility.getWidth(),
-                                m_depthNormalI_dummyVisibility.getHeight());
+    faces.computeScanLineRender(cam, width, height);
   }
 
   for (std::vector<vpMbtFaceDepthNormal *>::const_iterator it = m_depthNormalFaces.begin();
@@ -287,25 +283,23 @@ void vpMbDepthNormalTracker::display(const vpImage<unsigned char> &I, const vpHo
                                      const vpCameraParameters &cam_, const vpColor &col, const unsigned int thickness,
                                      const bool displayFullModel)
 {
-  vpCameraParameters c = cam_;
+  std::vector<std::vector<double> > models = vpMbDepthNormalTracker::getModelForDisplay(I.getWidth(), I.getHeight(), cMo_, cam_, displayFullModel);
 
-  bool changed = false;
-  m_depthNormalHiddenFacesDisplay.setVisible(I, c, cMo_, angleAppears, angleDisappears, changed);
-
-  if (useScanLine) {
-    c.computeFov(I.getWidth(), I.getHeight());
-
-    m_depthNormalHiddenFacesDisplay.computeClippedPolygons(cMo_, c);
-    m_depthNormalHiddenFacesDisplay.computeScanLineRender(c, I.getWidth(), I.getHeight());
+  for (size_t i = 0; i < models.size(); i++) {
+    if (vpMath::equal(models[i][0], 0)) {
+      vpImagePoint ip1(models[i][1], models[i][2]);
+      vpImagePoint ip2(models[i][3], models[i][4]);
+      vpDisplay::displayLine(I, ip1, ip2, col, thickness);
+    }
   }
 
-  for (std::vector<vpMbtFaceDepthNormal *>::const_iterator it = m_depthNormalFaces.begin();
-       it != m_depthNormalFaces.end(); ++it) {
-    vpMbtFaceDepthNormal *face_normal = *it;
-    face_normal->display(I, cMo_, c, col, thickness, displayFullModel);
-
-    if (displayFeatures) {
-      face_normal->displayFeature(I, cMo_, c, 0.05, thickness);
+  if (displayFeatures) {
+    std::vector<std::vector<double> > features = getFeaturesForDisplayDepthNormal();
+    for (size_t i = 0; i < features.size(); i++) {
+      vpImagePoint im_centroid(features[i][1], features[i][2]);
+      vpImagePoint im_extremity(features[i][3], features[i][4]);
+      bool desired = vpMath::equal(features[i][0], 2);
+      vpDisplay::displayArrow(I, im_centroid, im_extremity, desired ? vpColor::blue : vpColor::red, 4, 2, thickness);
     }
   }
 }
@@ -314,29 +308,80 @@ void vpMbDepthNormalTracker::display(const vpImage<vpRGBa> &I, const vpHomogeneo
                                      const vpCameraParameters &cam_, const vpColor &col, const unsigned int thickness,
                                      const bool displayFullModel)
 {
+  std::vector<std::vector<double> > models = vpMbDepthNormalTracker::getModelForDisplay(I.getWidth(), I.getHeight(), cMo_, cam_, displayFullModel);
+
+  for (size_t i = 0; i < models.size(); i++) {
+    if (vpMath::equal(models[i][0], 0)) {
+      vpImagePoint ip1(models[i][1], models[i][2]);
+      vpImagePoint ip2(models[i][3], models[i][4]);
+      vpDisplay::displayLine(I, ip1, ip2, col, thickness);
+    }
+  }
+
+  if (displayFeatures) {
+    std::vector<std::vector<double> > features = getFeaturesForDisplayDepthNormal();
+    for (size_t i = 0; i < features.size(); i++) {
+      vpImagePoint im_centroid(features[i][1], features[i][2]);
+      vpImagePoint im_extremity(features[i][3], features[i][4]);
+      bool desired = vpMath::equal(features[i][0], 2);
+      vpDisplay::displayArrow(I, im_centroid, im_extremity, desired ? vpColor::blue : vpColor::red, 4, 2, thickness);
+    }
+  }
+}
+
+std::vector<std::vector<double> > vpMbDepthNormalTracker::getFeaturesForDisplayDepthNormal() {
+  std::vector<std::vector<double> > features;
+
+  for (std::vector<vpMbtFaceDepthNormal *>::const_iterator it = m_depthNormalFaces.begin();
+       it != m_depthNormalFaces.end(); ++it) {
+    vpMbtFaceDepthNormal *face_normal = *it;
+    std::vector<std::vector<double> > currentFeatures = face_normal->getFeaturesForDisplay(cMo, cam);
+    features.insert(features.end(), currentFeatures.begin(), currentFeatures.end());
+  }
+
+  return features;
+}
+
+/*!
+  Return a list of primitives parameters to display the model at a given pose and camera parameters.
+  Line parameters are: <primitive id (here 0 for line)>, <pt_start.i()>, <pt_start.j()>
+                       <pt_end.i()>, <pt_end.j()>
+  Ellipse parameters are: <primitive id (here 1 for ellipse)>, <pt_center.i()>, <pt_center.j()>
+                          <mu20>, <mu11>, <mu02>
+
+  \param width : Image width.
+  \param height : Image height.
+  \param cMo_ : Pose used to project the 3D model into the image.
+  \param cam_ : The camera parameters.
+  \param displayFullModel : If true, the line is displayed even if it is not
+*/
+std::vector<std::vector<double> > vpMbDepthNormalTracker::getModelForDisplay(unsigned int width, unsigned int height,
+                                                                             const vpHomogeneousMatrix &cMo_,
+                                                                             const vpCameraParameters &cam_,
+                                                                             const bool displayFullModel)
+{
+  std::vector<std::vector<double> > models;
+
   vpCameraParameters c = cam_;
 
   bool changed = false;
-  vpImage<unsigned char> I_dummy;
-  vpImageConvert::convert(I, I_dummy);
-  m_depthNormalHiddenFacesDisplay.setVisible(I_dummy, c, cMo_, angleAppears, angleDisappears, changed);
+  m_depthNormalHiddenFacesDisplay.setVisible(width, height, c, cMo_, angleAppears, angleDisappears, changed);
 
   if (useScanLine) {
-    c.computeFov(I.getWidth(), I.getHeight());
+    c.computeFov(width, height);
 
     m_depthNormalHiddenFacesDisplay.computeClippedPolygons(cMo_, c);
-    m_depthNormalHiddenFacesDisplay.computeScanLineRender(c, I.getWidth(), I.getHeight());
+    m_depthNormalHiddenFacesDisplay.computeScanLineRender(c, width, height);
   }
 
   for (std::vector<vpMbtFaceDepthNormal *>::const_iterator it = m_depthNormalFaces.begin();
        it != m_depthNormalFaces.end(); ++it) {
     vpMbtFaceDepthNormal *face_normal = *it;
-    face_normal->display(I, cMo_, c, col, thickness, displayFullModel);
-
-    if (displayFeatures) {
-      face_normal->displayFeature(I, cMo_, c, 0.05, thickness);
-    }
+    std::vector<std::vector<double> > modelLines = face_normal->getModelForDisplay(width, height, cMo_, cam_, displayFullModel);
+    models.insert(models.end(), modelLines.begin(), modelLines.end());
   }
+
+  return models;
 }
 
 void vpMbDepthNormalTracker::init(const vpImage<unsigned char> &I)
@@ -347,7 +392,7 @@ void vpMbDepthNormalTracker::init(const vpImage<unsigned char> &I)
 
   bool reInitialisation = false;
   if (!useOgre) {
-    faces.setVisible(I, cam, cMo, angleAppears, angleDisappears, reInitialisation);
+    faces.setVisible(I.getWidth(), I.getHeight(), cam, cMo, angleAppears, angleDisappears, reInitialisation);
   } else {
 #ifdef VISP_HAVE_OGRE
     if (!faces.isOgreInitialised()) {
@@ -360,9 +405,9 @@ void vpMbDepthNormalTracker::init(const vpImage<unsigned char> &I)
       ogreShowConfigDialog = false;
     }
 
-    faces.setVisibleOgre(I, cam, cMo, angleAppears, angleDisappears, reInitialisation);
+    faces.setVisibleOgre(I.getWidth(), I.getHeight(), cam, cMo, angleAppears, angleDisappears, reInitialisation);
 #else
-    faces.setVisible(I, cam, cMo, angleAppears, angleDisappears, reInitialisation);
+    faces.setVisible(I.getWidth(), I.getHeight(), cam, cMo, angleAppears, angleDisappears, reInitialisation);
 #endif
   }
 

--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthDense.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthDense.cpp
@@ -686,14 +686,12 @@ void vpMbtFaceDepthDense::display(const vpImage<unsigned char> &I, const vpHomog
                                   const vpCameraParameters &cam, const vpColor &col, const unsigned int thickness,
                                   const bool displayFullModel)
 {
-  if ((m_polygon->isVisible() && m_isTrackedDepthDenseFace) || displayFullModel) {
-    computeVisibilityDisplay();
+  std::vector<std::vector<double> > models = getModelForDisplay(I.getWidth(), I.getHeight(), cMo, cam, displayFullModel);
 
-    for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_listOfFaceLines.begin(); it != m_listOfFaceLines.end();
-         ++it) {
-      vpMbtDistanceLine *line = *it;
-      line->display(I, cMo, cam, col, thickness, displayFullModel);
-    }
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -701,14 +699,12 @@ void vpMbtFaceDepthDense::display(const vpImage<vpRGBa> &I, const vpHomogeneousM
                                   const vpCameraParameters &cam, const vpColor &col, const unsigned int thickness,
                                   const bool displayFullModel)
 {
-  if ((m_polygon->isVisible() && m_isTrackedDepthDenseFace) || displayFullModel) {
-    computeVisibilityDisplay();
+  std::vector<std::vector<double> > models = getModelForDisplay(I.getWidth(), I.getHeight(), cMo, cam, displayFullModel);
 
-    for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_listOfFaceLines.begin(); it != m_listOfFaceLines.end();
-         ++it) {
-      vpMbtDistanceLine *line = *it;
-      line->display(I, cMo, cam, col, thickness, displayFullModel);
-    }
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -722,6 +718,38 @@ void vpMbtFaceDepthDense::displayFeature(const vpImage<vpRGBa> & /*I*/, const vp
                                          const vpCameraParameters & /*cam*/, const double /*scale*/,
                                          const unsigned int /*thickness*/)
 {
+}
+
+/*!
+  Return a list of line parameters to display the primitive at a given pose and camera parameters.
+  Parameters are: <primitive id (here 0 for line)>, <pt_start.i()>, <pt_start.j()>
+                  <pt_end.i()>, <pt_end.j()>
+
+  \param width : Image width.
+  \param height : Image height.
+  \param cMo : Pose used to project the 3D model into the image.
+  \param cam : The camera parameters.
+  \param displayFullModel : If true, the line is displayed even if it is not
+*/
+std::vector<std::vector<double> > vpMbtFaceDepthDense::getModelForDisplay(unsigned int width, unsigned int height,
+                                                                          const vpHomogeneousMatrix &cMo,
+                                                                          const vpCameraParameters &cam,
+                                                                          const bool displayFullModel)
+{
+  std::vector<std::vector<double> > models;
+
+  if ((m_polygon->isVisible() && m_isTrackedDepthDenseFace) || displayFullModel) {
+    computeVisibilityDisplay();
+
+    for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_listOfFaceLines.begin(); it != m_listOfFaceLines.end();
+         ++it) {
+      vpMbtDistanceLine *line = *it;
+      std::vector<std::vector<double> > lineModels = line->getModelForDisplay(width, height, cMo, cam, displayFullModel);
+      models.insert(models.end(), lineModels.begin(), lineModels.end());
+    }
+  }
+
+  return models;
 }
 
 /*!

--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
@@ -902,14 +902,12 @@ void vpMbtFaceDepthNormal::display(const vpImage<unsigned char> &I, const vpHomo
                                    const vpCameraParameters &cam, const vpColor &col, const unsigned int thickness,
                                    const bool displayFullModel)
 {
-  if ((m_polygon->isVisible() && m_isTrackedDepthNormalFace) || displayFullModel) {
-    computeVisibilityDisplay();
+  std::vector<std::vector<double> > models = getModelForDisplay(I.getWidth(), I.getHeight(), cMo, cam, displayFullModel);
 
-    for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_listOfFaceLines.begin(); it != m_listOfFaceLines.end();
-         ++it) {
-      vpMbtDistanceLine *line = *it;
-      line->display(I, cMo, cam, col, thickness, displayFullModel);
-    }
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -917,14 +915,12 @@ void vpMbtFaceDepthNormal::display(const vpImage<vpRGBa> &I, const vpHomogeneous
                                    const vpCameraParameters &cam, const vpColor &col, const unsigned int thickness,
                                    const bool displayFullModel)
 {
-  if ((m_polygon->isVisible() && m_isTrackedDepthNormalFace) || displayFullModel) {
-    computeVisibilityDisplay();
+  std::vector<std::vector<double> > models = getModelForDisplay(I.getWidth(), I.getHeight(), cMo, cam, displayFullModel);
 
-    for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_listOfFaceLines.begin(); it != m_listOfFaceLines.end();
-         ++it) {
-      vpMbtDistanceLine *line = *it;
-      line->display(I, cMo, cam, col, thickness, displayFullModel);
-    }
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -1482,6 +1478,115 @@ void vpMbtFaceDepthNormal::estimatePlaneEquationSVD(const std::vector<double> &p
   plane_equation_estimated[1] = B;
   plane_equation_estimated[2] = C;
   plane_equation_estimated[3] = D;
+}
+
+/*!
+  Return a list of features parameters for display.
+  Parameters are: <feature id (here 2 for depth normal)>, <centroid.i()>, <centroid.j()>,
+                  <extremity.i()>, extremity.j()
+*/
+std::vector<std::vector<double> > vpMbtFaceDepthNormal::getFeaturesForDisplay(const vpHomogeneousMatrix &cMo,
+                                                                              const vpCameraParameters &cam,
+                                                                              const double scale)
+{
+  std::vector<std::vector<double> > features;
+
+  if (m_faceActivated && m_isTrackedDepthNormalFace && m_isVisible) {
+    // Desired feature
+    vpPoint pt_centroid = m_faceDesiredCentroid;
+    pt_centroid.changeFrame(cMo);
+    pt_centroid.project();
+
+    vpImagePoint im_centroid;
+    vpMeterPixelConversion::convertPoint(cam, pt_centroid.get_x(), pt_centroid.get_y(), im_centroid);
+
+    vpPoint pt_normal = m_faceDesiredNormal;
+    pt_normal.changeFrame(cMo);
+    pt_normal.project();
+
+    vpPoint pt_extremity;
+    pt_extremity.set_X(pt_centroid.get_X() + pt_normal.get_X() * scale);
+    pt_extremity.set_Y(pt_centroid.get_Y() + pt_normal.get_Y() * scale);
+    pt_extremity.set_Z(pt_centroid.get_Z() + pt_normal.get_Z() * scale);
+    pt_extremity.project();
+
+    vpImagePoint im_extremity;
+    vpMeterPixelConversion::convertPoint(cam, pt_extremity.get_x(), pt_extremity.get_y(), im_extremity);
+
+    {
+      std::vector<double> params = {2, //desired normal
+                                    im_centroid.get_i(),
+                                    im_centroid.get_j(),
+                                    im_extremity.get_i(),
+                                    im_extremity.get_j()};
+      features.push_back(params);
+    }
+
+    // Current feature
+    // Transform the plane equation for the current pose
+    m_planeCamera = m_planeObject;
+    m_planeCamera.changeFrame(cMo);
+
+    double ux = m_planeCamera.getA();
+    double uy = m_planeCamera.getB();
+    double uz = m_planeCamera.getC();
+
+    vpColVector correct_normal;
+    computeNormalVisibility(ux, uy, uz, cMo, cam, correct_normal, pt_centroid);
+
+    pt_centroid.project();
+    vpMeterPixelConversion::convertPoint(cam, pt_centroid.get_x(), pt_centroid.get_y(), im_centroid);
+
+    pt_extremity.set_X(pt_centroid.get_X() + correct_normal[0] * scale);
+    pt_extremity.set_Y(pt_centroid.get_Y() + correct_normal[1] * scale);
+    pt_extremity.set_Z(pt_centroid.get_Z() + correct_normal[2] * scale);
+    pt_extremity.project();
+
+    vpMeterPixelConversion::convertPoint(cam, pt_extremity.get_x(), pt_extremity.get_y(), im_extremity);
+
+    {
+      std::vector<double> params = {3, //normal at current pose
+                                    im_centroid.get_i(),
+                                    im_centroid.get_j(),
+                                    im_extremity.get_i(),
+                                    im_extremity.get_j()};
+      features.push_back(params);
+    }
+  }
+
+  return features;
+}
+
+/*!
+  Return a list of line parameters to display the primitive at a given pose and camera parameters.
+  Parameters are: <primitive id (here 0 for line)>, <pt_start.i()>, <pt_start.j()>
+                  <pt_end.i()>, <pt_end.j()>
+
+  \param width : Image width.
+  \param height : Image height.
+  \param cMo : Pose used to project the 3D model into the image.
+  \param cam : The camera parameters.
+  \param displayFullModel : If true, the line is displayed even if it is not
+*/
+std::vector<std::vector<double> > vpMbtFaceDepthNormal::getModelForDisplay(unsigned int width, unsigned int height,
+                                                                           const vpHomogeneousMatrix &cMo,
+                                                                           const vpCameraParameters &cam,
+                                                                           const bool displayFullModel)
+{
+  std::vector<std::vector<double> > models;
+
+  if ((m_polygon->isVisible() && m_isTrackedDepthNormalFace) || displayFullModel) {
+    computeVisibilityDisplay();
+
+    for (std::vector<vpMbtDistanceLine *>::const_iterator it = m_listOfFaceLines.begin(); it != m_listOfFaceLines.end();
+         ++it) {
+      vpMbtDistanceLine *line = *it;
+      std::vector<std::vector<double> > lineModels = line->getModelForDisplay(width, height, cMo, cam, displayFullModel);
+      models.insert(models.end(), lineModels.begin(), lineModels.end());
+    }
+  }
+
+  return models;
 }
 
 /*!

--- a/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
@@ -3074,7 +3074,7 @@ void vpMbEdgeMultiTracker::track(std::map<std::string, const vpImage<unsigned ch
         if (displayFeatures) {
           for (std::map<std::string, vpMbEdgeTracker *>::const_iterator it = m_mapOfEdgeTrackers.begin();
                it != m_mapOfEdgeTrackers.end(); ++it) {
-            it->second->displayFeaturesOnImage(*mapOfImages[it->first], lvl);
+            it->second->m_featuresToBeDisplayedEdge = it->second->getFeaturesForDisplayEdge();
           }
         }
 

--- a/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtDistanceLine.cpp
@@ -614,42 +614,13 @@ void vpMbtDistanceLine::display(const vpImage<unsigned char> &I, const vpHomogen
                                 const vpCameraParameters &camera, const vpColor &col, const unsigned int thickness,
                                 const bool displayFullModel)
 {
-  if ((isvisible && isTrackedLine) || displayFullModel) {
-    p1->changeFrame(cMo);
-    p2->changeFrame(cMo);
+  std::vector<std::vector<double> > models =
+      getModelForDisplay(I.getWidth(), I.getHeight(), cMo, camera, displayFullModel);
 
-    vpImagePoint ip1, ip2;
-    vpCameraParameters c = camera;
-    if (poly.getClipping() > 3) // Contains at least one FOV constraint
-      c.computeFov(I.getWidth(), I.getHeight());
-
-    poly.computePolygonClipped(c);
-
-    if (poly.polyClipped.size() == 2 &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::NEAR_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::FAR_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::DOWN_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::UP_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::LEFT_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::RIGHT_CLIPPING) == 0)) {
-
-      std::vector<std::pair<vpPoint, vpPoint> > linesLst;
-      if (useScanLine && !displayFullModel) {
-        hiddenface->computeScanLineQuery(poly.polyClipped[0].first, poly.polyClipped[1].first, linesLst, true);
-      } else {
-        linesLst.push_back(std::make_pair(poly.polyClipped[0].first, poly.polyClipped[1].first));
-      }
-
-      for (unsigned int i = 0; i < linesLst.size(); i++) {
-        linesLst[i].first.project();
-        linesLst[i].second.project();
-
-        vpMeterPixelConversion::convertPoint(camera, linesLst[i].first.get_x(), linesLst[i].first.get_y(), ip1);
-        vpMeterPixelConversion::convertPoint(camera, linesLst[i].second.get_x(), linesLst[i].second.get_y(), ip2);
-
-        vpDisplay::displayLine(I, ip1, ip2, col, thickness);
-      }
-    }
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -668,42 +639,13 @@ void vpMbtDistanceLine::display(const vpImage<vpRGBa> &I, const vpHomogeneousMat
                                 const vpCameraParameters &camera, const vpColor &col, const unsigned int thickness,
                                 const bool displayFullModel)
 {
-  if ((isvisible && isTrackedLine) || displayFullModel) {
-    p1->changeFrame(cMo);
-    p2->changeFrame(cMo);
+  std::vector<std::vector<double> > models =
+      getModelForDisplay(I.getWidth(), I.getHeight(), cMo, camera, displayFullModel);
 
-    vpImagePoint ip1, ip2;
-    vpCameraParameters c = camera;
-    if (poly.getClipping() > 3) // Contains at least one FOV constraint
-      c.computeFov(I.getWidth(), I.getHeight());
-
-    poly.computePolygonClipped(c);
-
-    if (poly.polyClipped.size() == 2 &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::NEAR_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::FAR_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::DOWN_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::UP_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::LEFT_CLIPPING) == 0) &&
-        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::RIGHT_CLIPPING) == 0)) {
-
-      std::vector<std::pair<vpPoint, vpPoint> > linesLst;
-      if (useScanLine && !displayFullModel) {
-        hiddenface->computeScanLineQuery(poly.polyClipped[0].first, poly.polyClipped[1].first, linesLst, true);
-      } else {
-        linesLst.push_back(std::make_pair(poly.polyClipped[0].first, poly.polyClipped[1].first));
-      }
-
-      for (unsigned int i = 0; i < linesLst.size(); i++) {
-        linesLst[i].first.project();
-        linesLst[i].second.project();
-
-        vpMeterPixelConversion::convertPoint(camera, linesLst[i].first.get_x(), linesLst[i].first.get_y(), ip1);
-        vpMeterPixelConversion::convertPoint(camera, linesLst[i].second.get_x(), linesLst[i].second.get_y(), ip2);
-
-        vpDisplay::displayLine(I, ip1, ip2, col, thickness);
-      }
-    }
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -737,6 +679,95 @@ void vpMbtDistanceLine::displayMovingEdges(const vpImage<vpRGBa> &I)
       meline[i]->display(I);
     }
   }
+}
+
+/*!
+  Return a list of features parameters for display.
+  Parameters are: <feature id (here 0 for ME)>, <pt.i()>, <pt.j()> <state>
+*/
+std::vector<std::vector<double> > vpMbtDistanceLine::getFeaturesForDisplay()
+{
+  std::vector<std::vector<double> > features;
+
+  for (size_t i = 0; i < meline.size(); i++) {
+    vpMbtMeLine *line = meline[i];
+    if (line != NULL) {
+      for (std::list<vpMeSite>::const_iterator it = line->list.begin(); it != line->list.end(); ++it) {
+        vpMeSite p_me = *it;
+        std::vector<double> params = {0, //ME
+                                      p_me.get_ifloat(),
+                                      p_me.get_jfloat(),
+                                      static_cast<double>(p_me.getState())};
+        features.push_back(params);
+      }
+    }
+  }
+
+  return features;
+}
+
+/*!
+  Return a list of line parameters to display the primitive at a given pose and camera parameters.
+  Parameters are: <primitive id (here 0 for line)>, <pt_start.i()>, <pt_start.j()>
+                  <pt_end.i()>, <pt_end.j()>
+
+  \param width : Image width.
+  \param height : Image height.
+  \param cMo : Pose used to project the 3D model into the image.
+  \param camera : The camera parameters.
+  \param displayFullModel : If true, the line is displayed even if it is not
+*/
+std::vector<std::vector<double> > vpMbtDistanceLine::getModelForDisplay(unsigned int width, unsigned int height,
+                                                                        const vpHomogeneousMatrix &cMo,
+                                                                        const vpCameraParameters &camera,
+                                                                        const bool displayFullModel)
+{
+  std::vector<std::vector<double> > models;
+
+  if ((isvisible && isTrackedLine) || displayFullModel) {
+    p1->changeFrame(cMo);
+    p2->changeFrame(cMo);
+
+    vpImagePoint ip1, ip2;
+    vpCameraParameters c = camera;
+    if (poly.getClipping() > 3) // Contains at least one FOV constraint
+      c.computeFov(width, height);
+
+    poly.computePolygonClipped(c);
+
+    if (poly.polyClipped.size() == 2 &&
+        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::NEAR_CLIPPING) == 0) &&
+        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::FAR_CLIPPING) == 0) &&
+        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::DOWN_CLIPPING) == 0) &&
+        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::UP_CLIPPING) == 0) &&
+        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::LEFT_CLIPPING) == 0) &&
+        ((poly.polyClipped[1].second & poly.polyClipped[0].second & vpPolygon3D::RIGHT_CLIPPING) == 0)) {
+
+      std::vector<std::pair<vpPoint, vpPoint> > linesLst;
+      if (useScanLine && !displayFullModel) {
+        hiddenface->computeScanLineQuery(poly.polyClipped[0].first, poly.polyClipped[1].first, linesLst, true);
+      } else {
+        linesLst.push_back(std::make_pair(poly.polyClipped[0].first, poly.polyClipped[1].first));
+      }
+
+      for (unsigned int i = 0; i < linesLst.size(); i++) {
+        linesLst[i].first.project();
+        linesLst[i].second.project();
+
+        vpMeterPixelConversion::convertPoint(camera, linesLst[i].first.get_x(), linesLst[i].first.get_y(), ip1);
+        vpMeterPixelConversion::convertPoint(camera, linesLst[i].second.get_x(), linesLst[i].second.get_y(), ip2);
+
+        std::vector<double> params = {0, //0 for line parameters
+                                      ip1.get_i(),
+                                      ip1.get_j(),
+                                      ip2.get_i(),
+                                      ip2.get_j()};
+        models.push_back(params);
+      }
+    }
+  }
+
+  return models;
 }
 
 /*!

--- a/modules/tracker/mbt/src/hybrid/vpMbEdgeKltMultiTracker.cpp
+++ b/modules/tracker/mbt/src/hybrid/vpMbEdgeKltMultiTracker.cpp
@@ -1371,8 +1371,7 @@ void vpMbEdgeKltMultiTracker::loadModel(const std::string &modelFile, const bool
   modelInitialised = true;
 }
 
-void vpMbEdgeKltMultiTracker::postTracking(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
-                                           const unsigned int lvl)
+void vpMbEdgeKltMultiTracker::postTracking(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages)
 {
   // MBT
   vpMbEdgeTracker *edge = NULL;
@@ -1383,7 +1382,7 @@ void vpMbEdgeKltMultiTracker::postTracking(std::map<std::string, const vpImage<u
     edge->updateMovingEdgeWeights();
 
     if (displayFeatures) {
-      edge->displayFeaturesOnImage(*mapOfImages[it->first], lvl);
+      edge->m_featuresToBeDisplayedEdge = edge->getFeaturesForDisplayEdge();
     }
   }
 
@@ -2213,7 +2212,7 @@ void vpMbEdgeKltMultiTracker::track(std::map<std::string, const vpImage<unsigned
 
   computeVVS(mapOfImages);
 
-  postTracking(mapOfImages, 0);
+  postTracking(mapOfImages);
 
   if (computeProjError) {
     vpMbEdgeMultiTracker::computeProjectionError();

--- a/modules/tracker/mbt/src/klt/vpMbKltMultiTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltMultiTracker.cpp
@@ -1725,7 +1725,6 @@ void vpMbKltMultiTracker::preTracking(std::map<std::string, const vpImage<unsign
 
 void vpMbKltMultiTracker::postTracking(std::map<std::string, const vpImage<unsigned char> *> &mapOfImages)
 {
-
   for (std::map<std::string, vpMbKltTracker *>::const_iterator it = m_mapOfKltTrackers.begin();
        it != m_mapOfKltTrackers.end(); ++it) {
     vpMbKltTracker *klt = it->second;
@@ -1740,6 +1739,10 @@ void vpMbKltMultiTracker::postTracking(std::map<std::string, const vpImage<unsig
       if (it->first == m_referenceCameraName) {
         reinit(/*mapOfImages[it->first]*/);
       }
+    }
+
+    if (displayFeatures) {
+      klt->m_featuresToBeDisplayedKlt = klt->getFeaturesForDisplayKlt();
     }
   }
 }

--- a/modules/tracker/mbt/src/klt/vpMbtDistanceKltCylinder.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbtDistanceKltCylinder.cpp
@@ -576,52 +576,12 @@ void vpMbtDistanceKltCylinder::display(const vpImage<unsigned char> &I, const vp
                                        const vpCameraParameters &camera, const vpColor &col,
                                        const unsigned int thickness, const bool /*displayFullModel*/)
 {
-  // if(isvisible || displayFullModel)
-  {
-    // Perspective projection
-    circle1.changeFrame(cMo);
-    circle2.changeFrame(cMo);
-    cylinder.changeFrame(cMo);
+  std::vector<std::vector<double> > models = getModelForDisplay(cMo, camera);
 
-    try {
-      circle1.projection();
-    } catch (...) {
-      std::cout << "Problem projection circle 1";
-    }
-    try {
-      circle2.projection();
-    } catch (...) {
-      std::cout << "Problem projection circle 2";
-    }
-
-    cylinder.projection();
-
-    double rho1, theta1;
-    double rho2, theta2;
-
-    // Meters to pixels conversion
-    vpMeterPixelConversion::convertLine(camera, cylinder.getRho1(), cylinder.getTheta1(), rho1, theta1);
-    vpMeterPixelConversion::convertLine(camera, cylinder.getRho2(), cylinder.getTheta2(), rho2, theta2);
-
-    // Determine intersections between circles and limbos
-    double i11, i12, i21, i22, j11, j12, j21, j22;
-
-    vpCircle::computeIntersectionPoint(circle1, cam, rho1, theta1, i11, j11);
-    vpCircle::computeIntersectionPoint(circle2, cam, rho1, theta1, i12, j12);
-
-    vpCircle::computeIntersectionPoint(circle1, cam, rho2, theta2, i21, j21);
-    vpCircle::computeIntersectionPoint(circle2, cam, rho2, theta2, i22, j22);
-
-    // Create the image points
-    vpImagePoint ip11, ip12, ip21, ip22;
-    ip11.set_ij(i11, j11);
-    ip12.set_ij(i12, j12);
-    ip21.set_ij(i21, j21);
-    ip22.set_ij(i22, j22);
-
-    // Display
-    vpDisplay::displayLine(I, ip11, ip12, col, thickness);
-    vpDisplay::displayLine(I, ip21, ip22, col, thickness);
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
   }
 }
 
@@ -629,6 +589,61 @@ void vpMbtDistanceKltCylinder::display(const vpImage<vpRGBa> &I, const vpHomogen
                                        const vpCameraParameters &camera, const vpColor &col,
                                        const unsigned int thickness, const bool /*displayFullModel*/)
 {
+  std::vector<std::vector<double> > models = getModelForDisplay(cMo, camera);
+
+  for (size_t i = 0; i < models.size(); i++) {
+    vpImagePoint ip1(models[i][1], models[i][2]);
+    vpImagePoint ip2(models[i][3], models[i][4]);
+
+    vpDisplay::displayLine(I, ip1, ip2, col, thickness);
+  }
+}
+
+/*!
+  Return a list of features parameters for display.
+  Parameters are: <feature id (here 1 for KLT)>, <pt.i()>, <pt.j()>,
+                  <klt_id.i()>, <klt_id.j()>, <klt_id.id>
+*/
+std::vector<std::vector<double> > vpMbtDistanceKltCylinder::getFeaturesForDisplay()
+{
+  std::vector<std::vector<double> > features;
+
+  std::map<int, vpImagePoint>::const_iterator iter = curPoints.begin();
+  for (; iter != curPoints.end(); ++iter) {
+    int id(iter->first);
+    vpImagePoint iP;
+    iP.set_i(static_cast<double>(iter->second.get_i()));
+    iP.set_j(static_cast<double>(iter->second.get_j()));
+
+    vpImagePoint iP2;
+    iP2.set_i(vpMath::round(iP.get_i() + 7));
+    iP2.set_j(vpMath::round(iP.get_j() + 7));
+
+    std::vector<double> params = {1, //KLT
+                                  iP.get_i(),
+                                  iP.get_j(),
+                                  iP2.get_i(),
+                                  iP2.get_j(),
+                                  static_cast<double>(id)};
+    features.push_back(params);
+  }
+
+  return features;
+}
+
+/*!
+  Return a list of line parameters to display the primitive at a given pose and camera parameters.
+  Parameters are: <primitive id (here 0 for line)>, <pt_start.i()>, <pt_start.j()>
+                  <pt_end.i()>, <pt_end.j()>
+
+  \param cMo : Pose used to project the 3D model into the image.
+  \param camera : The camera parameters.
+*/
+std::vector<std::vector<double> > vpMbtDistanceKltCylinder::getModelForDisplay(const vpHomogeneousMatrix &cMo,
+                                                                               const vpCameraParameters &camera)
+{
+  std::vector<std::vector<double> > models;
+
   // if(isvisible || displayFullModel)
   {
     // Perspective projection
@@ -672,10 +687,22 @@ void vpMbtDistanceKltCylinder::display(const vpImage<vpRGBa> &I, const vpHomogen
     ip21.set_ij(i21, j21);
     ip22.set_ij(i22, j22);
 
-    // Display
-    vpDisplay::displayLine(I, ip11, ip12, col, thickness);
-    vpDisplay::displayLine(I, ip21, ip22, col, thickness);
+    std::vector<double> params1 = {0, //line parameters
+                                   ip11.get_i(),
+                                   ip11.get_j(),
+                                   ip12.get_i(),
+                                   ip12.get_j()};
+    models.push_back(params1);
+
+    std::vector<double> params2 = {0, //line parameters
+                                   ip21.get_i(),
+                                   ip21.get_j(),
+                                   ip22.get_i(),
+                                   ip22.get_j()};
+    models.push_back(params1);
   }
+
+  return models;
 }
 
 // ######################

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -3485,7 +3485,7 @@ double vpMbTracker::computeProjectionErrorImpl(const vpImage<unsigned char> &I, 
   if (clippingFlag > 2)
     m_projectionErrorCam.computeFov(I.getWidth(), I.getHeight());
 
-  projectionErrorVisibleFace(I, _cMo);
+  projectionErrorVisibleFace(I.getWidth(), I.getHeight(), _cMo);
 
   projectionErrorResetMovingEdges();
 
@@ -3561,17 +3561,17 @@ double vpMbTracker::computeProjectionErrorImpl(const vpImage<unsigned char> &I, 
   return totalProjectionError;
 }
 
-void vpMbTracker::projectionErrorVisibleFace(const vpImage<unsigned char> &_I, const vpHomogeneousMatrix &_cMo)
+void vpMbTracker::projectionErrorVisibleFace(unsigned int width, unsigned int height, const vpHomogeneousMatrix &_cMo)
 {
   bool changed = false;
 
   if (!useOgre) {
-    m_projectionErrorFaces.setVisible(_I, m_projectionErrorCam, _cMo, angleAppears, angleDisappears, changed);
+    m_projectionErrorFaces.setVisible(width, height, m_projectionErrorCam, _cMo, angleAppears, angleDisappears, changed);
   } else {
 #ifdef VISP_HAVE_OGRE
-     m_projectionErrorFaces.setVisibleOgre(_I, m_projectionErrorCam, _cMo, angleAppears, angleDisappears, changed);
+     m_projectionErrorFaces.setVisibleOgre(width, height, m_projectionErrorCam, _cMo, angleAppears, angleDisappears, changed);
 #else
-    m_projectionErrorFaces.setVisible(_I, m_projectionErrorCam, _cMo, angleAppears, angleDisappears, changed);
+    m_projectionErrorFaces.setVisible(width, height, m_projectionErrorCam, _cMo, angleAppears, angleDisappears, changed);
 #endif
   }
 }

--- a/modules/tracker/mbt/src/vpMbtPolygon.cpp
+++ b/modules/tracker/mbt/src/vpMbtPolygon.cpp
@@ -105,7 +105,7 @@ vpMbtPolygon::~vpMbtPolygon() {}
   \return Return true if the polygon is visible.
 */
 bool vpMbtPolygon::isVisible(const vpHomogeneousMatrix &cMo, const double alpha, const bool &modulo,
-                             const vpCameraParameters &cam, const vpImage<unsigned char> &I)
+                             const vpCameraParameters &cam, unsigned int width, unsigned int height)
 {
   //   std::cout << "Computing angle from MBT Face (cMo, alpha)" << std::endl;
 
@@ -116,7 +116,7 @@ bool vpMbtPolygon::isVisible(const vpHomogeneousMatrix &cMo, const double alpha,
     if (useLod) {
       vpCameraParameters c = cam;
       if (clippingFlag > 3) { // Contains at least one FOV constraint
-        c.computeFov(I.getWidth(), I.getHeight());
+        c.computeFov(width, height);
       }
       computePolygonClipped(c);
       std::vector<vpImagePoint> roiImagePoints;
@@ -194,7 +194,7 @@ bool vpMbtPolygon::isVisible(const vpHomogeneousMatrix &cMo, const double alpha,
     if (useLod) {
       vpCameraParameters c = cam;
       if (clippingFlag > 3) { // Contains at least one FOV constraint
-        c.computeFov(I.getWidth(), I.getHeight());
+        c.computeFov(width, height);
       }
       computePolygonClipped(c);
       std::vector<vpImagePoint> roiImagePoints;

--- a/modules/tracker/me/src/moving-edges/vpMeSite.cpp
+++ b/modules/tracker/me/src/moving-edges/vpMeSite.cpp
@@ -598,8 +598,15 @@ VISP_EXPORT std::ostream &operator<<(std::ostream &os, vpMeSite &vpMeS)
 #endif
 }
 
-void vpMeSite::display(const vpImage<unsigned char> &I) { vpMeSite::display(I, ifloat, jfloat, state); }
-void vpMeSite::display(const vpImage<vpRGBa> &I) { vpMeSite::display(I, ifloat, jfloat, state); }
+void vpMeSite::display(const vpImage<unsigned char> &I)
+{
+  vpMeSite::display(I, ifloat, jfloat, state);
+}
+
+void vpMeSite::display(const vpImage<vpRGBa> &I)
+{
+  vpMeSite::display(I, ifloat, jfloat, state);
+}
 
 // Static functions
 


### PR DESCRIPTION
 - Can be useful to display the model and the features without using ViSP GUI or for foward display (e.g. ROS).
 - Use directly image width and height with `vpMbHiddenFaces` visibility (API changes).