### PR TITLE
Fix Intel MKL ILP64

### DIFF
--- a/cmake/AddExtraCompilationFlags.cmake
+++ b/cmake/AddExtraCompilationFlags.cmake
@@ -141,18 +141,6 @@ if(DEFINED WINRT_8_1)
   add_extra_compiler_option(/ZW) # do not use with 8.0
 endif()
 
-if(USE_MKL)
-  if (NOT DEFINED ENV{CRAY_PRGENVPGI} AND
-      NOT DEFINED ENV{CRAY_PRGENVGNU} AND
-      NOT DEFINED ENV{CRAY_PRGENVCRAY} AND
-      NOT DEFINED ENV{CRAY_PRGENVINTEL})
-    set(ABI "-m64")
-  endif()
-
-  add_extra_compiler_option(-DMKL_ILP64)
-  add_extra_compiler_option("${ABI}")
-endif()
-
 # Add user supplied extra options (optimization, etc...)
 vp_list_unique(VISP_EXTRA_C_FLAGS)
 

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -35,13 +35,16 @@ if (MKL_INCLUDE_DIRS AND MKL_LIBRARIES AND MKL_INTERFACE_LIBRARY AND
   set (MKL_FIND_QUIETLY TRUE)
 endif()
 
-if(NOT BUILD_SHARED_LIBS)
-  set(INT_LIB "libmkl_intel_ilp64.a")
-  set(SEQ_LIB "libmkl_sequential.a")
-  set(THR_LIB "libmkl_intel_thread.a")
-  set(COR_LIB "libmkl_core.a")
-else()
-  set(INT_LIB "mkl_intel_ilp64")
+# Only support of 64 bits architecture
+if (CMAKE_CXX_SIZEOF_DATA_PTR EQUAL 8)
+  include(CheckTypeSize)
+  CHECK_TYPE_SIZE(int _sizeof_int)
+  if (_sizeof_int EQUAL 4)
+    set(INT_LIB "mkl_intel_lp64")
+  else()
+    set(INT_LIB "mkl_intel_ilp64")
+  endif()
+
   set(SEQ_LIB "mkl_sequential")
   set(THR_LIB "mkl_intel_thread")
   set(COR_LIB "mkl_core")
@@ -78,13 +81,11 @@ if (MKL_INCLUDE_DIR AND
     MKL_SEQUENTIAL_LAYER_LIBRARY AND
     MKL_CORE_LIBRARY)
 else()
-
   set(MKL_INCLUDE_DIRS "")
   set(MKL_LIBRARIES "")
   set(MKL_INTERFACE_LIBRARY "")
   set(MKL_SEQUENTIAL_LAYER_LIBRARY "")
   set(MKL_CORE_LIBRARY "")
-
 endif()
 
 # Handle the QUIETLY and REQUIRED arguments and set MKL_FOUND to TRUE if


### PR DESCRIPTION
- Use dynamic linking for Intel MKL.
- Detect the architecture to use ILP64 or LP64 MKL interface.