### PR TITLE
MBT: load cao model with transformation

### DIFF
--- a/modules/core/include/visp3/core/vpIoTools.h
+++ b/modules/core/include/visp3/core/vpIoTools.h
@@ -246,6 +246,9 @@ public:
   static void writeBinaryValueLE(std::ofstream &file, const float float_value);
   static void writeBinaryValueLE(std::ofstream &file, const double double_value);
 
+  static bool parseBoolean(std::string input);
+  static std::string trim(std::string s);
+
 protected:
   static std::string baseName;
   static std::string baseDir;

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -41,6 +41,8 @@
   \brief File and directories basic tools.
 */
 #include <algorithm>
+#include <cctype>
+#include <functional>
 #include <cmath>
 #include <errno.h>
 #include <fcntl.h>
@@ -193,6 +195,18 @@ double swapDouble(const double d)
   return dat2.d;
 }
 #endif
+
+std::string &ltrim(std::string &s)
+{
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+  return s;
+}
+
+std::string &rtrim(std::string &s)
+{
+  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+  return s;
+}
 }
 
 /*!
@@ -2037,4 +2051,23 @@ void vpIoTools::writeBinaryValueLE(std::ofstream &file, const double double_valu
 #else
   file.write((char *)(&double_value), sizeof(double_value));
 #endif
+}
+
+bool vpIoTools::parseBoolean(std::string input)
+{
+  std::transform(input.begin(), input.end(), input.begin(), ::tolower);
+  std::istringstream is(input);
+  bool b;
+  // Parse string to boolean either in the textual representation
+  // (True/False)  or in numeric representation (1/0)
+  is >> (input.size() > 1 ? std::boolalpha : std::noboolalpha) >> b;
+  return b;
+}
+
+/*!
+   Remove whitespaces on both sides.
+ */
+std::string vpIoTools::trim(std::string s)
+{
+  return ltrim(rtrim(s));
 }

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
@@ -45,13 +45,7 @@
 #ifndef vpMbTracker_hh
 #define vpMbTracker_hh
 
-#include <algorithm>
-#include <cctype>
-#include <fstream>
-#include <functional> // std::not1
-#include <locale>
 #include <map>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -898,32 +892,7 @@ protected:
 
   void removeComment(std::ifstream &fileId);
 
-  inline bool parseBoolean(std::string &input)
-  {
-    std::transform(input.begin(), input.end(), input.begin(), ::tolower);
-    std::istringstream is(input);
-    bool b;
-    // Parse string to boolean either in the textual representation
-    // (True/False)  or in numeric representation (1/0)
-    is >> (input.size() > 1 ? std::boolalpha : std::noboolalpha) >> b;
-    return b;
-  }
-
   std::map<std::string, std::string> parseParameters(std::string &endLine);
-
-  inline std::string &ltrim(std::string &s) const
-  {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-    return s;
-  }
-
-  inline std::string &rtrim(std::string &s) const
-  {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-    return s;
-  }
-
-  inline std::string &trim(std::string &s) const { return ltrim(rtrim(s)); }
 
   bool samePoint(const vpPoint &P1, const vpPoint &P2) const;
 };


### PR DESCRIPTION
To be able to do:

- `lego.cao`
```
load("lego_parts/cube_row.cao")
load("lego_parts/cube_row.cao", t=[0.304; 0.0; -0.152], tu=[0; 180 deg ; 0])
```

- `cube_row.cao`
```
load("cube_left.cao", t=[0.012; 0.152; -0.012])
load("cube_middle.cao", t=[0.088; 0.152; -0.012])
load("cube_middle.cao", t=[0.164; 0.152; -0.012])
load("cube_right.cao", t=[0.240; 0.152; -0.012])
```

Etc.