### PR TITLE
The vpDot2::track method has now a parameter to determine if the sear…

### DIFF
--- a/modules/tracker/blob/include/visp3/blob/vpDot2.h
+++ b/modules/tracker/blob/include/visp3/blob/vpDot2.h
@@ -341,7 +341,7 @@ public:
   void setSizePrecision(const double &sizePrecision);
   void setWidth(const double &width);
 
-  void track(const vpImage<unsigned char> &I);
+  void track(const vpImage<unsigned char> &I, bool canMakeTheWindowGrow = true);
   void track(const vpImage<unsigned char> &I, vpImagePoint &cog);
 
   static void trackAndDisplay(vpDot2 dot[], const unsigned int &n, vpImage<unsigned char> &I,

--- a/modules/tracker/blob/src/dots/vpDot2.cpp
+++ b/modules/tracker/blob/src/dots/vpDot2.cpp
@@ -411,7 +411,7 @@ void vpDot2::initTracking(const vpImage<unsigned char> &I, const vpImagePoint &i
   \param I : Image.
   
   \param canMakeTheWindowGrow: if true, the size of the searching area is 
-  increased if the blob is not  found, otherwise it stays the same. Default
+  increased if the blob is not found, otherwise it stays the same. Default
   value is true.
 
   \exception vpTrackingException::featureLostError : If the dot tracking
@@ -487,10 +487,10 @@ void vpDot2::track(const vpImage<unsigned char> &I, bool canMakeTheWindowGrow)
         std::fabs(getHeight()) <= std::numeric_limits<double>::epsilon()) {
       searchWindowWidth = 80.;
       searchWindowHeight = 80.;
-    } else if(canMakeTheWindowGrow){
+    } else if (canMakeTheWindowGrow) {
         searchWindowWidth = getWidth() * 5;
         searchWindowWidth = getWidth() * 5;
-    }else{
+    } else {
         searchWindowWidth = getWidth();
         searchWindowHeight = getHeight();
     }

--- a/modules/tracker/blob/src/dots/vpDot2.cpp
+++ b/modules/tracker/blob/src/dots/vpDot2.cpp
@@ -409,6 +409,10 @@ void vpDot2::initTracking(const vpImage<unsigned char> &I, const vpImagePoint &i
   - If no valid dot was found in the window, return an exception.
 
   \param I : Image.
+  
+  \param canMakeTheWindowGrow: if true, the size of the searching area is 
+  increased if the blob is not  found, otherwise it stays the same. Default
+  value is true.
 
   \exception vpTrackingException::featureLostError : If the dot tracking
   failed. The tracking can fail if the following characteristics are not
@@ -435,7 +439,7 @@ void vpDot2::initTracking(const vpImage<unsigned char> &I, const vpImagePoint &i
 
 
 */
-void vpDot2::track(const vpImage<unsigned char> &I)
+void vpDot2::track(const vpImage<unsigned char> &I, bool canMakeTheWindowGrow)
 {
   m00 = m11 = m02 = m20 = m10 = m01 = 0;
 
@@ -483,10 +487,14 @@ void vpDot2::track(const vpImage<unsigned char> &I)
         std::fabs(getHeight()) <= std::numeric_limits<double>::epsilon()) {
       searchWindowWidth = 80.;
       searchWindowHeight = 80.;
-    } else {
-      searchWindowWidth = getWidth() * 5;
-      searchWindowHeight = getHeight() * 5;
+    } else if(canMakeTheWindowGrow){
+        searchWindowWidth = getWidth() * 5;
+        searchWindowWidth = getWidth() * 5;
+    }else{
+        searchWindowWidth = getWidth();
+        searchWindowHeight = getHeight();
     }
+  
     std::list<vpDot2> candidates;
     searchDotsInArea(I, (int)(this->cog.get_u() - searchWindowWidth / 2.0),
                      (int)(this->cog.get_v() - searchWindowHeight / 2.0), (unsigned int)searchWindowWidth,


### PR DESCRIPTION
Hello,

In this branch, a parameter with a default value keeping the behavior consistent with ViSP actual implementation has been added to the vpDot2::track method. It permits to avoid the searching area growth when the blob is not found. It is useful for instance when you are tracking a slow object and the tracking fails a few steps.

Regards,
Romain