### PR TITLE
Fix Drone CI build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: gcc
-    CMAKE_FLAGS: '-DBUILD_DEMOS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_JAVA=OFF -DBUILD_MODULE_visp_java_bindings_generator=OFF -DBUILD_TUTORIALS=OFF'
+    CMAKE_FLAGS: '-DBUILD_DEMOS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_JAVA=OFF -DBUILD_MODULE_visp_java_bindings_generator=OFF -DBUILD_TUTORIALS=OFF -DCTEST_TEST_TIMEOUT=2500'
   commands:
     - lscpu
     - cat /proc/cpuinfo
@@ -79,7 +79,7 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: gcc
-    CMAKE_FLAGS: '-DBUILD_DEMOS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_JAVA=OFF -DBUILD_MODULE_visp_java_bindings_generator=OFF -DBUILD_TUTORIALS=OFF'
+    CMAKE_FLAGS: '-DBUILD_DEMOS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_JAVA=OFF -DBUILD_MODULE_visp_java_bindings_generator=OFF -DBUILD_TUTORIALS=OFF -DCTEST_TEST_TIMEOUT=2500'
   commands:
     - lscpu
     - cat /proc/cpuinfo

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Platform | Build Status |
 -------- | ------------ |
 Linux and OS X | [![Build Status](https://travis-ci.org/lagadic/visp.png)](https://travis-ci.org/lagadic/visp) |
 Windows | [![Build status](https://ci.appveyor.com/api/projects/status/121dscdkryf5dbn0/branch/master?svg=true)](https://ci.appveyor.com/project/fspindle/visp/branch/master) |
+ARM | [![Build Status](https://cloud.drone.io/api/badges/lagadic/visp/status.svg)](https://cloud.drone.io/lagadic/visp) |
 
 This project is a cross-platform library (Linux, Windows, Mac) that allows prototyping and developing applications using visual tracking and visual servoing technics at the heart of the researches done now by Inria <a href="http://team.inria.fr/rainbow">Rainbow team</a> and before 2018 by <a href="http://team.inria.fr/lagadic">Lagadic team</a>. ViSP is able to compute control laws that can be applied to robotic systems. It provides a set of visual features that can be tracked using real time image processing or computer vision algorithms. ViSP provides also simulation capabilities. ViSP can be useful in robotics, computer vision, augmented reality and computer animation. Our <a href="https://www.youtube.com/user/VispTeam">YouTube channel</a> gives an overview of the applications that could be tackled.
 

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -279,10 +279,10 @@ void vpIoTools::getUserName(std::string &username)
   DWORD bufCharCount = (DWORD)info_buffer_size;
   // Get the user name.
   if (!GetUserName(infoBuf, &bufCharCount)) {
-    delete[] infoBuf;
-    throw(vpIoException(vpIoException::cantGetUserName, "Cannot get the username"));
+    username = "unknown";
+  } else {
+    username = infoBuf;
   }
-  username = infoBuf;
   delete[] infoBuf;
 #else
   // Universal platform
@@ -292,6 +292,7 @@ void vpIoTools::getUserName(std::string &username)
   username = "unknown";
 #endif
 }
+
 /*!
   Get the user name.
 
@@ -304,40 +305,12 @@ void vpIoTools::getUserName(std::string &username)
 
   \return The user name.
 
-  \exception vpIoException::cantGetUserName : If this method cannot get the
-  user name.
-
   \sa getUserName(std::string &)
 */
 std::string vpIoTools::getUserName()
 {
   std::string username;
-#if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
-  // Get the user name.
-  char *_username = ::getenv("LOGNAME");
-  if (! _username) {
-    vpERROR_TRACE("Cannot get the username. Check your LOGNAME environment variable");
-    throw(vpIoException(vpIoException::cantGetUserName, "Cannot get the username"));
-  }
-  username = _username;
-#elif defined(_WIN32)
-#if (!defined(WINRT))
-  unsigned int info_buffer_size = 1024;
-  TCHAR *infoBuf = new TCHAR[info_buffer_size];
-  DWORD bufCharCount = (DWORD)info_buffer_size;
-  // Get the user name.
-  if (!GetUserName(infoBuf, &bufCharCount)) {
-    delete[] infoBuf;
-    vpERROR_TRACE("Cannot get the username");
-    throw(vpIoException(vpIoException::cantGetUserName, "Cannot get the username"));
-  }
-  username = infoBuf;
-  delete[] infoBuf;
-#else
-  throw(vpIoException(vpIoException::cantGetUserName, "Cannot get the username: not implemented on Universal "
-                                                      "Windows Platform"));
-#endif
-#endif
+  getUserName(username);
   return username;
 }
 


### PR DESCRIPTION
Do not throw an exception but rather set username to `unknown` for `vpIoTools::getUserName()` on Windows (same behavior than for Unix).

Uniform the behavior between `void vpIoTools::getUserName(std::string &username)` and `std::string vpIoTools::getUserName()`.