### PR TITLE
Fix warning implicitly-declared operator= occuring with g++ 9.1.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,7 +27,7 @@ ViSP 3.2.1 (under work)
     . Compatibility with FlyCapture 2.13 to enable vpFlyCaptureGrabber usage
     . Compatibility with PCL > 1.9.1 to enable additional features in vpRealSense2 class
     . Compatibility with Windows 10 SDK latest version to enable vpDisplayGDI usage
-    . Compatibility with Fedora 29
+    . Compatibility with Fedora 30
     . New option to select CXX standard set by default to c++11
   - Tutorials
     . New tutorial: Installation from source for Windows with Visual C++ 2019 (vc16)

--- a/doc/tutorial/unix/tutorial-install-fedora.doc
+++ b/doc/tutorial/unix/tutorial-install-fedora.doc
@@ -3,7 +3,7 @@
 \page tutorial-install-fedora Tutorial: Installation from source for Linux Fedora
 \tableofcontents
 
-In this tutorial you will learn how to install ViSP from source on Linux Fedora. These steps have been tested for Fedora 21, Fedora 26 (64 bit), Fedora 28 (64 bits) and Fedora 29 (64 bits) distributions, but should work with any other distribution as well. 
+In this tutorial you will learn how to install ViSP from source on Linux Fedora. These steps have been tested for Fedora 21, Fedora 26 (64 bit), Fedora 28 (64 bits), Fedora 29 (64 bits) and Fedora 30 (64 bits) distributions, but should work with any other distribution as well. 
 
 \note Concerning ViSP installation, we provide also other \ref tutorial.
 

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -247,8 +247,8 @@ if(MSVC)
 endif()
 
 if(USE_EIGEN3)
-  vp_set_source_file_compile_flag(src/math/matrix/vpMatrix_svd.cpp -Wno-float-equal -Wno-strict-overflow -Wno-misleading-indentation -Wno-int-in-bool-context)
-  vp_set_source_file_compile_flag(src/math/matrix/vpMatrix_lu.cpp -Wno-float-equal -Wno-strict-overflow -Wno-misleading-indentation -Wno-int-in-bool-context)
+  vp_set_source_file_compile_flag(src/math/matrix/vpMatrix_svd.cpp -Wno-float-equal -Wno-strict-overflow -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-deprecated-copy)
+  vp_set_source_file_compile_flag(src/math/matrix/vpMatrix_lu.cpp -Wno-float-equal -Wno-strict-overflow -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-deprecated-copy)
   vp_set_source_file_compile_flag(src/math/matrix/vpEigenConversion.cpp -Wno-float-equal -Wno-strict-overflow -Wno-misleading-indentation -Wno-int-in-bool-context)
 endif()
 

--- a/modules/core/include/visp3/core/vpPoint.h
+++ b/modules/core/include/visp3/core/vpPoint.h
@@ -102,7 +102,9 @@ public:
   void init();
 
   friend VISP_EXPORT std::ostream &operator<<(std::ostream &os, const vpPoint &vpp);
-  vpPoint &operator=(const vpPoint &vpp);
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpPoint &operator=(const vpPoint &vpp) = default;
+#endif
 
   //! Projection onto the image plane of a point. Input: the 3D coordinates in
   //! the camera frame _cP, output : the 2D coordinates _p.

--- a/modules/core/include/visp3/core/vpQuaternionVector.h
+++ b/modules/core/include/visp3/core/vpQuaternionVector.h
@@ -145,6 +145,7 @@ public:
   vpQuaternionVector operator/(const double l) const;
   vpQuaternionVector &operator=(const vpColVector &q);
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpQuaternionVector &operator=(const vpQuaternionVector &q) = default;
   vpQuaternionVector &operator=(const std::initializer_list<double> &list);
 #endif
 

--- a/modules/core/include/visp3/core/vpRectOriented.h
+++ b/modules/core/include/visp3/core/vpRectOriented.h
@@ -58,7 +58,11 @@ public:
 
   vpRectOriented(const vpRect &rect);
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpRectOriented &operator=(const vpRectOriented &rect) = default;
+#else
   vpRectOriented &operator=(const vpRectOriented &rect);
+#endif
 
   vpRectOriented &operator=(const vpRect &rect);
 

--- a/modules/core/include/visp3/core/vpRxyzVector.h
+++ b/modules/core/include/visp3/core/vpRxyzVector.h
@@ -211,6 +211,7 @@ public:
   vpRxyzVector &operator=(const vpColVector &rxyz);
   vpRxyzVector &operator=(double x);
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpRxyzVector &operator=(const vpRxyzVector &rxyz) = default;
   vpRxyzVector &operator=(const std::initializer_list<double> &list);
 #endif
 };

--- a/modules/core/include/visp3/core/vpRzyxVector.h
+++ b/modules/core/include/visp3/core/vpRzyxVector.h
@@ -213,6 +213,7 @@ public:
   vpRzyxVector &operator=(const vpColVector &rzyx);
   vpRzyxVector &operator=(double x);
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpRzyxVector &operator=(const vpRzyxVector &rzyx) = default;
   vpRzyxVector &operator=(const std::initializer_list<double> &list);
 #endif
 };

--- a/modules/core/include/visp3/core/vpRzyzVector.h
+++ b/modules/core/include/visp3/core/vpRzyzVector.h
@@ -211,6 +211,7 @@ public:
   vpRzyzVector &operator=(const vpColVector &rzyz);
   vpRzyzVector &operator=(double x);
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpRzyzVector &operator=(const vpRzyzVector &rzyz) = default;
   vpRzyzVector &operator=(const std::initializer_list<double> &list);
 #endif
 };

--- a/modules/core/src/tools/geometry/vpRectOriented.cpp
+++ b/modules/core/src/tools/geometry/vpRectOriented.cpp
@@ -87,6 +87,7 @@ vpRectOriented::vpRectOriented(const vpRect &rect)
   m_topRight.set_j(m_center.get_j() + m_width / 2.0);
 }
 
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
 /** Assignement operator.
  * @param rectOriented Oriented rectangle to copy.
  */
@@ -102,6 +103,7 @@ vpRectOriented &vpRectOriented::operator=(const vpRectOriented &rectOriented)
   m_topRight = rectOriented.getTopRight();
   return *this;
 }
+#endif
 
 /** Assignement operator from vpRect.
  * @param rect Rectangle to copy.

--- a/modules/core/src/tracking/forward-projection/vpPoint.cpp
+++ b/modules/core/src/tracking/forward-projection/vpPoint.cpp
@@ -387,6 +387,7 @@ void vpPoint::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, 
 
 VISP_EXPORT std::ostream &operator<<(std::ostream &os, const vpPoint & /* vpp */) { return (os << "vpPoint"); }
 
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
 vpPoint &vpPoint::operator=(const vpPoint &vpp)
 {
   p = vpp.p;
@@ -396,6 +397,7 @@ vpPoint &vpPoint::operator=(const vpPoint &vpp)
 
   return *this;
 }
+#endif
 
 /*!
   Display the point in the image.

--- a/modules/sensor/include/visp3/sensor/vpLaserScan.h
+++ b/modules/sensor/include/visp3/sensor/vpLaserScan.h
@@ -92,6 +92,11 @@ public:
   inline void clear() { listScanPoints.clear(); }
   /*! Get the list of points. */
   inline std::vector<vpScanPoint> getScanPoints() { return listScanPoints; }
+
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpLaserScan &operator=(const vpLaserScan &scan) = default;
+#endif
+
   /*! Specifies the id of former measurements and increases with
       every measurement. */
   inline void setMeasurementId(const unsigned short &id) { this->measurementId = id; }

--- a/modules/sensor/include/visp3/sensor/vpScanPoint.h
+++ b/modules/sensor/include/visp3/sensor/vpScanPoint.h
@@ -146,6 +146,10 @@ public:
   */
   inline double getZ() const { return (rDist * cos(this->hAngle) * sin(this->vAngle)); }
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpScanPoint &operator=(const vpScanPoint &) = default;
+#endif
+
   friend inline std::ostream &operator<<(std::ostream &s, const vpScanPoint &p);
 
   /*!


### PR DESCRIPTION
On Fedora 30, g++ 9.1.1 produces a lot of warnings like `implicitly-declared class & operator=(const class&) is deprecated [-Wdeprecated-copy]`

This PR fix all the warnings due to visp and disable those due to eigen 3rd party