### PR TITLE
Correction for vpBSpline::findSpan method

### DIFF
--- a/modules/core/src/math/spline/vpBSpline.cpp
+++ b/modules/core/src/math/spline/vpBSpline.cpp
@@ -100,8 +100,8 @@ unsigned int vpBSpline::findSpan(double l_u, unsigned int l_p, std::vector<doubl
   double high = m - l_p;
   double middle = (low + high) / 2.0;
 
-  while (l_u < l_knots[(unsigned int)vpMath::round(middle)] ||
-         l_u >= l_knots[(unsigned int)vpMath::round(middle + 1)]) {
+  while (l_u < l_knots[(unsigned int)middle] ||
+         l_u >= l_knots[(unsigned int)middle + 1]) {
     if (l_u < l_knots[(unsigned int)vpMath::round(middle)])
       high = middle;
     else


### PR DESCRIPTION
Hello,
This pull request corresponds to a fix for the bug described in #549.

It can be tested using the following CMakeProject:
[vpBSpline.zip](https://github.com/lagadic/visp/files/3018299/vpBSpline.zip)

The error came from the fact that the test conditions of the while loop and the result affectation did not match each other.

Romain
