### PR TITLE
EPPnP and REPPnP pose computation methods

### DIFF
--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -1548,12 +1548,7 @@ void vpMatrix::stackColumns(vpColVector &out)
   if ((out.rowNum != colNum * rowNum) || (out.colNum != 1))
     out.resize(colNum * rowNum, false, false);
 
-  double *optr = out.data;
-  for (unsigned int j = 0; j < colNum; j++) {
-    for (unsigned int i = 0; i < rowNum; i++) {
-      *(optr++) = rowPtrs[i][j];
-    }
-  }
+  memcpy(out.data, data, sizeof(double)*out.getRows());
 }
 
 /*!
@@ -1576,11 +1571,7 @@ void vpMatrix::stackRows(vpRowVector &out)
   if ((out.getRows() != 1) || (out.getCols() != colNum * rowNum))
     out.resize(colNum * rowNum, false, false);
 
-  double *mdata = data;
-  double *optr = out.data;
-  for (unsigned int i = 0; i < dsize; i++) {
-    *(optr++) = *(mdata++);
-  }
+  memcpy(out.data, data, sizeof(double)*out.getCols());
 }
 /*!
   Stacks rows of a matrix in a vector.
@@ -1639,10 +1630,7 @@ void vpMatrix::kron(const vpMatrix &m1, const vpMatrix &m2, vpMatrix &out)
   unsigned int r2 = m2.getRows();
   unsigned int c2 = m2.getCols();
 
-  if (r1 * r2 != out.rowNum || c1 * c2 != out.colNum) {
-    vpERROR_TRACE("Kronecker prodect bad dimension of output vpMatrix");
-    throw(vpException(vpException::dimensionError, "In Kronecker product bad dimension of output matrix"));
-  }
+  out.resize(r1*r2, c1*c2, false, false);
 
   for (unsigned int r = 0; r < r1; r++) {
     for (unsigned int c = 0; c < c1; c++) {

--- a/modules/vision/include/visp3/vision/vpPose.h
+++ b/modules/vision/include/visp3/vision/vpPose.h
@@ -94,8 +94,12 @@ public:
                              initialization from Lagrange or Dementhon aproach */
     DEMENTHON_VIRTUAL_VS, /*!< Non linear virtual visual servoing approach
                              initialized by Dementhon approach */
-    LAGRANGE_VIRTUAL_VS   /*!< Non linear virtual visual servoing approach
+    LAGRANGE_VIRTUAL_VS,  /*!< Non linear virtual visual servoing approach
                              initialized by Lagrange approach */
+    EPPnP,
+    EPPnP_LOWE,
+    EPPnP_VIRTUAL_VS,
+    REPPnP
   } vpPoseMethodType;
 
   enum RANSAC_FILTER_FLAGS {
@@ -147,6 +151,10 @@ private:
   //! Stop the optimization loop when the residual change (|r-r_prec|) <=
   //! epsilon
   double vvsEpsilon;
+  //! Inliers / outliers decision threshold in m for REPPnP method
+  double m_REPPnPMinError;
+  ///! Inlier indices for REPPnP method
+  std::vector<unsigned int> m_REPPnPInlierIndices;
 
   // For parallel RANSAC
   class RansacFunctor
@@ -225,10 +233,14 @@ public:
   void init();
   void poseDementhonPlan(vpHomogeneousMatrix &cMo);
   void poseDementhonNonPlan(vpHomogeneousMatrix &cMo);
+  void poseEPPnPNonPlan(vpHomogeneousMatrix &cMo);
+  void poseEPPnPPlan(vpHomogeneousMatrix &cMo);
   void poseLagrangePlan(vpHomogeneousMatrix &cMo);
   void poseLagrangeNonPlan(vpHomogeneousMatrix &cMo);
   void poseLowe(vpHomogeneousMatrix &cMo);
   bool poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &) = NULL);
+  void poseREPPnPNonPlan(vpHomogeneousMatrix &cMo);
+  void poseREPPnPPlan(vpHomogeneousMatrix &cMo);
   void poseVirtualVSrobust(vpHomogeneousMatrix &cMo);
   void poseVirtualVS(vpHomogeneousMatrix &cMo);
   void printPoint();
@@ -258,6 +270,13 @@ public:
   unsigned int getRansacNbInliers() const { return (unsigned int)ransacInliers.size(); }
   std::vector<unsigned int> getRansacInlierIndex() const { return ransacInlierIndex; }
   std::vector<vpPoint> getRansacInliers() const { return ransacInliers; }
+
+  void setREPPnPMinError(double t)
+  {
+    m_REPPnPMinError = t;
+  }
+
+  std::vector<unsigned int> getREPPnPInlierIndices() const { return m_REPPnPInlierIndices; }
 
   /*!
     Set if the covariance matrix has to be computed in the Virtual Visual

--- a/modules/vision/src/pose-estimation/vpPoseEPPnP.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseEPPnP.cpp
@@ -1,0 +1,622 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * REPPnP / EPPnP pose computation methods.
+ *
+ *****************************************************************************/
+/*
+% Copyright (C) <2014>  <Luis Ferraz, Xavier Binefa, Francesc Moreno-Noguer>
+%
+% This program is free software: you can redistribute it and/or modify
+% it under the terms of the version 3 of the GNU General Public License
+% as published by the Free Software Foundation.
+%
+% This program is distributed in the hope that it will be useful, but
+% WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+% General Public License for more details.
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <visp3/vision/vpPose.h>
+
+namespace
+{
+static vpMatrix defineControlPoints()
+{
+  vpMatrix M(4, 3, 0.0);
+  for (unsigned int i = 0; i < 3; i++) {
+    M[i][i] = 1.0;
+  }
+
+  return M;
+}
+
+static vpMatrix computeM(const vpMatrix& U, const vpMatrix& Alpha)
+{
+  vpMatrix m(2, 3, { 1, 0, -1, 0, 1, -1 });
+  vpMatrix M;
+  vpMatrix::kron(Alpha, m, M);
+
+  vpMatrix tmp(M.getRows(), 4);
+  for (unsigned int i = 0; i < M.getRows(); i++) {
+    tmp[i][0] = M[i][2];
+    tmp[i][1] = M[i][5];
+    tmp[i][2] = M[i][8];
+    tmp[i][3] = M[i][11];
+  }
+
+  vpMatrix tmp2 = tmp.hadamard(U * vpMatrix(1, 4, 1.0));
+
+  for (unsigned int i = 0; i < M.getRows(); i++) {
+    M[i][2] = tmp2[i][0];
+    M[i][5] = tmp2[i][1];
+    M[i][8] = tmp2[i][2];
+    M[i][11] = tmp2[i][3];
+  }
+
+  return M;
+}
+
+static vpMatrix computeAlphas(const vpMatrix& Xw, const vpMatrix& Cw)
+{
+  unsigned int nbPts = Xw.getRows();
+
+  //generate auxiliar matrix to compute alphas
+  vpMatrix C(4, 4, 1.0);
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < 4; j++) {
+      C[i][j] = Cw[j][i];
+    }
+  }
+
+  vpMatrix X(4, nbPts, 1.0);
+  vpMatrix Xwt = Xw.t();
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < nbPts; j++) {
+      X[i][j] = Xwt[i][j];
+    }
+  }
+
+  vpMatrix Alpha = C.inverseByLU() * X;
+
+  return Alpha.t();
+}
+
+static vpMatrix reshape1DMatlab(const vpMatrix& src)
+{
+  vpMatrix dst(src.getRows()*src.getCols(), 1);
+  for (unsigned int j = 0; j < src.getCols(); j++) {
+    for (unsigned int i = 0; i < src.getRows(); i++) {
+      dst[j*src.getRows() + i][0] = src[i][j];
+    }
+  }
+
+  return dst;
+}
+
+static void prepareData(const std::vector<vpPoint>& points, vpMatrix& M, vpMatrix& Cw, vpMatrix& Alpha)
+{
+  vpMatrix Cwt = defineControlPoints();
+  Cw = Cwt.t();
+
+  unsigned int nbPts = static_cast<unsigned int>(points.size());
+  vpMatrix Xw(nbPts, 3);
+  vpMatrix U(2, nbPts);
+
+  for (unsigned int i = 0; i < nbPts; i++) {
+    const vpPoint& pt = points[i];
+    Xw[i][0] = pt.get_oX();
+    Xw[i][1] = pt.get_oY();
+    Xw[i][2] = pt.get_oZ();
+
+    U[0][i] = pt.get_x();
+    U[1][i] = pt.get_y();
+  }
+
+  Alpha = computeAlphas(Xw, Cwt);
+  M = computeM(reshape1DMatlab(U), Alpha);
+}
+
+static vpMatrix kernelNoise(const vpMatrix& M, int dimKer)
+{
+  vpMatrix MtM = M.AtA();
+  vpColVector W;
+  vpMatrix eigenVectors;
+  MtM.svd(W, eigenVectors);
+
+  const unsigned int sz0 = eigenVectors.getRows(), sz1 = eigenVectors.getCols();
+  vpMatrix K(sz0, static_cast<unsigned int>(dimKer));
+  for (unsigned int i = 0, i2 = 0; i < sz0; i++, i2++) {
+    for (unsigned int j = sz1-static_cast<unsigned int>(dimKer), j2 = 0; j < sz1; j++, j2++) {
+      K[i2][j2] = eigenVectors[i][j];
+    }
+  }
+
+  return K;
+}
+
+static vpMatrix reshapeMatlab(const vpMatrix& V, unsigned int rows, unsigned int cols)
+{
+  if (V.getCols() > 1) {
+    throw vpException(vpException::dimensionError, "V must be a column vector!");
+  }
+  vpMatrix Mreshape(rows, cols);
+  for (unsigned int j = 0; j < cols; j++)
+  {
+    for (unsigned int i = 0; i < rows; i++)
+    {
+      Mreshape[i][j] = V[j*rows + i][0];
+    }
+  }
+
+  return Mreshape;
+}
+
+struct Procrustes
+{
+  vpMatrix P;
+  vpMatrix mP;
+  vpMatrix cP;
+  double norm;
+  vpMatrix nP;
+};
+
+static vpMatrix reduceRowAvg(const vpMatrix& M)
+{
+  vpMatrix avg;
+
+  if (M.getRows()*M.getCols() > 0) {
+    avg.resize(M.getRows(), 1);
+
+    for (unsigned int i = 0; i < M.getRows(); i++) {
+      for (unsigned int j = 0; j < M.getCols(); j++) {
+        avg[i][0] += M[i][j];
+      }
+      avg[i][0] /= M.getCols();
+    }
+  }
+
+  return  avg;
+}
+
+static vpMatrix reduceColSum(const vpMatrix& M)
+{
+  vpMatrix sum;
+
+  if (M.getRows()*M.getCols() > 0) {
+    sum.resize(M.getCols(), 1);
+
+    for (unsigned int j = 0; j < M.getCols(); j++) {
+      for (unsigned int i = 0; i < M.getRows(); i++) {
+        sum[j][0] += M[i][j];
+      }
+    }
+  }
+
+  return  sum;
+}
+
+static std::vector<unsigned int> findIdxZero(const vpMatrix& M)
+{
+  std::vector<unsigned int> idx;
+
+  for (unsigned int i = 0; i < M.getRows(); i++) {
+    if (vpMath::nul(M[i][0], 1e-9)) {
+      idx.push_back(i);
+    }
+  }
+
+  return idx;
+}
+
+template <typename T> int sgn(T val)
+{
+    return (T(0) < val) - (val < T(0));
+}
+
+static void EPPnPProcrustes(const Procrustes& X, const vpMatrix& Y, vpMatrix& R, double& b, vpMatrix& mc)
+{
+  const unsigned int dims = Y.getCols();
+  vpMatrix mY = reduceRowAvg(Y);
+  vpMatrix cY = Y - mY*vpMatrix(1, dims, 1.0);
+  double ncY = sqrt(cY.sumSquare());
+  vpMatrix tcY = cY / ncY;
+
+  vpMatrix A = X.nP * tcY.t();
+  vpColVector w;
+  vpMatrix M;
+  A.svd(w, M);
+
+  vpColVector vec_diag(3, 1.0);
+  vec_diag[2] = sgn((M*A.t()).det());
+  vpMatrix M_diag;
+  M_diag.diag(vec_diag);
+  R = M * M_diag * A.t();
+
+  b = (w.sum() * X.norm/ncY);
+  vpMatrix c = X.mP - b*R.t()*mY;
+  mc = c*vpMatrix(1, dims, 1.0);
+}
+
+static void KernelPnP(const vpMatrix& Cw, const vpMatrix& Km, unsigned int dims, vpMatrix& R, vpMatrix& T, double& err, bool solIter=true)
+{
+  vpMatrix Km_lastCol(Km.getRows(), 1);
+  for (unsigned int i = 0; i < Km.getRows(); i++) {
+    Km_lastCol[i][0] = Km[i][Km.getCols()-1];
+  }
+  vpMatrix vK = reshapeMatlab(Km_lastCol, 3, dims);
+
+  Procrustes X;
+  X.P = Cw;
+  X.mP = reduceRowAvg(X.P);
+
+  vpMatrix ones(1, dims, 1.0);
+  X.cP = X.P - X.mP*ones;
+
+  vpColVector cP = X.cP.stackColumns();
+  X.norm = sqrt(cP.sumSquare());
+
+  double inv_norm = 1/X.norm;
+  X.nP = X.cP*inv_norm;
+
+  double mean_vK_lastRows = vK.getRow(vK.getRows()-1).sum() / vK.getCols();
+  if (mean_vK_lastRows < 0) {
+    vK = -vK;
+  }
+
+  vpMatrix mc;
+  double b;
+  EPPnPProcrustes(X, vK, R, b, mc);
+
+  vpMatrix solV = b*vK;
+  vpMatrix solR = R;
+  vpMatrix solmc = mc;
+
+  if (solIter) {
+    err = std::numeric_limits<double>::max();
+    const int nIter = 10;
+
+    // procrustes solution using 4 kernel eigenvectors
+    for (int iter = 0; iter < nIter; iter++)
+    {
+      // projection of previous solution into the null space
+      vpMatrix A = R * (-mc + X.P);
+      vpMatrix abcd = Km.pseudoInverse() * reshape1DMatlab(A);
+      vpMatrix newV = reshapeMatlab(Km*abcd, 3, dims);
+
+      // euclidean error
+      vpColVector w;
+      vpMatrix V;
+      (R.t()*newV + mc-X.P).svd(w, V);
+      double newErr = w[0];
+
+      if (newErr > err && iter >= 2) {
+        break;
+      } else {
+        // procrustes solution
+        EPPnPProcrustes(X, newV, R, b, mc);
+
+        solV = b * newV;
+        solmc = mc;
+        solR = R;
+        err = newErr;
+      }
+    }
+  }
+
+  R = solR;
+  vpMatrix mV = reduceRowAvg(solV);
+  T = mV - R*X.mP;
+}
+
+static std::vector<unsigned int> setDiff(unsigned int srcSize, const std::vector<unsigned int>& removeIdx)
+{
+  std::vector<unsigned int> srcIdx(srcSize);
+  for (unsigned int i = 0; i < srcSize; i++) {
+    srcIdx[i] = i;
+  }
+
+  std::vector<unsigned int> diffIdx;
+  std::set_difference(srcIdx.begin(), srcIdx.end(),
+                      removeIdx.begin(), removeIdx.end(),
+                      std::back_inserter(diffIdx));
+  return diffIdx;
+}
+
+static vpMatrix copyCols(const vpMatrix& M, const std::vector<unsigned int>& colIdx)
+{
+  vpMatrix M_out(M.getRows(), static_cast<unsigned int>(colIdx.size()));
+
+  for (size_t idx = 0; idx < colIdx.size(); idx++) {
+    for (unsigned int i = 0; i < M.getRows(); i++) {
+      M_out[i][idx] = M[i][colIdx[idx]];
+    }
+  }
+
+  return  M_out;
+}
+
+static vpMatrix copyRows(const vpMatrix& M, const std::vector<unsigned int>& rowIdx)
+{
+  vpMatrix M_out(static_cast<unsigned int>(rowIdx.size()), M.getCols());
+
+  for (unsigned int idx = 0; idx < static_cast<unsigned int>(rowIdx.size()); idx++) {
+    for (unsigned int j = 0; j < M.getCols(); j++) {
+      M_out[idx][j] = M[rowIdx[idx]][j];
+    }
+  }
+
+  return  M_out;
+}
+
+static vpMatrix squareRoot(const vpMatrix& M)
+{
+  vpMatrix M_out(M.getRows(), M.getCols());
+
+  for (unsigned int i = 0; i < M.getRows(); i++) {
+    for (unsigned int j = 0; j < M.getCols(); j++) {
+      M_out[i][j] = sqrt(M[i][j]);
+    }
+  }
+
+  return M_out;
+}
+
+static void sort(const vpColVector& V, vpColVector& Vsorted, std::vector<unsigned int>& idx)
+{
+  std::vector<std::pair<double, unsigned int> > pairs;
+  pairs.reserve(V.getRows());
+  for (unsigned int i = 0; i < V.getRows(); i++) {
+    pairs.push_back(std::pair<double, unsigned int>(V[i], i));
+  }
+  std::sort(pairs.begin(), pairs.end());
+
+  Vsorted.resize(V.getRows(), false);
+  idx.resize(pairs.size());
+  for (unsigned int i = 0; i < static_cast<unsigned int>(pairs.size()); i++) {
+    Vsorted[i] = pairs[i].first;
+    idx[i] = pairs[i].second;
+  }
+}
+
+static int countInliers(const vpColVector& V, double med, double minError)
+{
+  int sum = 0;
+  const double threshold = std::max(med, minError);
+
+  for (unsigned int i = 0; i < V.getRows(); i++) {
+    if (V[i] < threshold) {
+      sum++;
+    } else {
+      break;
+    }
+  }
+
+  return sum;
+}
+
+static std::vector<unsigned int> getNewInliersIdx(const std::vector<unsigned int>& idx)
+{
+  std::vector<unsigned int> newIdx(2*idx.size());
+
+  for (size_t i = 0; i < idx.size(); i++) {
+    newIdx[2*i] = 2*idx[i];
+    newIdx[2*i+1] = 2*idx[i]+1;
+  }
+
+  return  newIdx;
+}
+
+static vpMatrix robustKernelNoise(const vpMatrix& M, unsigned int dimKer, double minError, std::vector<unsigned int>& idxInliers)
+{
+  const unsigned int m = M.getRows();
+  std::vector<unsigned int> idx(m);
+  for (unsigned int i = 0; i < m; i++) {
+    idx[i] = i;
+  }
+
+  vpMatrix N = M;
+  //SVD
+  vpColVector w;
+  vpMatrix V, resV;
+  vpMatrix M_even(M.getRows()/2, M.getCols()), M_odd(M.getRows()/2, M.getCols());
+  for (unsigned int i = 0; i < M_even.getRows(); i++) {
+    for (unsigned int j = 0; j < M.getCols(); j++) {
+      M_even[i][j] = M[2*i][j];
+      M_odd[i][j] = M[2*i+1][j];
+    }
+  }
+
+  double prev_sv = std::numeric_limits<double>::max();
+  const int maxIters = 50;
+  for (int iter = 0; iter < maxIters; iter++) {
+    N = copyRows(M, idx);
+    N.AtA().svd(w, V);
+
+    vpColVector error10 = M_even * V.getCol(V.getCols()-1);
+    vpColVector error11 = M_odd * V.getCol(V.getCols()-1);
+    vpColVector error1 = squareRoot(error10.hadamard(error10) + error11.hadamard(error11));
+
+    vpColVector sv;
+    std::vector<unsigned int> tidx;
+    sort(error1, sv, tidx);
+
+    double med = sv[static_cast<unsigned int>(std::floor(m/8.0)) > 0 ?
+          static_cast<unsigned int>(std::floor(m/8.0))-1 :
+          static_cast<unsigned int>(std::floor(m/8.0))];
+
+    int nInliers = countInliers(sv, med, minError);
+
+    if (med >= prev_sv) {
+      break;
+    } else {
+      prev_sv = med;
+      resV = V;
+      idxInliers = std::vector<unsigned int>(tidx.begin(), tidx.begin()+nInliers);
+    }
+
+    idx = getNewInliersIdx(idxInliers);
+  }
+
+  vpMatrix K(resV.getRows(), dimKer);
+  for (unsigned int i = 0; i < resV.getRows(); i++) {
+    for (unsigned int j = resV.getCols()-dimKer, j2 = 0; j < resV.getCols(); j++, j2++) {
+      K[i][j2] = resV[i][j];
+    }
+  }
+
+  return K;
+}
+} //namespace
+
+void vpPose::poseEPPnPNonPlan(vpHomogeneousMatrix& cMo)
+{
+  vpMatrix M, Cw, Alpha;
+  std::vector<vpPoint> vecPoints{std::begin(listP), std::end(listP)};
+  prepareData(vecPoints, M, Cw, Alpha);
+  const unsigned int dimKer = 4;
+  vpMatrix Km = kernelNoise(M, dimKer);
+
+  double err = std::numeric_limits<double>::max();
+  vpMatrix R, tvec;
+  KernelPnP(Cw, Km, dimKer, R, tvec, err);
+
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < 3; j++) {
+      cMo[i][j] = R[i][j];
+    }
+    cMo[i][3] = tvec[i][0];
+  }
+}
+
+void vpPose::poseEPPnPPlan(vpHomogeneousMatrix& cMo)
+{
+  vpMatrix M, Cw, Alpha;
+  std::vector<vpPoint> vecPoints{std::begin(listP), std::end(listP)};
+  prepareData(vecPoints, M, Cw, Alpha);
+
+  std::vector<unsigned int> idx = findIdxZero( reduceColSum( reshapeMatlab(reduceColSum(M), 3, 4) ) );
+
+  if (!idx.empty()) {
+    std::vector<unsigned int> removeIdx, removeIdxCw;
+    for (size_t i = 0; i < idx.size(); i++) {
+      removeIdx.push_back(3*idx[i]);
+      removeIdx.push_back(3*idx[i]+1);
+      removeIdx.push_back(3*idx[i]+2);
+
+      removeIdxCw.push_back(idx[i]);
+    }
+    std::vector<unsigned int> diffIdx = setDiff(M.getCols(), removeIdx);
+    M = copyCols(M, diffIdx);
+
+    diffIdx = setDiff(Cw.getCols(), removeIdxCw);
+    Cw = copyCols(Cw, diffIdx);
+
+    Alpha = copyCols(Alpha, diffIdx);
+  }
+
+  const unsigned int dimKer = 3;
+  vpMatrix Km = kernelNoise(M, dimKer);
+
+  double err = std::numeric_limits<double>::max();
+  vpMatrix R, tvec;
+  KernelPnP(Cw, Km, dimKer, R, tvec, err);
+
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < 3; j++) {
+      cMo[i][j] = R[i][j];
+    }
+    cMo[i][3] = tvec[i][0];
+  }
+}
+
+void vpPose::poseREPPnPNonPlan(vpHomogeneousMatrix& cMo)
+{
+  vpMatrix M, Cw, Alpha;
+  std::vector<vpPoint> vecPoints{std::begin(listP), std::end(listP)};
+  prepareData(vecPoints, M, Cw, Alpha);
+  const unsigned int dimKer = 4;
+  vpMatrix Km = robustKernelNoise(M, dimKer, m_REPPnPMinError, m_REPPnPInlierIndices);
+
+  double err = std::numeric_limits<double>::max();
+  vpMatrix R, tvec;
+  KernelPnP(Cw, Km, dimKer, R, tvec, err);
+
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < 3; j++) {
+      cMo[i][j] = R[i][j];
+    }
+    cMo[i][3] = tvec[i][0];
+  }
+}
+
+void vpPose::poseREPPnPPlan(vpHomogeneousMatrix& cMo)
+{
+  vpMatrix M, Cw, Alpha;
+  std::vector<vpPoint> vecPoints{std::begin(listP), std::end(listP)};
+  prepareData(vecPoints, M, Cw, Alpha);
+
+  std::vector<unsigned int> idx = findIdxZero( reduceColSum( reshapeMatlab(reduceColSum(M), 3, 4) ) );
+
+  if (!idx.empty()) {
+    std::vector<unsigned int> removeIdx, removeIdxCw;
+    for (size_t i = 0; i < idx.size(); i++) {
+      removeIdx.push_back(3*idx[i]);
+      removeIdx.push_back(3*idx[i]+1);
+      removeIdx.push_back(3*idx[i]+2);
+
+      removeIdxCw.push_back(idx[i]);
+    }
+    std::vector<unsigned int> diffIdx = setDiff(M.getCols(), removeIdx);
+    M = copyCols(M, diffIdx);
+
+    diffIdx = setDiff(Cw.getCols(), removeIdxCw);
+    Cw = copyCols(Cw, diffIdx);
+
+    Alpha = copyCols(Alpha, diffIdx);
+  }
+
+  const unsigned int dimKer = 3;
+  vpMatrix Km = robustKernelNoise(M, dimKer, m_REPPnPMinError, m_REPPnPInlierIndices);
+
+  double err = std::numeric_limits<double>::max();
+  vpMatrix R, tvec;
+  KernelPnP(Cw, Km, dimKer, R, tvec, err);
+
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < 3; j++) {
+      cMo[i][j] = R[i][j];
+    }
+    cMo[i][3] = tvec[i][0];
+  }
+}

--- a/modules/vision/test/pose/testPose2.cpp
+++ b/modules/vision/test/pose/testPose2.cpp
@@ -1,0 +1,994 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test pose computation methods.
+ *
+ *****************************************************************************/
+
+#include <algorithm>    // std::transform
+#include <map>
+#include <visp3/core/vpGaussRand.h>
+#include <visp3/core/vpMeterPixelConversion.h>
+#include <visp3/core/vpPixelMeterConversion.h>
+#include <visp3/gui/vpPlot.h>
+#include <visp3/vision/vpPose.h>
+
+#if (VISP_HAVE_OPENCV_VERSION >= 0x030000)
+#include <opencv2/calib3d.hpp>
+#endif
+
+namespace
+{
+#if (VISP_HAVE_OPENCV_VERSION >= 0x030000)
+using namespace cv;
+#endif
+using namespace std;
+
+namespace posit
+{
+static vpHomogeneousMatrix pose_dementhon(const vector<vpColVector> &wX,
+                                          const vector<vpColVector> &x)
+{
+  unsigned int npoints = static_cast<unsigned int>(wX.size());
+  vpColVector r1, r2, r3;
+  vpMatrix A(npoints, 4);
+  for(unsigned int i = 0; i < npoints; i++) {
+    for (unsigned int j = 0; j < 4; j++) {
+      A[i][j] = wX[i][j];
+    }
+  }
+
+  vpMatrix Ap = A.pseudoInverse();
+  vpColVector eps(npoints);
+  eps = 0; // Initialize epsilon_i = 0
+  vpColVector Bx(npoints);
+  vpColVector By(npoints);
+  double tx = 0.0, ty = 0.0, tz = 0.0;
+  vpMatrix I, J;
+  vpColVector Istar(3), Jstar(3);
+
+  // POSIT loop
+  for (unsigned int iter = 0; iter < 20; iter++) {
+    for (unsigned int i = 0; i < npoints; i++) {
+      Bx[i] = x[i][0] * (eps[i] + 1.);
+      By[i] = x[i][1] * (eps[i] + 1.);
+    }
+
+    I = Ap * Bx; // Notice that the pseudo inverse
+    J = Ap * By; // of matrix A is a constant that has been precompiled.
+    for (unsigned int i = 0; i < 3; i++) {
+      Istar[i] = I[i][0];
+      Jstar[i] = J[i][0];
+    }
+
+    // Estimation of the rotation matrix
+    double normI = sqrt( Istar.sumSquare() );
+    double normJ = sqrt( Jstar.sumSquare() );
+    r1 = Istar / normI;
+    r2 = Jstar / normJ;
+    r3 = vpColVector::crossProd(r1, r2);
+
+    // Estimation of the translation
+    tz = 1/normI;
+    tx = tz * I[3][0];
+    ty = tz * J[3][0];
+
+    // Update epsilon_i
+    for(unsigned int i = 0; i < npoints; i++) {
+      eps[i] = (r3[0] * wX[i][0] + r3[1] * wX[i][1] + r3[2] * wX[i][2]) / tz;
+    }
+  }
+
+  vpHomogeneousMatrix cTw;
+  // Update translation vector
+  cTw[0][3] = tx;
+  cTw[1][3] = ty;
+  cTw[2][3] = tz;
+
+  // update rotation matrix
+  for (unsigned int i = 0; i < 3; i++) {
+    cTw[0][i] = r1[i];
+    cTw[1][i] = r2[i];
+    cTw[2][i] = r3[i];
+  }
+
+  return cTw;
+}
+
+static vpHomogeneousMatrix pose_dementhon(const vector<vpPoint>& points, bool centered)
+{
+  vector<vpColVector> wX(points.size()), x(points.size());
+
+  double cog_x = 0.0, cog_y = 0.0, cog_z = 0.0;
+  if (centered) {
+    /* compute the cog of the 3D points */
+    for (size_t i = 0; i < points.size(); i++) {
+      const vpPoint& pt = points[i];
+      cog_x += pt.get_oX();
+      cog_y += pt.get_oY();
+      cog_z += pt.get_oZ();
+    }
+
+    cog_x /= points.size();
+    cog_y /= points.size();
+    cog_z /= points.size();
+  }
+
+  for (size_t i = 0; i < points.size(); i++) {
+    const vpPoint& pt = points[i];
+
+    if (centered) {
+      wX[i] = {pt.get_oX() - cog_x, pt.get_oY() - cog_y, pt.get_oZ() - cog_z, 1.0};
+      x[i] = {pt.get_x(), pt.get_y(), 1.0};
+    } else {
+      wX[i] = {pt.get_oX(), pt.get_oY(), pt.get_oZ(), 1.0};
+      x[i] = {pt.get_x(), pt.get_y(), 1.0};
+    }
+  }
+
+  vpHomogeneousMatrix cMo = pose_dementhon(wX, x);
+  if (centered) {
+    // go back to the initial frame
+    cMo[0][3] -= (cog_x * cMo[0][0] + cog_y * cMo[0][1] + cog_z * cMo[0][2]);
+    cMo[1][3] -= (cog_x * cMo[1][0] + cog_y * cMo[1][1] + cog_z * cMo[1][2]);
+    cMo[2][3] -= (cog_x * cMo[2][0] + cog_y * cMo[2][1] + cog_z * cMo[2][2]);
+  }
+
+
+  return cMo;
+}
+} //namespace posit
+
+static double randInterval(double a, double b, vpUniRand& randGen)
+{
+  return a + (b-a) * randGen();
+}
+
+static vpHomogeneousMatrix generatePose(const vector<vpPoint>& points, vpUniRand& randGen, int nbTrials=10)
+{
+  vpHomogeneousMatrix cMo;
+
+  bool validPose = false;
+  for (int trial = 0; trial < nbTrials && !validPose; trial++) {
+    vpThetaUVector tu(randInterval(-1,1,randGen), randInterval(-1,1,randGen), randInterval(-1,1,randGen));
+    vpTranslationVector t(randInterval(-1,1,randGen), randInterval(-1,1,randGen), randInterval(0.5,2,randGen));
+    cMo.buildFrom(t, tu);
+
+    bool positiveDepth = true;
+    for (size_t i = 0; i < points.size() && positiveDepth; i++) {
+      vpPoint pt = points[i];
+      pt.changeFrame(cMo);
+      if (pt.get_Z() <= 0) {
+        positiveDepth = false;
+      }
+    }
+    validPose = positiveDepth;
+  }
+
+  return  cMo;
+}
+
+static double max3(double a, double b, double c)
+{
+  double max1 = (a < b) ? b : a;
+  return (max1 < c) ? c : max1;
+}
+
+static double safeAcos(double x)
+{
+  if (x < -1.0) x = -1.0;
+  else if (x > 1.0) x = 1.0;
+  return acos (x) ;
+}
+
+static double getRotationError(const vpHomogeneousMatrix& cMo_ref, const vpHomogeneousMatrix& cMo_est)
+{
+  vpRotationMatrix R_ref(cMo_ref), R_est(cMo_est);
+  double err0 = safeAcos(R_ref.getCol(0).t() * R_est.getCol(0)) * 180 / M_PI;
+  double err1 = safeAcos(R_ref.getCol(1).t() * R_est.getCol(1)) * 180 / M_PI;
+  double err2 = safeAcos(R_ref.getCol(2).t() * R_est.getCol(2)) * 180 / M_PI;
+
+  return max3(err0, err1, err2);
+}
+
+static double getTranslationError(const vpHomogeneousMatrix& cMo_ref, const vpHomogeneousMatrix& cMo_est)
+{
+  vpTranslationVector t_ref(cMo_ref), t_est(cMo_est);
+  return sqrt((t_ref - t_est).sumSquare()) / sqrt(t_est.sumSquare()) * 100;
+}
+
+static void getTimeInfo(const vector<double>& times, double& meanTime, double& medianTime, double& stdTime)
+{
+  if (!times.empty()) {
+    meanTime = vpMath::getMean(times);
+    medianTime = vpMath::getMedian(times);
+    stdTime = vpMath::getStdev(times);
+  }
+}
+
+struct ErrorInfo
+{
+  double rotationError;
+  double translationError;
+
+  ErrorInfo(double rotErr, double tErr) : rotationError(rotErr), translationError(tErr) {}
+};
+
+static double opExtractRotation(const ErrorInfo& err)
+{
+  return err.rotationError;
+}
+
+static double opExtractTranslation(const ErrorInfo& err)
+{
+  return err.translationError;
+}
+
+static void getErrorMean(const vector<ErrorInfo>& errors, double& rotationMeanError, double& translationMeanError)
+{
+  vector<double> rotationErrors(errors.size()), translationErrors(errors.size());
+  transform(errors.begin(), errors.end(), rotationErrors.begin(), opExtractRotation);
+  transform(errors.begin(), errors.end(), translationErrors.begin(), opExtractTranslation);
+
+  rotationMeanError = vpMath::getMean(rotationErrors);
+  translationMeanError = vpMath::getMean(translationErrors);
+}
+
+static void getErrorMedian(const vector<ErrorInfo>& errors, double& rotationMedianError, double& translationMedianError)
+{
+  vector<double> rotationErrors(errors.size()), translationErrors(errors.size());
+  transform(errors.begin(), errors.end(), rotationErrors.begin(), opExtractRotation);
+  transform(errors.begin(), errors.end(), translationErrors.begin(), opExtractTranslation);
+
+  rotationMedianError = vpMath::getMedian(rotationErrors);
+  translationMedianError = vpMath::getMedian(translationErrors);
+}
+
+static void getErrorStd(const vector<ErrorInfo>& errors, double& rotationStdError, double& translationStdError)
+{
+  vector<double> rotationErrors(errors.size()), translationErrors(errors.size());
+  transform(errors.begin(), errors.end(), rotationErrors.begin(), opExtractRotation);
+  transform(errors.begin(), errors.end(), translationErrors.begin(), opExtractTranslation);
+
+  rotationStdError = vpMath::getStdev(rotationErrors);
+  translationStdError = vpMath::getStdev(translationErrors);
+}
+
+static ErrorInfo getPoseError(const vpHomogeneousMatrix& cMo_ref, const vpHomogeneousMatrix& cMo_est)
+{
+  return ErrorInfo(getRotationError(cMo_ref, cMo_est), getTranslationError(cMo_ref, cMo_est));
+}
+
+static void runTest(vector<vpPoint> points,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsDementhon,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsPOSIT,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsPOSIT_centered,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsLagrange,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsEPPnP,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsEPnP,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsDementhonVVS,
+                    pair<vector<ErrorInfo>, vector<double> >& errorsLagrangeVVS,
+                    int gaussianSigma=0, int nbTrials=100)
+{
+  vpUniRand randGen;
+  vpGaussRand gaussRandGen(gaussianSigma, 0.0);
+  vpCameraParameters cam(600.0, 600.0, 320.0, 240.0);
+
+  vector<Point3d> cv_objectPoints(points.size());
+  for (size_t i = 0; i < points.size(); i++) {
+    const vpPoint& pt = points[i];
+    cv_objectPoints[i] = Point3d(pt.get_oX(), pt.get_oY(), pt.get_oZ());
+  }
+  vector<Point2d> cv_imagePoints(points.size());
+
+  for (int trial = 0; trial < nbTrials; trial++) {
+    vpHomogeneousMatrix cMo_ref = generatePose(points, randGen);
+    for (size_t i = 0; i < points.size(); i++) {
+      points[i].project(cMo_ref);
+
+      if (gaussianSigma > 0) {
+        vpImagePoint imPt;
+        vpMeterPixelConversion::convertPoint(cam, points[i].get_x(), points[i].get_y(), imPt);
+        imPt.set_uv(imPt.get_u() + gaussRandGen(), imPt.get_v() + gaussRandGen());
+
+        double x = 0.0, y = 0.0;
+        vpPixelMeterConversion::convertPoint(cam, imPt.get_u(), imPt.get_v(), x, y);
+        points[i].set_x(x);
+        points[i].set_y(y);
+      }
+
+      cv_imagePoints[i].x = points[i].get_x();
+      cv_imagePoints[i].y = points[i].get_y();
+    }
+    {
+      vpHomogeneousMatrix cMo_dementhon;
+      vpPose pose;
+      pose.addPoints(points);
+      try {
+        double t = vpTime::measureTimeMs();
+        pose.computePose(vpPose::DEMENTHON, cMo_dementhon);
+        t = vpTime::measureTimeMs() - t;
+        errorsDementhon.first.push_back(getPoseError(cMo_ref, cMo_dementhon));
+        errorsDementhon.second.push_back(t);
+      } catch (...) {}
+    }
+    {
+      const bool centered = false;
+      double t = vpTime::measureTimeMs();
+      vpHomogeneousMatrix cMo_POSIT = posit::pose_dementhon(points, centered);
+      t = vpTime::measureTimeMs() - t;
+      errorsPOSIT.first.push_back(getPoseError(cMo_ref, cMo_POSIT));
+      errorsPOSIT.second.push_back(t);
+    }
+    {
+      const bool centered = true;
+      double t = vpTime::measureTimeMs();
+      vpHomogeneousMatrix cMo_POSIT_centered = posit::pose_dementhon(points, centered);
+      t = vpTime::measureTimeMs() - t;
+      errorsPOSIT_centered.first.push_back(getPoseError(cMo_ref, cMo_POSIT_centered));
+      errorsPOSIT_centered.second.push_back(t);
+    }
+    {
+      vpHomogeneousMatrix cMo_lagrange;
+      vpPose pose;
+      pose.addPoints(points);
+      try {
+        double t = vpTime::measureTimeMs();
+        pose.computePose(vpPose::LAGRANGE, cMo_lagrange);
+        t = vpTime::measureTimeMs() - t;
+        errorsLagrange.first.push_back(getPoseError(cMo_ref, cMo_lagrange));
+        errorsLagrange.second.push_back(t);
+      } catch (...) {}
+    }
+    {
+      vpHomogeneousMatrix cMo_EPPnP;
+      vpPose pose;
+      pose.addPoints(points);
+      try {
+        double t = vpTime::measureTimeMs();
+        pose.computePose(vpPose::EPPnP, cMo_EPPnP);
+        t = vpTime::measureTimeMs() - t;
+        errorsEPPnP.first.push_back(getPoseError(cMo_ref, cMo_EPPnP));
+        errorsEPPnP.second.push_back(t);
+      } catch (...) {}
+    }
+#if (VISP_HAVE_OPENCV_VERSION >= 0x030000)
+    {
+      Matx31d rvec, tvec;
+      double t = vpTime::measureTimeMs();
+      bool success = solvePnP(cv_objectPoints, cv_imagePoints, Matx33d::eye(), noArray(), rvec, tvec, false, SOLVEPNP_EPNP);
+      t = vpTime::measureTimeMs() - t;
+      if (success) {
+        vpHomogeneousMatrix cMo_EPnP(vpTranslationVector(tvec(0), tvec(1), tvec(2)), vpThetaUVector(rvec(0), rvec(1), rvec(2)));
+        errorsEPnP.first.push_back(getPoseError(cMo_ref, cMo_EPnP));
+        errorsEPnP.second.push_back(t);
+      }
+    }
+#endif
+    {
+      vpHomogeneousMatrix cMo_dementhonVVS;
+      vpPose pose;
+      pose.addPoints(points);
+      try {
+        double t = vpTime::measureTimeMs();
+        pose.computePose(vpPose::DEMENTHON_VIRTUAL_VS, cMo_dementhonVVS);
+        t = vpTime::measureTimeMs() - t;
+        errorsDementhonVVS.first.push_back(getPoseError(cMo_ref, cMo_dementhonVVS));
+        errorsDementhonVVS.second.push_back(t);
+      } catch (...) {}
+    }
+    {
+      vpHomogeneousMatrix cMo_lagrangeVVS;
+      vpPose pose;
+      pose.addPoints(points);
+      try {
+        double t = vpTime::measureTimeMs();
+        pose.computePose(vpPose::LAGRANGE_VIRTUAL_VS, cMo_lagrangeVVS);
+        t = vpTime::measureTimeMs() - t;
+        errorsLagrangeVVS.first.push_back(getPoseError(cMo_ref, cMo_lagrangeVVS));
+        errorsLagrangeVVS.second.push_back(t);
+      } catch (...) {}
+    }
+  }
+}
+
+static vector<vpPoint> generateRandomObjectPointsSkew(int nbPoints, vpUniRand& randGen, double size=0.2)
+{
+  vector<vpPoint> points(static_cast<size_t>(nbPoints));
+
+  for (int i = 0; i < nbPoints; i++) {
+    points.push_back(vpPoint(randInterval(0, 2*size, randGen),
+                             randInterval(0, 2*size, randGen),
+                             randInterval(0, 2*size, randGen)));
+  }
+
+  return  points;
+}
+
+static vector<vpPoint> generateRandomObjectPoints(int nbPoints, vpUniRand& randGen, double size=0.2)
+{
+  vector<vpPoint> points(static_cast<size_t>(nbPoints));
+
+  for (int i = 0; i < nbPoints; i++) {
+    points.push_back(vpPoint(randInterval(-size, size, randGen),
+                             randInterval(-size, size, randGen),
+                             randInterval(-size, size, randGen)));
+  }
+
+  return  points;
+}
+
+struct TestResults
+{
+  double meanRotationError;
+  double meanTranslationError;
+  double medianRotationError;
+  double medianTranslationError;
+  double stdRotationError;
+  double stdTranslationError;
+  double meanComputationTime;
+  double medianComputationTime;
+  double stdComputationTime;
+
+  TestResults(double meanRot, double meanTrans,
+              double medianRot, double medianTrans,
+              double stdRot, double stdTrans,
+              double meanTime, double medianTime, double stdTime) :
+    meanRotationError(meanRot), meanTranslationError(meanTrans), medianRotationError(medianRot),
+    medianTranslationError(medianTrans), stdRotationError(stdRot), stdTranslationError(stdTrans),
+    meanComputationTime(meanTime), medianComputationTime(medianTime), stdComputationTime(stdTime) {}
+
+  TestResults() :
+    meanRotationError(0), meanTranslationError(0), medianRotationError(0),
+    medianTranslationError(0), stdRotationError(0), stdTranslationError(0),
+    meanComputationTime(0), medianComputationTime(0), stdComputationTime(0) {}
+};
+
+static void runTestNonPlanar(bool skew, int minPoints=4, int maxPoints=100)
+{
+  vpUniRand randGen;
+
+  map<int, map<string, TestResults> > mapOfResults;
+  for (int nbPoints = minPoints; nbPoints <= maxPoints; nbPoints++) {
+    vector<vpPoint> points;
+    if (skew) {
+      points = generateRandomObjectPointsSkew(nbPoints, randGen);
+    } else {
+      points = generateRandomObjectPoints(nbPoints, randGen);
+    }
+
+    pair<vector<ErrorInfo>, vector<double> > errorsDementhon, errorsPOSIT, errorsPOSIT_centered, errorsLagrange, errorsEPPnP, errorsEPnP;
+    pair<vector<ErrorInfo>, vector<double> > errorsDementhonVVS, errorsLagrangeVVS;
+    const int gaussianSigma = 2; //constant Gaussian noise of 2
+    runTest(points, errorsDementhon, errorsPOSIT, errorsPOSIT_centered, errorsLagrange, errorsEPPnP, errorsEPnP,
+            errorsDementhonVVS, errorsLagrangeVVS, gaussianSigma);
+
+    map<string, TestResults> mapOfTestResults;
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsDementhon.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsDementhon.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsDementhon.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsDementhon.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Dementhon"] = TestResults(rotErrMean, transErrMean,
+                                                  rotErrMedian, transErrMedian,
+                                                  rotErrStd, transErrStd,
+                                                  meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsPOSIT.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsPOSIT.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsPOSIT.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsPOSIT.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["POSIT"] = TestResults(rotErrMean, transErrMean,
+                                              rotErrMedian, transErrMedian,
+                                              rotErrStd, transErrStd,
+                                              meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsPOSIT_centered.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsPOSIT_centered.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsPOSIT_centered.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsPOSIT_centered.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["POSIT centered"] = TestResults(rotErrMean, transErrMean,
+                                                       rotErrMedian, transErrMedian,
+                                                       rotErrStd, transErrStd,
+                                                       meanTime, medianTime, stdTime);
+    }
+    if (nbPoints >= 6)
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsLagrange.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsLagrange.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsLagrange.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsLagrange.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Lagrange"] = TestResults(rotErrMean, transErrMean,
+                                                 rotErrMedian, transErrMedian,
+                                                 rotErrStd, transErrStd,
+                                                 meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsEPPnP.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsEPPnP.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsEPPnP.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsEPPnP.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["EPPnP"] = TestResults(rotErrMean, transErrMean,
+                                              rotErrMedian, transErrMedian,
+                                              rotErrStd, transErrStd,
+                                              meanTime, medianTime, stdTime);
+    }
+#if (VISP_HAVE_OPENCV_VERSION >= 0x030000)
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsEPnP.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsEPnP.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsEPnP.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsEPnP.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["EPnP"] = TestResults(rotErrMean, transErrMean,
+                                             rotErrMedian, transErrMedian,
+                                             rotErrStd, transErrStd,
+                                             meanTime, medianTime, stdTime);
+    }
+#endif
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsDementhonVVS.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsDementhonVVS.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsDementhonVVS.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsDementhonVVS.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Dementhon VVS"] = TestResults(rotErrMean, transErrMean,
+                                                      rotErrMedian, transErrMedian,
+                                                      rotErrStd, transErrStd,
+                                                      meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsLagrangeVVS.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsLagrangeVVS.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsLagrangeVVS.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsLagrangeVVS.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Lagrange VVS"] = TestResults(rotErrMean, transErrMean,
+                                                     rotErrMedian, transErrMedian,
+                                                     rotErrStd, transErrStd,
+                                                     meanTime, medianTime, stdTime);
+    }
+
+    mapOfResults[nbPoints] = mapOfTestResults;
+  }
+
+  vpPlot plot(3);
+  plot.initGraph(0, 8);
+  plot.setLegend(0, 0, "Dementhon");
+  plot.setLegend(0, 1, "POSIT");
+  plot.setLegend(0, 2, "POSIT centered");
+  plot.setLegend(0, 3, "Lagrange");
+  plot.setLegend(0, 4, "EPPnP");
+  plot.setLegend(0, 5, "EPnP");
+  plot.setLegend(0, 6, "Dementhon VVS");
+  plot.setLegend(0, 7, "Lagrange VVS");
+
+  plot.initGraph(1, 8);
+  plot.setLegend(1, 0, "Dementhon");
+  plot.setLegend(1, 1, "POSIT");
+  plot.setLegend(1, 2, "POSIT centered");
+  plot.setLegend(1, 3, "Lagrange");
+  plot.setLegend(1, 4, "EPPnP");
+  plot.setLegend(1, 5, "EPnP");
+  plot.setLegend(1, 6, "Dementhon VVS");
+  plot.setLegend(1, 7, "Lagrange VVS");
+
+  plot.initGraph(2, 8);
+  plot.setLegend(2, 0, "Dementhon");
+  plot.setLegend(2, 1, "POSIT");
+  plot.setLegend(2, 2, "POSIT centered");
+  plot.setLegend(2, 3, "Lagrange");
+  plot.setLegend(2, 4, "EPPnP");
+  plot.setLegend(2, 5, "EPnP");
+  plot.setLegend(2, 6, "Dementhon VVS");
+  plot.setLegend(2, 7, "Lagrange VVS");
+
+  for (map<int, map<string, TestResults> >::const_iterator it1 = mapOfResults.begin(); it1 != mapOfResults.end(); ++it1) {
+    map<string, TestResults>::const_iterator it2 = it1->second.find("Dementhon");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 0, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 0, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 0, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("POSIT");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 1, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 1, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 1, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("POSIT centered");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 2, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 2, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 2, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("Lagrange");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 3, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 3, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 3, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("EPPnP");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 4, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 4, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 4, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("EPnP");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 5, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 5, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 5, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("Dementhon VVS");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 6, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 6, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 6, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("Lagrange VVS");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 7, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 7, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 7, it1->first, it2->second.medianComputationTime);
+    }
+  }
+
+  if (skew) {
+    plot.saveData(0, "TestNonPlanar_rotationErrors_skew.txt");
+    plot.saveData(1, "TestNonPlanar_translationErrors_skew.txt");
+    plot.saveData(2, "TestNonPlanar_computationTime_skew.txt");
+  } else {
+    plot.saveData(0, "TestNonPlanar_rotationErrors.txt");
+    plot.saveData(1, "TestNonPlanar_translationErrors.txt");
+    plot.saveData(2, "TestNonPlanar_computationTime.txt");
+  }
+}
+
+static void runTestNonPlanarGaussianNoise(int nbPoints, bool skew, int minGaussianSigma=0, int maxGaussianSigma=20)
+{
+  vpUniRand randGen;
+
+  map<int, map<string, TestResults> > mapOfResults;
+  for (int gaussianSigma = minGaussianSigma; gaussianSigma <= maxGaussianSigma; gaussianSigma++) {
+    vector<vpPoint> points;
+    if (skew) {
+      points = generateRandomObjectPointsSkew(nbPoints, randGen);
+    } else {
+      points = generateRandomObjectPoints(nbPoints, randGen);
+    }
+
+    pair<vector<ErrorInfo>, vector<double> > errorsDementhon, errorsPOSIT, errorsPOSIT_centered, errorsLagrange, errorsEPPnP, errorsEPnP;
+    pair<vector<ErrorInfo>, vector<double> > errorsDementhonVVS, errorsLagrangeVVS;
+    runTest(points, errorsDementhon, errorsPOSIT, errorsPOSIT_centered, errorsLagrange, errorsEPPnP, errorsEPnP,
+            errorsDementhonVVS, errorsLagrangeVVS, gaussianSigma);
+
+    map<string, TestResults> mapOfTestResults;
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsDementhon.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsDementhon.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsDementhon.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsDementhon.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Dementhon"] = TestResults(rotErrMean, transErrMean,
+                                                  rotErrMedian, transErrMedian,
+                                                  rotErrStd, transErrStd,
+                                                  meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsPOSIT.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsPOSIT.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsPOSIT.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsPOSIT.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["POSIT"] = TestResults(rotErrMean, transErrMean,
+                                              rotErrMedian, transErrMedian,
+                                              rotErrStd, transErrStd,
+                                              meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsPOSIT_centered.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsPOSIT_centered.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsPOSIT_centered.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsPOSIT_centered.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["POSIT centered"] = TestResults(rotErrMean, transErrMean,
+                                                       rotErrMedian, transErrMedian,
+                                                       rotErrStd, transErrStd,
+                                                       meanTime, medianTime, stdTime);
+    }
+    if (nbPoints >= 6)
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsLagrange.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsLagrange.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsLagrange.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsLagrange.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Lagrange"] = TestResults(rotErrMean, transErrMean,
+                                                 rotErrMedian, transErrMedian,
+                                                 rotErrStd, transErrStd,
+                                                 meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsEPPnP.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsEPPnP.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsEPPnP.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsEPPnP.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["EPPnP"] = TestResults(rotErrMean, transErrMean,
+                                              rotErrMedian, transErrMedian,
+                                              rotErrStd, transErrStd,
+                                              meanTime, medianTime, stdTime);
+    }
+#if (VISP_HAVE_OPENCV_VERSION >= 0x030000)
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsEPnP.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsEPnP.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsEPnP.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsEPnP.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["EPnP"] = TestResults(rotErrMean, transErrMean,
+                                             rotErrMedian, transErrMedian,
+                                             rotErrStd, transErrStd,
+                                             meanTime, medianTime, stdTime);
+    }
+#endif
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsDementhonVVS.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsDementhonVVS.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsDementhonVVS.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsDementhonVVS.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Dementhon VVS"] = TestResults(rotErrMean, transErrMean,
+                                                      rotErrMedian, transErrMedian,
+                                                      rotErrStd, transErrStd,
+                                                      meanTime, medianTime, stdTime);
+    }
+    {
+      double rotErrMean = 0.0, transErrMean = 0.0;
+      getErrorMean(errorsLagrangeVVS.first, rotErrMean, transErrMean);
+      double rotErrMedian = 0.0, transErrMedian = 0.0;
+      getErrorMedian(errorsLagrangeVVS.first, rotErrMedian, transErrMedian);
+      double rotErrStd = 0.0, transErrStd = 0.0;
+      getErrorStd(errorsLagrangeVVS.first, rotErrStd, transErrStd);
+      double meanTime = 0.0, medianTime = 0.0, stdTime = 0.0;
+      getTimeInfo(errorsLagrangeVVS.second, meanTime, medianTime, stdTime);
+
+      mapOfTestResults["Lagrange VVS"] = TestResults(rotErrMean, transErrMean,
+                                                     rotErrMedian, transErrMedian,
+                                                     rotErrStd, transErrStd,
+                                                     meanTime, medianTime, stdTime);
+    }
+
+    mapOfResults[gaussianSigma] = mapOfTestResults;
+  }
+
+  vpPlot plot(3);
+  plot.initGraph(0, 8);
+  plot.setLegend(0, 0, "Dementhon");
+  plot.setLegend(0, 1, "POSIT");
+  plot.setLegend(0, 2, "POSIT centered");
+  plot.setLegend(0, 3, "Lagrange");
+  plot.setLegend(0, 4, "EPPnP");
+  plot.setLegend(0, 5, "EPnP");
+  plot.setLegend(0, 6, "Dementhon VVS");
+  plot.setLegend(0, 7, "Lagrange VVS");
+
+  plot.initGraph(1, 8);
+  plot.setLegend(1, 0, "Dementhon");
+  plot.setLegend(1, 1, "POSIT");
+  plot.setLegend(1, 2, "POSIT centered");
+  plot.setLegend(1, 3, "Lagrange");
+  plot.setLegend(1, 4, "EPPnP");
+  plot.setLegend(1, 5, "EPnP");
+  plot.setLegend(1, 6, "Dementhon VVS");
+  plot.setLegend(1, 7, "Lagrange VVS");
+
+  plot.initGraph(2, 8);
+  plot.setLegend(2, 0, "Dementhon");
+  plot.setLegend(2, 1, "POSIT");
+  plot.setLegend(2, 2, "POSIT centered");
+  plot.setLegend(2, 3, "Lagrange");
+  plot.setLegend(2, 4, "EPPnP");
+  plot.setLegend(2, 5, "EPnP");
+  plot.setLegend(2, 6, "Dementhon VVS");
+  plot.setLegend(2, 7, "Lagrange VVS");
+
+  for (map<int, map<string, TestResults> >::const_iterator it1 = mapOfResults.begin(); it1 != mapOfResults.end(); ++it1) {
+    map<string, TestResults>::const_iterator it2 = it1->second.find("Dementhon");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 0, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 0, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 0, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("POSIT");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 1, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 1, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 1, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("POSIT centered");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 2, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 2, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 2, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("Lagrange");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 3, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 3, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 3, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("EPPnP");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 4, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 4, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 4, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("EPnP");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 5, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 5, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 5, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("Dementhon VVS");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 6, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 6, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 6, it1->first, it2->second.medianComputationTime);
+    }
+
+    it2 = it1->second.find("Lagrange VVS");
+    if (it2 != it1->second.end()) {
+      plot.plot(0, 7, it1->first, it2->second.medianRotationError);
+      plot.plot(1, 7, it1->first, it2->second.medianTranslationError);
+      plot.plot(2, 7, it1->first, it2->second.medianComputationTime);
+    }
+  }
+
+  if (skew) {
+    plot.saveData(0, "TestNonPlanar_GaussianNoise_rotationErrors_skew.txt");
+    plot.saveData(1, "TestNonPlanar_GaussianNoise_translationErrors_skew.txt");
+    plot.saveData(2, "TestNonPlanar_GaussianNoise_computationTime_skew.txt");
+  } else {
+    plot.saveData(0, "TestNonPlanar_GaussianNoise_rotationErrors.txt");
+    plot.saveData(1, "TestNonPlanar_GaussianNoise_translationErrors.txt");
+    plot.saveData(2, "TestNonPlanar_GaussianNoise_computationTime.txt");
+  }
+}
+
+} //namespace
+
+int main()
+{
+  {
+    const bool skew = false;
+    const int minPoints = 6;
+    runTestNonPlanar(skew, minPoints);
+  }
+  {
+    const bool skew = false;
+    const int nbPoints = 30;
+    runTestNonPlanarGaussianNoise(nbPoints, skew);
+  }
+  {
+    const bool skew = true;
+    const int minPoints = 6;
+    runTestNonPlanar(skew, minPoints);
+  }
+  {
+    const bool skew = true;
+    const int nbPoints = 30;
+    runTestNonPlanarGaussianNoise(nbPoints, skew);
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Efficient Procrustes PnP (EPPnP) and Robust Efficient Procrustes PnP (REPPnP) C++ code based on the [Matlab implementation code](https://www.iri.upc.edu/people/fmoreno/FMoreno_Publ.html):
```
@inproceedings{Ferraz_cvpr2014,
title = {Very Fast Solution to the PnP Problem with Algebraic Outlier Rejection},
author = {L. Ferraz and X. Binefa and F. Moreno-Noguer},
booktitle = {Proceedings of the Conference on Computer Vision and Pattern Recognition (CVPR)},
pages = {501-508},
year = {2014}
}
```

After implementing the C++ code, unfortunately I did not manage to get good results for the REPPnP method compared to a RANSAC approach on real data. For EPPnP, performance of the approach drops for n <= 6 and the planar case does not handle all the cases in the current implementation.

**Current implemented methods in ViSP are sufficient and I will just summarizes the results here.**

---

Tested methods are:

- Dementhon, Lagrange, Dementhon + VVS and Lagrange VVS from ViSP
- POSIT [from the tutorial](https://visp-doc.inria.fr/doxygen/camera_localization/tutorial-pose-dementhon-visp.html) and POSIT with 3D object coordinates centered
- EPnP from OpenCV

- Rotation error vs number of points with constant Gaussian noise

![TestNonPlanar_rotationErrors](https://user-images.githubusercontent.com/8035162/60403557-225aeb80-9b9f-11e9-8893-3e9617ee2436.png)

- Translation error vs number of points with constant Gaussian noise

![TestNonPlanar_translationErrors](https://user-images.githubusercontent.com/8035162/60403567-3acb0600-9b9f-11e9-9d69-d4ace47b51ab.png)

- Rotation error vs Gaussian noise

![TestNonPlanar_GaussianNoise_rotationErrors](https://user-images.githubusercontent.com/8035162/60403576-51715d00-9b9f-11e9-9cca-6e1cabcaede5.png)

- Translation error vs Gaussian noise

![TestNonPlanar_GaussianNoise_translationErrors](https://user-images.githubusercontent.com/8035162/60403579-5d5d1f00-9b9f-11e9-847e-4ea9d20356b3.png)

- Computation time

![TestNonPlanar_computationTime](https://user-images.githubusercontent.com/8035162/60403586-7239b280-9b9f-11e9-8de7-125f57e4f988.png)

These figures were plotted using the median and with generated object points centered to zero. With the mean and generated object points skewed (the plots are more scattered when using the mean):

- Rotation error vs Gaussian noise (mean)

![TestNonPlanar_GaussianNoise_rotationErrors_skew](https://user-images.githubusercontent.com/8035162/60403642-305d3c00-9ba0-11e9-8a73-f399bd103f43.png)

- Translation error vs Gaussian noise (mean)

![TestNonPlanar_GaussianNoise_translationErrors_skew](https://user-images.githubusercontent.com/8035162/60403661-7adeb880-9ba0-11e9-973e-66fea2504613.png)

---

At the end, Dementhon + VVS will give better results than EPPnP. Since EPPnP is not appropriate when the number of points is <= 6, we cannot use it during the first RANSAC step. Also, since the Dementhon in ViSP "normalizes" the 3D object coordinates, it does not suffer of the center of gravity of the input points.

Lagrange method is very sensitive to the image noise. Also, most of the time we use 4 non-coplanar points to initialize the model-based tracker and the Lagrange method needs at least 6 points.

These are all results from simulated data. A better representation would be to use boxplots and not only the median values.