### PR TITLE
Fix vpDot2 tracker

### DIFF
--- a/modules/tracker/blob/src/dots/vpDot2.cpp
+++ b/modules/tracker/blob/src/dots/vpDot2.cpp
@@ -488,7 +488,7 @@ void vpDot2::track(const vpImage<unsigned char> &I, bool canMakeTheWindowGrow)
       searchWindowHeight = 80.;
     } else if (canMakeTheWindowGrow) {
       searchWindowWidth = getWidth() * 5;
-      searchWindowWidth = getWidth() * 5;
+      searchWindowHeight = getHeight() * 5;
     } else {
       searchWindowWidth = getWidth();
       searchWindowHeight = getHeight();


### PR DESCRIPTION
Since PR #576 some examples using `vpDot2` class are failing:
- `trackDot2.cpp` when small blobs are tracked
- `AROgre.cpp` and `AROgreBasic.cpp`