### PR TITLE
Fix Apriltags warning

### DIFF
--- a/3rdparty/apriltag/apriltag_quad_thresh.c
+++ b/3rdparty/apriltag/apriltag_quad_thresh.c
@@ -1628,7 +1628,7 @@ zarray_t* do_gradient_clusters(image_u8_t* threshim, int ts, int y0, int y1, int
                             clustermap[clustermap_bucket] = entry;          \
                         }                                                   \
                                                                             \
-                        struct pt p = { /*.x =*/ (uint16_t)(2*x + dx), /*.y =*/ (uint16_t)(2*y + dy), /*.gx =*/ (int16_t)(dx*((int) v1-v0)), /*.gy =*/ (int16_t)(dy*((int) v1-v0)) }; \
+                        struct pt p = { /*.x =*/ (uint16_t)(2*x + dx), /*.y =*/ (uint16_t)(2*y + dy), /*.gx =*/ (int16_t)(dx*((int) v1-v0)), /*.gy =*/ (int16_t)(dy*((int) v1-v0)), /*.slope =*/ 0.f }; \
                         zarray_add(entry->cluster, &p);                     \
                     }                                                   \
                 }                                                       \


### PR DESCRIPTION
Fix warning: missing initializer for member ‘pt::slope’ [-Wmissing-field-initializers]