### PR TITLE
Optimize template tracker

### DIFF
--- a/example/tracking/CMakeLists.txt
+++ b/example/tracking/CMakeLists.txt
@@ -195,12 +195,8 @@ add_test(trackDot2        trackDot2 -c ${OPTION_TO_DESACTIVE_DISPLAY})
 #add_test(templateTracker-SSDESM-SRT           templateTracker -c -l 2 -t 0 -w 3 ${OPTION_TO_DESACTIVE_DISPLAY})
 #add_test(templateTracker-SSDESM-Translation   templateTracker -c -l 2 -t 0 -w 4 ${OPTION_TO_DESACTIVE_DISPLAY})
 
-add_test(templateTrackerPyramidal-SSDESM-Affine        templateTracker -c -l 2 -t 0 -w 0 -p ${OPTION_TO_DESACTIVE_DISPLAY})
-add_test(templateTrackerPyramidal-SSDESM-Homography    templateTracker -c -l 2 -t 0 -w 1 -p ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(templateTrackerPyramidal-SSDESM-HomographySL3 templateTracker -c -l 2 -t 0 -w 2 -p ${OPTION_TO_DESACTIVE_DISPLAY})
-add_test(templateTrackerPyramidal-SSDESM-SRT           templateTracker -c -l 2 -t 0 -w 3 -p ${OPTION_TO_DESACTIVE_DISPLAY})
 add_test(templateTrackerPyramidal-SSDESM-Translation   templateTracker -c -l 2 -t 0 -w 4 -p ${OPTION_TO_DESACTIVE_DISPLAY})
-add_test(templateTrackerPyramidal-SSDESM-RT            templateTracker -c -l 2 -t 0 -w 5 -p ${OPTION_TO_DESACTIVE_DISPLAY})
 
 #add_test(templateTracker-SSDForwardAdditional-Affine        templateTracker -c -l 2 -t 1 -w 0 ${OPTION_TO_DESACTIVE_DISPLAY})
 #add_test(templateTracker-SSDForwardAdditional-Homography    templateTracker -c -l 2 -t 1 -w 1 ${OPTION_TO_DESACTIVE_DISPLAY})

--- a/example/tracking/templateTracker.cpp
+++ b/example/tracking/templateTracker.cpp
@@ -84,7 +84,7 @@
 #include <visp3/tt_mi/vpTemplateTrackerMIInverseCompositional.h>
 #endif
 
-#define GETOPTARGS "cdhi:l:pt:w:"
+#define GETOPTARGS "cdhi:l:Lprs:t:w:"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 typedef enum {
@@ -118,12 +118,7 @@ typedef enum {
 #endif
 
 void usage(const char *name, const char *badparam, const WarpType &warp_type, TrackerType &tracker_type,
-           const long &last_frame);
-bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_allowed, bool &display, bool &pyramidal,
-                WarpType &warp_type, TrackerType &tracker_type, long &last_frame);
-
-void usage(const char *name, const char *badparam, const WarpType &warp_type, TrackerType &tracker_type,
-           const long &last_frame)
+           const long &last_frame, const double &residual_threhold)
 {
   fprintf(stdout, "\n\
 Example of template tracking.\n\
@@ -131,7 +126,7 @@ Example of template tracking.\n\
 SYNOPSIS\n\
   %s [-i <test image path>] [-c] [-d] [-p] \n\
      [-w <warp type>] [-t <tracker type>] \n\
-     [-l <last frame number>] [-h]\n", name);
+     [-l <last frame number>] [-r] [-L] [-h]\n", name);
 
   fprintf(stdout, "\n\
 OPTIONS:                                                            Default\n\
@@ -195,7 +190,7 @@ OPTIONS:                                                            Default\n\
      %d : MI ESM\n\
      %d : MI forward additional\n\
      %d : MI forward compositional\n\
-     %d : MI inverse compositional\n\n", (int)tracker_type, (int)TRACKER_SSD_ESM, (int)TRACKER_SSD_FORWARD_ADDITIONAL,
+     %d : MI inverse compositional\n", (int)tracker_type, (int)TRACKER_SSD_ESM, (int)TRACKER_SSD_FORWARD_ADDITIONAL,
           (int)TRACKER_SSD_FORWARD_COMPOSITIONAL, (int)TRACKER_SSD_INVERSE_COMPOSITIONAL,
           (int)TRACKER_ZNCC_FORWARD_ADDITIONEL, (int)TRACKER_ZNCC_INVERSE_COMPOSITIONAL, (int)TRACKER_MI_ESM,
           (int)TRACKER_MI_FORWARD_ADDITIONAL, (int)TRACKER_MI_FORWARD_COMPOSITIONAL,
@@ -210,7 +205,7 @@ OPTIONS:                                                            Default\n\
      %d : SSD forward compositional\n\
      %d : SSD inverse compositional\n\
      %d : ZNCC forward additional\n\
-     %d : ZNCC inverse compositional\n\n", (int)tracker_type, (int)TRACKER_SSD_ESM, (int)TRACKER_SSD_FORWARD_ADDITIONAL,
+     %d : ZNCC inverse compositional\n", (int)tracker_type, (int)TRACKER_SSD_ESM, (int)TRACKER_SSD_FORWARD_ADDITIONAL,
           (int)TRACKER_SSD_FORWARD_COMPOSITIONAL, (int)TRACKER_SSD_INVERSE_COMPOSITIONAL,
           (int)TRACKER_ZNCC_FORWARD_ADDITIONEL, (int)TRACKER_ZNCC_INVERSE_COMPOSITIONAL);
 
@@ -218,16 +213,28 @@ OPTIONS:                                                            Default\n\
   fprintf(stdout, "\n\
   -p\n\
      Enable pyramidal tracking.\n\
-                  \n\
+                          \n\
+  -r\n\
+     Disable re-init at frame 10.\n\
+                          \n\
+  -s <residual r-threshold>                                            %g\n\
+     Threshold used to stop optimization when residual difference\n\
+     between two successive optimization iteration becomes lower\n\
+     that this parameter.\n\
+          \n\
+  -L \n\
+     Create log file.\n\
+                                  \n\
   -h \n\
-     Print the help.\n\n");
+     Print the help.\n\n", residual_threhold);
 
   if (badparam)
     fprintf(stdout, "\nERROR: Bad parameter [%s]\n", badparam);
 }
 
 bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_allowed, bool &display, bool &pyramidal,
-                WarpType &warp_type, TrackerType &tracker_type, long &last_frame)
+                WarpType &warp_type, TrackerType &tracker_type, long &last_frame, bool &reinit, double &threshold_residual,
+                bool &log)
 {
   const char *optarg_;
   int c;
@@ -241,7 +248,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
       display = false;
       break;
     case 'h':
-      usage(argv[0], NULL, warp_type, tracker_type, last_frame);
+      usage(argv[0], NULL, warp_type, tracker_type, last_frame, threshold_residual);
       return false;
       break;
     case 'i':
@@ -250,8 +257,14 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
     case 'l':
       last_frame = (long)atoi(optarg_);
       break;
+    case 'L':
+      log = true;
+      break;
     case 'p':
       pyramidal = true;
+      break;
+    case 'r':
+      reinit = false;
       break;
     case 't':
       tracker_type = (TrackerType)atoi(optarg_);
@@ -259,22 +272,25 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
     case 'w':
       warp_type = (WarpType)atoi(optarg_);
       break;
+    case 's':
+      threshold_residual = std::atof(optarg_);
+      break;
 
     default:
-      usage(argv[0], optarg_, warp_type, tracker_type, last_frame);
+      usage(argv[0], optarg_, warp_type, tracker_type, last_frame, threshold_residual);
       return false;
       break;
     }
   }
 
   if (warp_type >= WARP_LAST) {
-    usage(argv[0], NULL, warp_type, tracker_type, last_frame);
+    usage(argv[0], NULL, warp_type, tracker_type, last_frame, threshold_residual);
     std::cerr << "ERROR: " << std::endl;
     std::cerr << "  Bad argument -w <warp type> with \"warp type\"=" << (int)warp_type << std::endl << std::endl;
     return false;
   }
   if (tracker_type >= TRACKER_LAST) {
-    usage(argv[0], NULL, warp_type, tracker_type, last_frame);
+    usage(argv[0], NULL, warp_type, tracker_type, last_frame, threshold_residual);
     std::cerr << "ERROR: " << std::endl;
     std::cerr << "  Bad argument -t <tracker type> with \"tracker type\"=" << (int)tracker_type << std::endl
               << std::endl;
@@ -282,7 +298,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
   }
   if ((c == 1) || (c == -1)) {
     // standalone param or error
-    usage(argv[0], NULL, warp_type, tracker_type, last_frame);
+    usage(argv[0], NULL, warp_type, tracker_type, last_frame, threshold_residual);
     std::cerr << "ERROR: " << std::endl;
     std::cerr << "  Bad argument " << optarg_ << std::endl << std::endl;
     return false;
@@ -303,6 +319,21 @@ int main(int argc, const char **argv)
     TrackerType opt_tracker_type = TRACKER_SSD_INVERSE_COMPOSITIONAL;
     WarpType opt_warp_type = WARP_AFFINE;
     long opt_last_frame = 30;
+    bool opt_reinit = true;
+    double opt_threshold_residual = 1e-4;
+    bool opt_log = false;
+    std::ofstream ofs;
+
+    // Set the default output path
+#if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
+    std::string opath = "/tmp";
+#elif defined(_WIN32)
+    std::string opath = "C:\\temp";
+#endif
+
+    // Get the user login name
+    std::string username;
+    vpIoTools::getUserName(username);
 
     // Get the visp-images-data package path or VISP_INPUT_IMAGE_PATH
     // environment variable value
@@ -312,15 +343,19 @@ int main(int argc, const char **argv)
     if (!env_ipath.empty())
       ipath = env_ipath;
 
+    // Append to the output path string, the login name of the user
+    std::string odirname = vpIoTools::createFilePath(opath, username);
+    std::string logfilename = vpIoTools::createFilePath(odirname, "template-tracker.log");
+
     // Read the command line options
     if (!getOptions(argc, argv, opt_ipath, opt_click_allowed, opt_display, opt_pyramidal, opt_warp_type,
-                    opt_tracker_type, opt_last_frame)) {
+                    opt_tracker_type, opt_last_frame, opt_reinit, opt_threshold_residual, opt_log)) {
       return (-1);
     }
 
     // Test if an input path is set
     if (opt_ipath.empty() && env_ipath.empty()) {
-      usage(argv[0], NULL, opt_warp_type, opt_tracker_type, opt_last_frame);
+      usage(argv[0], NULL, opt_warp_type, opt_tracker_type, opt_last_frame, opt_threshold_residual);
       std::cerr << std::endl << "ERROR:" << std::endl;
       std::cerr << "  Use -i <visp image path> option or set VISP_INPUT_IMAGE_PATH " << std::endl
                 << "  environment variable to specify the location of the " << std::endl
@@ -335,6 +370,10 @@ int main(int argc, const char **argv)
       ipath = vpIoTools::createFilePath(opt_ipath, "mire-2/image.%04d.pgm");
     else
       ipath = vpIoTools::createFilePath(env_ipath, "mire-2/image.%04d.pgm");
+
+    if (opt_log) {
+      ofs.open( logfilename );
+    }
 
     vpImage<unsigned char> I;
     vpVideoReader reader;
@@ -444,6 +483,7 @@ int main(int argc, const char **argv)
     if (opt_pyramidal) {
       tracker->setPyramidal(2, 1);
     }
+    tracker->setThresholdResidualDifference(opt_threshold_residual);
     bool delaunay = false;
     if (opt_display && opt_click_allowed)
       tracker->initClick(I, delaunay);
@@ -466,6 +506,9 @@ int main(int argc, const char **argv)
       tracker->initFromPoints(I, v_ip, false);
     }
 
+    double t_init = vpTime::measureTimeMs();
+    int niter = 0;
+
     while (!reader.end()) {
       // Acquire a new image
       reader.acquire(I);
@@ -474,9 +517,13 @@ int main(int argc, const char **argv)
       vpDisplay::display(I);
       // Track the template
       tracker->track(I);
+      // Save log
+      if (opt_log) {
+        ofs << tracker->getNbIteration() << std::endl;
+      }
 
       // Simulate a re-init
-      if (reader.getFrameIndex() == 10) {
+      if (opt_reinit && (reader.getFrameIndex() == 10)) {
         std::cout << "re-init simulation" << std::endl;
         if (opt_click_allowed)
           vpDisplay::getClick(I);
@@ -520,7 +567,18 @@ int main(int argc, const char **argv)
 #endif
 
       vpDisplay::flush(I);
+
+      niter ++;
     }
+    double t_end = vpTime::measureTimeMs();
+    std::cout << "Total time: " << t_end - t_init << " ms" << std::endl;
+    std::cout << "Total mean: " << (t_end - t_init)/niter << " ms" << std::endl;
+
+    if (opt_log) {
+      std::cout << "Log are saved in: " << logfilename << std::endl;
+      ofs.close();
+    }
+
     if (opt_click_allowed) {
       vpDisplay::displayText(I, 10, 10, "A click to exit...", vpColor::red);
       vpDisplay::flush(I);

--- a/example/tracking/templateTracker.cpp
+++ b/example/tracking/templateTracker.cpp
@@ -160,8 +160,8 @@ OPTIONS:                                                            Default\n\
      %d : Homography\n\
      %d : Homography in SL3\n\
      %d : SRT (scale, rotation, translation)\n\
-     %d : RT (rotation, translation)\n\
-     %d : Translation\n\n", (int)warp_type, (int)WARP_AFFINE, (int)WARP_HOMOGRAPHY, (int)WARP_HOMOGRAPHY_SL3, (int)WARP_SRT,
+     %d : Translation\n\
+     %d : RT (rotation, translation)\n\n", (int)warp_type, (int)WARP_AFFINE, (int)WARP_HOMOGRAPHY, (int)WARP_HOMOGRAPHY_SL3, (int)WARP_SRT,
           (int)WARP_TRANSLATION, (int)WARP_RT);
 #else
   fprintf(stdout, "\n\

--- a/example/tracking/templateTracker.cpp
+++ b/example/tracking/templateTracker.cpp
@@ -217,7 +217,7 @@ OPTIONS:                                                            Default\n\
   -r\n\
      Disable re-init at frame 10.\n\
                           \n\
-  -s <residual r-threshold>                                            %g\n\
+  -s <residual threshold>                                            %g\n\
      Threshold used to stop optimization when residual difference\n\
      between two successive optimization iteration becomes lower\n\
      that this parameter.\n\

--- a/modules/tracker/tt/include/visp3/tt/vpTemplateTracker.h
+++ b/modules/tracker/tt/include/visp3/tt/vpTemplateTracker.h
@@ -84,8 +84,7 @@ protected:
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
   vpTemplateTrackerPointSuppMIInv *ptTemplateSupp;     // pour inverse et compo
-  vpTemplateTrackerPointSuppMIInv **ptTemplateSuppPyr; // pour inverse et
-                                                       // compo
+  vpTemplateTrackerPointSuppMIInv **ptTemplateSuppPyr; // pour inverse et compo
 #endif
 
   vpTemplateTrackerPointCompo *ptTemplateCompo;     // pour ESM

--- a/modules/tracker/tt/include/visp3/tt/vpTemplateTracker.h
+++ b/modules/tracker/tt/include/visp3/tt/vpTemplateTracker.h
@@ -66,6 +66,11 @@ protected:
   unsigned int nbLvlPyr; // If = 1, disable pyramidal usage
   unsigned int l0Pyr;
   bool pyrInitialised;
+  // For evolRMS computation
+  double evolRMS;
+  std::vector<double> x_pos;
+  std::vector<double> y_pos;
+  double evolRMS_eps;
 
   vpTemplateTrackerPoint *ptTemplate;
   vpTemplateTrackerPoint **ptTemplatePyr;
@@ -138,37 +143,6 @@ protected:
   vpImage<double> dIx;
   vpImage<double> dIy;
   vpTemplateTrackerZone zoneRef_; // Reference zone
-
-  // private:
-  //#ifndef DOXYGEN_SHOULD_SKIP_THIS
-  //    vpTemplateTracker(const vpTemplateTracker &)
-  //      : nbLvlPyr(0), l0Pyr(0), pyrInitialised(false), ptTemplate(NULL),
-  //      ptTemplatePyr(NULL),
-  //        ptTemplateInit(false), templateSize(0), templateSizePyr(NULL),
-  //        ptTemplateSelect(NULL), ptTemplateSelectPyr(NULL),
-  //        ptTemplateSelectInit(false), templateSelectSize(0),
-  //        ptTemplateSupp(NULL), ptTemplateSuppPyr(NULL),
-  //        ptTemplateCompo(NULL), ptTemplateCompoPyr(NULL),
-  //        zoneTracked(NULL), zoneTrackedPyr(NULL), pyr_IDes(NULL), H(),
-  //        Hdesire(), HdesirePyr(NULL), HLM(), HLMdesire(),
-  //        HLMdesirePyr(NULL), HLMdesireInverse(), HLMdesireInversePyr(NULL),
-  //        G(), gain(0), thresholdGradient(0),
-  //        costFunctionVerification(false), blur(false), useBrent(false),
-  //        nbIterBrent(0), taillef(0), fgG(NULL), fgdG(NULL),
-  //        ratioPixelIn(0), mod_i(0), mod_j(0), nbParam(), lambdaDep(0),
-  //        iterationMax(0), iterationGlobale(0), diverge(false),
-  //        nbIteration(0), useCompositionnal(false), useInverse(false),
-  //        Warp(NULL), p(), dp(), X1(), X2(), dW(), BI(), dIx(), dIy(),
-  //        zoneRef_()
-  //    {
-  //      throw vpException(vpException::functionNotImplementedError, "Not
-  //      implemented!");
-  //    }
-  //    vpTemplateTracker &operator=(const vpTemplateTracker &){
-  //      throw vpException(vpException::functionNotImplementedError, "Not
-  //      implemented!"); return *this;
-  //    }
-  //#endif
 
 public:
   //! Default constructor.
@@ -278,19 +252,46 @@ public:
     mod_j = sample_j;
   }
   void setThresholdGradient(double threshold) { thresholdGradient = threshold; }
+  /*!
+    Set the threshold used to stop optimization loop.
+    When the residual difference between two successive iterations becomes lower than the threshold we stop
+    optimization loop.
+
+    \note Increasing the default value allows to speed up the tracking.
+
+    \param threshold : Threshold used to stop optimization. Default value is set to 1e-4.
+   */
+  void setThresholdResidualDifference(double threshold) { evolRMS_eps = threshold; }
+
   /*! By default Brent usage is disabled. */
   void setUseBrent(bool b) { useBrent = b; }
 
   void track(const vpImage<unsigned char> &I);
   void trackRobust(const vpImage<unsigned char> &I);
 
+#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+    \deprecated This function is deprecated and the value set is no more used.
+    Use rather setThresholdResidualDerivative()
+    \param threshold : Unused value.
+   */
+  vp_deprecated void setThresholdRMS(double threshold) { (void)threshold; }
+  //@}
+#endif
+
 protected:
+  void computeEvalRMS(const vpColVector &p);
   void computeOptimalBrentGain(const vpImage<unsigned char> &I, vpColVector &tp, double tMI, vpColVector &direction,
                                double &alpha);
   virtual double getCost(const vpImage<unsigned char> &I, const vpColVector &tp) = 0;
   void getGaussianBluredImage(const vpImage<unsigned char> &I) { vpImageFilter::filter(I, BI, fgG, taillef); }
   virtual void initHessienDesired(const vpImage<unsigned char> &I) = 0;
   virtual void initHessienDesiredPyr(const vpImage<unsigned char> &I);
+  void initPosEvalRMS(const vpColVector &p);
   virtual void initPyramidal(unsigned int nbLvl, unsigned int l0);
   void initTracking(const vpImage<unsigned char> &I, vpTemplateTrackerZone &zone);
   virtual void initTrackingPyr(const vpImage<unsigned char> &I, vpTemplateTrackerZone &zone);

--- a/modules/tracker/tt/include/visp3/tt/vpTemplateTrackerSSDInverseCompositional.h
+++ b/modules/tracker/tt/include/visp3/tt/vpTemplateTrackerSSDInverseCompositional.h
@@ -59,21 +59,12 @@ protected:
   bool compoInitialised;
   vpMatrix HInv;
   vpMatrix HCompInverse;
-  bool useTemplateSelect; // use only the strong gradient pixels to compute
-                          // the Jabocian
-  // pour eval evolRMS
-  double evolRMS;
-  std::vector<double> x_pos;
-  std::vector<double> y_pos;
-  double threshold_RMS;
+  bool useTemplateSelect; // use only the strong gradient pixels to compute the Jabocian
 
 protected:
   void initHessienDesired(const vpImage<unsigned char> &I);
   void initCompInverse(const vpImage<unsigned char> &I);
   void trackNoPyr(const vpImage<unsigned char> &I);
-  void deletePosEvalRMS();
-  void computeEvalRMS(const vpColVector &p);
-  void initPosEvalRMS(const vpColVector &p);
 
 public:
   explicit vpTemplateTrackerSSDInverseCompositional(vpTemplateTrackerWarp *warp);
@@ -81,6 +72,5 @@ public:
   /*! Use only the strong gradient pixels to compute the Jabobian. By default
    * this feature is disabled. */
   void setUseTemplateSelect(bool b) { useTemplateSelect = b; }
-  void setThresholdRMS(double threshold) { threshold_RMS = threshold; }
 };
 #endif

--- a/modules/tracker/tt/include/visp3/tt/vpTemplateTrackerZNCCInverseCompositional.h
+++ b/modules/tracker/tt/include/visp3/tt/vpTemplateTrackerZNCCInverseCompositional.h
@@ -59,24 +59,14 @@ class VISP_EXPORT vpTemplateTrackerZNCCInverseCompositional : public vpTemplateT
 {
 protected:
   bool compoInitialised;
-  // pour eval evolRMS
-  double evolRMS;
-  std::vector<double> x_pos;
-  std::vector<double> y_pos;
-  double threshold_RMS;
   vpColVector moydIrefdp;
 
 protected:
   void initCompInverse(const vpImage<unsigned char> &I);
   void initHessienDesired(const vpImage<unsigned char> &I);
   void trackNoPyr(const vpImage<unsigned char> &I);
-  void deletePosEvalRMS();
-  void computeEvalRMS(const vpColVector &p);
-  void initPosEvalRMS(const vpColVector &p);
 
 public:
   explicit vpTemplateTrackerZNCCInverseCompositional(vpTemplateTrackerWarp *warp);
-
-  void setThresholdRMS(double threshold) { threshold_RMS = threshold; }
 };
 #endif

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSD.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSD.cpp
@@ -78,11 +78,11 @@ double vpTemplateTrackerSSD::getCost(const vpImage<unsigned char> &I, const vpCo
       else
         IW = BI.getValue(i2, j2);
       // IW=getSubPixBspline4(I,i2,j2);
-      erreur += ((double)Tij - IW) * ((double)Tij - IW);
+      erreur += (Tij - IW) * (Tij - IW);
       Nbpoint++;
     }
   }
-  ratioPixelIn = (double)Nbpoint / (double)templateSize;
+  ratioPixelIn = static_cast<double>(Nbpoint) / static_cast<double>(templateSize);
 
   if (Nbpoint == 0)
     return 10e10;
@@ -115,7 +115,7 @@ double vpTemplateTrackerSSD::getSSD(const vpImage<unsigned char> &I, const vpCol
       double Tij = ptTemplate[point].val;
       IW = I.getValue(i2, j2);
       // IW=getSubPixBspline4(I,i2,j2);
-      erreur += ((double)Tij - IW) * ((double)Tij - IW);
+      erreur += (Tij - IW) * (Tij - IW);
       Nbpoint++;
     }
   }

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDESM.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDESM.cpp
@@ -46,10 +46,10 @@ vpTemplateTrackerSSDESM::vpTemplateTrackerSSDESM(vpTemplateTrackerWarp *warp)
   useCompositionnal = false;
   useInverse = false;
 
-  if (!Warp->isESMcompatible())
-    std::cerr << "The selected warp function is not appropriate for the ESM "
-                 "algorithm..."
-              << std::endl;
+  if (!Warp->isESMcompatible()) {
+    throw(vpException(vpException::badValue,
+                      "The selected warp function is not appropriate for the ESM algorithm..."));
+  }
 
   HInv.resize(nbParam, nbParam);
   HDir.resize(nbParam, nbParam);
@@ -63,8 +63,6 @@ void vpTemplateTrackerSSDESM::initHessienDesired(const vpImage<unsigned char> &I
 
 void vpTemplateTrackerSSDESM::initCompInverse(const vpImage<unsigned char> & /*I*/)
 {
-  // std::cout<<"Initialise precomputed value of ESM with templateSize: "<<
-  // templateSize<<std::endl;
   ptTemplateCompo = new vpTemplateTrackerPointCompo[templateSize];
   int i, j;
   // direct
@@ -112,6 +110,13 @@ void vpTemplateTrackerSSDESM::trackNoPyr(const vpImage<unsigned char> &I)
   int i, j;
   double i2, j2;
   double alpha = 2.;
+
+  initPosEvalRMS(p);
+
+  double evolRMS_init = 0;
+  double evolRMS_prec = 0;
+  double evolRMS_delta;
+
   do {
     unsigned int Nbpoint = 0;
     double erreur = 0;
@@ -145,15 +150,10 @@ void vpTemplateTrackerSSDESM::trackNoPyr(const vpImage<unsigned char> &I)
 
         erreur += er * er;
 
-        // DIRECT
-        // dIWx=dIx.getValue(i2,j2);
-        // dIWy=dIy.getValue(i2,j2);
-
         dIWx = dIx.getValue(i2, j2) + ptTemplate[point].dx;
         dIWy = dIy.getValue(i2, j2) + ptTemplate[point].dy;
 
         // Calcul du Hessien
-        // Warp->dWarp(X1,X2,p,dW);
         Warp->dWarpCompo(X1, X2, p, ptTemplateCompo[point].dW, dW);
 
         double *tempt = new double[nbParam];
@@ -170,19 +170,14 @@ void vpTemplateTrackerSSDESM::trackNoPyr(const vpImage<unsigned char> &I)
       }
     }
     if (Nbpoint == 0) {
-      // std::cout<<"plus de point dans template suivi"<<std::endl;
       throw(vpTrackingException(vpTrackingException::notEnoughPointError, "No points in the template"));
     }
 
     vpMatrix::computeHLM(HDir, lambdaDep, HLMDir);
 
     try {
-      // dp=(HLMInv+HLMDir).inverseByLU()*(GInv+GDir);
-      // dp=HLMInv.inverseByLU()*GInv+HLMDir.inverseByLU()*GDir;
-      // dp=HLMInv.inverseByLU()*GInv;
       dp = (HLMDir).inverseByLU() * (GDir);
     } catch (const vpException &e) {
-      // std::cout<<"probleme inversion"<<std::endl;
       throw(e);
     }
 
@@ -193,123 +188,20 @@ void vpTemplateTrackerSSDESM::trackNoPyr(const vpImage<unsigned char> &I)
       dp = alpha * dp;
     }
 
-    // Warp->pRondp(p,dp,p);
     p += dp;
+
+    computeEvalRMS(p);
+
+    if (iteration == 0) {
+      evolRMS_init = evolRMS;
+    }
+
     iteration++;
 
-  } while ((iteration < iterationMax));
+    evolRMS_delta = std::fabs(evolRMS - evolRMS_prec);
+    evolRMS_prec = evolRMS;
+
+  } while ( (iteration < iterationMax) && (evolRMS_delta > std::fabs(evolRMS_init)*evolRMS_eps) );
 
   nbIteration = iteration;
 }
-
-/*void vpTemplateTrackerSSDESM::InitCompInverse(vpImage<unsigned char> &I)
-{
-  ptTempateCompo=new vpTemplateTrackerPointCompo[taille_template];
-  int i,j;
-  for(int point=0;point<taille_template;point++)
-  {
-    i=ptTemplate[point].y;
-    j=ptTemplate[point].x;
-    ptTempateCompo[point].dW=new double[2*nbParam];
-    Warp->getdWdp0(i,j,ptTempateCompo[point].dW);
-  }
-
-}
-
-void vpTemplateTrackerSSDESM::track(vpImage<unsigned char> &I)
-{
-  double erreur=0,erreur_prec=1e38;
-  int Nbpoint=0;
-
-  int taillefiltre=taille_filtre_dgaussien;
-  double *fg=new double[taillefiltre+1] ;
-  getGaussianDerivativeKernel(fg, taillefiltre) ;
-  getGradX(I, dIx,fg,taillefiltre);
-  getGradY(I, dIy,fg,taillefiltre);
-  delete[] fg;
-
-  vpColVector dpinv(nbParam);
-  double lambda=lambdaDep;
-  double IW,dIWx,dIWy;
-  double Tij;
-  int iteration=0;
-  int i,j;
-  double i2,j2;
-  vpTemplateTrackerPoint *pt;
-  do
-  {
-    Nbpoint=0;
-    erreur_prec=erreur;
-    erreur=0;
-    dp=0;
-    HDir=0;
-    GDir=0;
-    GInv=0;
-    Warp->ComputeCoeff(p);
-    for(int point=0;point<taille_template;point++)
-    {
-      pt=&ptTemplate[point];
-      i=pt->y;
-      j=pt->x;
-      X1[0]=j;X1[1]=i;
-
-      Warp->ComputeDenom(X1,p);
-      Warp->warpX(X1,X2,p);
-
-      j2=X2[0];i2=X2[1];
-      if((j2<I.getWidth())&&(i2<I.getHeight())&&(i2>0)&&(j2>0))
-      {
-        //INVERSE
-        Tij=pt->val;
-        IW=I.getPixelBI(j2,i2);
-        Nbpoint++;
-        double er=(Tij-IW);
-        for(int it=0;it<nbParam;it++)
-          GInv[it]+=er*ptTemplate[point].dW[it];
-
-        erreur+=er*er;
-
-        //DIRECT COMPO
-        Tij=ptTemplate[point].val;
-        IW=I.getPixelBI(j2,i2);
-        dIWx=dIx.getPixelBI(j2,i2);
-        dIWy=dIy.getPixelBI(j2,i2);
-        Nbpoint++;
-        Warp->dWarpCompo(X1,X2,p,ptTempateCompo[point].dW,dW);
-        double *tempt=new double[nbParam];
-        for(int it=0;it<nbParam;it++)
-          tempt[it] =dW[0][it]*dIWx+dW[1][it]*dIWy;
-
-        for(int it=0;it<nbParam;it++)
-          for(int jt=0;jt<nbParam;jt++)
-            HDir[it][jt]+=tempt[it]*tempt[jt];
-
-        for(int it=0;it<nbParam;it++)
-          GDir[it]+=er*tempt[it];
-
-        delete[] tempt;
-      }
-
-
-    }
-    if(Nbpoint==0)std::cout<<"plus de point dans template suivi"<<std::endl;
-    try
-    {
-      dp=(HInv+HDir).inverseByLU()*(GInv+GDir);
-    }
-    catch(...)
-    {
-      std::cout<<"probleme inversion"<<std::endl;
-      break;
-    }
-
-    if(Compare)write_infos(p,erreur/Nbpoint);
-
-    p+=Gain*dp;
-    iteration++;
-
-  }
-  while( (iteration < IterationMax));
-
-  NbIteration=iteration;
-}*/

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardAdditional.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardAdditional.cpp
@@ -124,7 +124,7 @@ void vpTemplateTrackerSSDForwardAdditional::trackNoPyr(const vpImage<unsigned ch
 
     vpMatrix::computeHLM(H, lambda, HLM);
     try {
-      dp = 1. * HLM.inverseByLU() * G;
+      dp = HLM.inverseByLU() * G;
     } catch (const vpException &e) {
       throw(e);
     }
@@ -132,7 +132,7 @@ void vpTemplateTrackerSSDForwardAdditional::trackNoPyr(const vpImage<unsigned ch
     switch (minimizationMethod) {
     case vpTemplateTrackerSSDForwardAdditional::USE_LMA: {
       vpColVector p_test_LMA(nbParam);
-      p_test_LMA = p + 1. * dp;
+      p_test_LMA = p + dp;
       erreur = -getCost(I, p);
       double erreur_LMA = -getCost(I, p_test_LMA);
       if (erreur_LMA < erreur) {

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardCompositional.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardCompositional.cpp
@@ -110,11 +110,6 @@ void vpTemplateTrackerSSDForwardCompositional::trackNoPyr(const vpImage<unsigned
         dIWx = dIx.getValue(i2, j2);
         dIWy = dIy.getValue(i2, j2);
         Nbpoint++;
-        // Calcul du Hessien
-        /*Warp->dWarp(X1,X2,p,dW);
-        double *tempt=new double[nbParam];
-        for(int it=0;it<nbParam;it++)
-        tempt[it]=dW[0][it]*dIWx+dW[1][it]*dIWy;*/
 
         Warp->dWarpCompo(X1, X2, p, ptTemplate[point].dW, dW);
 
@@ -135,7 +130,6 @@ void vpTemplateTrackerSSDForwardCompositional::trackNoPyr(const vpImage<unsigned
       }
     }
     if (Nbpoint == 0) {
-      // std::cout<<"plus de point dans template suivi"<<std::endl;
       throw(vpTrackingException(vpTrackingException::notEnoughPointError, "No points in the template"));
     }
 
@@ -144,7 +138,6 @@ void vpTemplateTrackerSSDForwardCompositional::trackNoPyr(const vpImage<unsigned
     try {
       dp = 1. * HLM.inverseByLU() * G;
     } catch (const vpException &e) {
-      // std::cout<<"probleme inversion"<<std::endl;
       throw(e);
     }
 
@@ -155,9 +148,9 @@ void vpTemplateTrackerSSDForwardCompositional::trackNoPyr(const vpImage<unsigned
       dp = alpha * dp;
     }
     Warp->pRondp(p, dp, p);
-    // p+=Gain*dp;
+
     iteration++;
-  } while (/*( erreur_prec-erreur<50) &&*/ (iteration < iterationMax));
+  } while ( (iteration < iterationMax) );
 
   nbIteration = iteration;
 }

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardCompositional.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDForwardCompositional.cpp
@@ -141,7 +141,7 @@ void vpTemplateTrackerSSDForwardCompositional::trackNoPyr(const vpImage<unsigned
     vpMatrix::computeHLM(H, lambda, HLM);
 
     try {
-      dp = 1. * HLM.inverseByLU() * G;
+      dp = HLM.inverseByLU() * G;
     } catch (const vpException &e) {
       throw(e);
     }

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDInverseCompositional.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDInverseCompositional.cpp
@@ -83,7 +83,7 @@ void vpTemplateTrackerSSDInverseCompositional::initCompInverse(const vpImage<uns
       for (unsigned int it = 0; it < nbParam; it++)
         dWtemp[it] = ptTemplate[point].dW[it];
 
-      HiGtemp = -1. * HCompInverse * dWtemp;
+      HiGtemp = - HCompInverse * dWtemp;
       ptTemplate[point].HiG = new double[nbParam];
 
       for (unsigned int it = 0; it < nbParam; it++)

--- a/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDInverseCompositional.cpp
+++ b/modules/tracker/tt/src/ssd/vpTemplateTrackerSSDInverseCompositional.cpp
@@ -50,7 +50,6 @@ vpTemplateTrackerSSDInverseCompositional::vpTemplateTrackerSSDInverseComposition
 
 void vpTemplateTrackerSSDInverseCompositional::initCompInverse(const vpImage<unsigned char> & /*I*/)
 {
-
   H = 0;
   int i, j;
 
@@ -76,14 +75,11 @@ void vpTemplateTrackerSSDInverseCompositional::initCompInverse(const vpImage<uns
 
   HCompInverse.resize(nbParam, nbParam);
   HCompInverse = HLMtemp.inverseByLU();
-  // std::cout<<Hinverse<<std::endl;
   vpColVector dWtemp(nbParam);
   vpColVector HiGtemp(nbParam);
 
   for (unsigned int point = 0; point < templateSize; point++) {
     if ((!useTemplateSelect) || (ptTemplateSelect[point])) {
-      // i=ptTemplate[point].y;
-      // j=ptTemplate[point].x;
       for (unsigned int it = 0; it < nbParam; it++)
         dWtemp[it] = ptTemplate[point].dW[it];
 
@@ -114,7 +110,6 @@ void vpTemplateTrackerSSDInverseCompositional::trackNoPyr(const vpImage<unsigned
   int i, j;
   double i2, j2;
   double alpha = 2.;
-  // vpTemplateTrackerPointtest *pt;
   initPosEvalRMS(p);
 
   vpTemplateTrackerPoint *pt;
@@ -130,7 +125,6 @@ void vpTemplateTrackerSSDInverseCompositional::trackNoPyr(const vpImage<unsigned
     Warp->computeCoeff(p);
     for (unsigned int point = 0; point < templateSize; point++) {
       if ((!useTemplateSelect) || (ptTemplateSelect[point])) {
-        // pt=&ptTemplatetest[point];
         pt = &ptTemplate[point];
         i = pt->y;
         j = pt->x;
@@ -156,7 +150,6 @@ void vpTemplateTrackerSSDInverseCompositional::trackNoPyr(const vpImage<unsigned
         }
       }
     }
-    // std::cout << "npoint: " << Nbpoint << std::endl;
     if (Nbpoint == 0) {
       throw(vpTrackingException(vpTrackingException::notEnoughPointError, "No points in the template"));
     }

--- a/modules/tracker/tt/src/tools/vpTemplateTrackerBSpline.cpp
+++ b/modules/tracker/tt/src/tools/vpTemplateTrackerBSpline.cpp
@@ -44,18 +44,18 @@
 double vpTemplateTrackerBSpline::getSubPixBspline4(const vpImage<double> &I, double r, double t)
 {
   double res = 0;
-  int cr = (int)(r);
-  int ct = (int)(t);
-  double er = (double)r - cr;
-  double et = (double)t - ct;
-  int height = (int)I.getHeight(); // r
-  int width = (int)I.getWidth();   // t
+  int cr = static_cast<int>(r);
+  int ct = static_cast<int>(t);
+  double er = static_cast<double>(r) - cr;
+  double et = static_cast<double>(t) - ct;
+  int height = static_cast<int>(I.getHeight()); // r
+  int width = static_cast<int>(I.getWidth());   // t
   for (int ir = -1; ir <= 2; ir++) {
     int tr = ir + cr;
     for (int it = -1; it <= 2; it++) {
       int tt = it + ct;
       if (tr >= 0 && tr < height && tt >= 0 && tt < width)
-        res += Bspline4((double)ir - er) * Bspline4((double)it - et) * I[tr][tt];
+        res += Bspline4(static_cast<double>(ir) - er) * Bspline4(static_cast<double>(it) - et) * I[tr][tt];
     }
   }
   return res;

--- a/modules/tracker/tt/src/warp/vpTemplateTrackerWarpHomography.cpp
+++ b/modules/tracker/tt/src/warp/vpTemplateTrackerWarpHomography.cpp
@@ -104,7 +104,7 @@ void vpTemplateTrackerWarpHomography::computeDenom(vpColVector &vX, const vpColV
   double value = (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1.);
 
   if (std::fabs(value) > std::numeric_limits<double>::epsilon()) {
-    denom = (1. / (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1.));
+    denom = (1. / value);
   } else {
     throw(vpTrackingException(vpTrackingException::fatalError,
                               "Division by zero in vpTemplateTrackerWarpHomography::computeDenom()"));
@@ -162,15 +162,16 @@ void vpTemplateTrackerWarpHomography::dWarpCompo(const vpColVector & /*X1*/, con
 
 void vpTemplateTrackerWarpHomography::warpXInv(const vpColVector &vX, vpColVector &vXres, const vpColVector &ParamM)
 {
+  double value = (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1.);
 
-  if ((ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1) < 0) // si dans le plan image reel
-  {
-    vXres[0] = ((1 + ParamM[0]) * vX[0] + ParamM[3] * vX[1] + ParamM[6]) / (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1);
-    vXres[1] = (ParamM[1] * vX[0] + (1 + ParamM[4]) * vX[1] + ParamM[7]) / (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1);
-  } else
+  if (std::fabs(value) > std::numeric_limits<double>::epsilon()) {
+    vXres[0] = ((1 + ParamM[0]) * vX[0] + ParamM[3] * vX[1] + ParamM[6]) / value;
+    vXres[1] = (ParamM[1] * vX[0] + (1 + ParamM[4]) * vX[1] + ParamM[7]) / value;
+  } else {
     throw(vpTrackingException(vpTrackingException::fatalError, "Division by zero in "
                                                                "vpTemplateTrackerWarpHomography::"
-                                                               "warpXSpecialInv()"));
+                                                               "warpXInv()"));
+  }
 }
 void vpTemplateTrackerWarpHomography::getParamInverse(const vpColVector &ParamM, vpColVector &ParamMinv) const
 {

--- a/modules/tracker/tt/src/warp/vpTemplateTrackerWarpHomography.cpp
+++ b/modules/tracker/tt/src/warp/vpTemplateTrackerWarpHomography.cpp
@@ -101,7 +101,14 @@ void vpTemplateTrackerWarpHomography::getdWdp0(const int &i, const int &j, doubl
 }
 void vpTemplateTrackerWarpHomography::computeDenom(vpColVector &vX, const vpColVector &ParamM)
 {
-  denom = (1. / (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1.));
+  double value = (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1.);
+
+  if (std::fabs(value) > std::numeric_limits<double>::epsilon()) {
+    denom = (1. / (ParamM[2] * vX[0] + ParamM[5] * vX[1] + 1.));
+  } else {
+    throw(vpTrackingException(vpTrackingException::fatalError,
+                              "Division by zero in vpTemplateTrackerWarpHomography::computeDenom()"));
+  }
 }
 
 void vpTemplateTrackerWarpHomography::warpX(const int &i, const int &j, double &i2, double &j2,
@@ -113,14 +120,8 @@ void vpTemplateTrackerWarpHomography::warpX(const int &i, const int &j, double &
 
 void vpTemplateTrackerWarpHomography::warpX(const vpColVector &vX, vpColVector &vXres, const vpColVector &ParamM)
 {
-  // if((ParamM[2]*vX[0]+ParamM[5]*vX[1]+1)>0)//si dans le plan image reel
-  if ((denom) > 0) // FS optimisation
-  {
-    vXres[0] = ((1 + ParamM[0]) * vX[0] + ParamM[3] * vX[1] + ParamM[6]) * denom;
-    vXres[1] = (ParamM[1] * vX[0] + (1 + ParamM[4]) * vX[1] + ParamM[7]) * denom;
-  } else
-    throw(vpTrackingException(vpTrackingException::fatalError,
-                              "Division by zero in vpTemplateTrackerWarpHomography::warpX()"));
+  vXres[0] = ((1 + ParamM[0]) * vX[0] + ParamM[3] * vX[1] + ParamM[6]) * denom;
+  vXres[1] = (ParamM[1] * vX[0] + (1 + ParamM[4]) * vX[1] + ParamM[7]) * denom;
 }
 
 void vpTemplateTrackerWarpHomography::dWarp(const vpColVector &X1, const vpColVector &X2,

--- a/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCForwardAdditional.cpp
+++ b/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCForwardAdditional.cpp
@@ -138,11 +138,6 @@ void vpTemplateTrackerZNCCForwardAdditional::initHessienDesired(const vpImage<un
         for (unsigned int jt = 0; jt < nbParam; jt++)
           Hdesire[it][jt] += prod * (dW[0][it] * (dW[0][jt] * d_Ixx + dW[1][jt] * d_Ixy) +
                                      dW[1][it] * (dW[0][jt] * d_Ixy + dW[1][jt] * d_Iyy));
-      /*Hdesire[0][0]+=prod*d_Ixx;
-      Hdesire[1][0]+=prod*d_Ixy;
-      Hdesire[0][1]+=prod*d_Ixy;
-      Hdesire[1][1]+=prod*d_Iyy;*/
-
       denom += (Tij - moyTij) * (Tij - moyTij) * (IW - moyIW) * (IW - moyIW);
       delete[] tempt;
     }
@@ -161,16 +156,8 @@ void vpTemplateTrackerZNCCForwardAdditional::trackNoPyr(const vpImage<unsigned c
   vpImageFilter::getGradXGauss2D(I, dIx, fgG, fgdG, taillef);
   vpImageFilter::getGradYGauss2D(I, dIy, fgG, fgdG, taillef);
 
-  /*vpImage<double> dIxx,dIxy,dIyx,dIyy;
-  getGradX(dIx, dIxx, fgdG,taillef);
-  getGradY(dIx, dIxy, fgdG,taillef);
-
-  getGradX(dIy, dIyx, fgdG,taillef);
-  getGradY(dIy, dIyy, fgdG,taillef);*/
-
   dW = 0;
 
-  // double lambda=lambdaDep;
   double IW, dIWx, dIWy;
   double Tij;
   unsigned int iteration = 0;
@@ -217,8 +204,6 @@ void vpTemplateTrackerZNCCForwardAdditional::trackNoPyr(const vpImage<unsigned c
 
     moyTij = moyTij / Nbpoint;
     moyIW = moyIW / Nbpoint;
-    // vpMatrix d2Wx(nbParam,nbParam);
-    // vpMatrix d2Wy(nbParam,nbParam);
     for (unsigned int point = 0; point < templateSize; point++) {
       i = ptTemplate[point].y;
       j = ptTemplate[point].x;
@@ -250,45 +235,18 @@ void vpTemplateTrackerZNCCForwardAdditional::trackNoPyr(const vpImage<unsigned c
         for (unsigned int it = 0; it < nbParam; it++)
           G[it] += prod * tempt[it];
 
-        /*	Warp->d2Warp(X1,X2,p,d2Wx,d2Wy);
-        for(int it=0;it<nbParam;it++)
-          for(int jt=0;jt<nbParam;jt++)
-            H[it][jt]+=prod*(d2Wx[it][jt]*dIWx+d2Wx[it][jt]*dIWy);*/
-        /*double d_Ixx=dIxx.getValue(i2,j2);
-        double d_Iyy=dIyy.getValue(i2,j2);
-        double d_Ixy=dIxy.getValue(i2,j2);
-
-        for(int it=0;it<nbParam;it++)
-          for(int jt=0;jt<nbParam;jt++)
-            H[it][jt] +=prod*(dW[0][it]*(dW[0][jt]*d_Ixx+dW[1][jt]*d_Ixy)
-                +dW[1][it]*(dW[0][jt]*d_Ixy+dW[1][jt]*d_Iyy));*/
-        /*H[0][0]+=prod*d_Ixx;
-        H[1][0]+=prod*d_Ixy;
-        H[0][1]+=prod*d_Ixy;
-        H[1][1]+=prod*d_Iyy;*/
-
         double er = (Tij - IW);
         erreur += (er * er);
         denom += (Tij - moyTij) * (Tij - moyTij) * (IW - moyIW) * (IW - moyIW);
         delete[] tempt;
       }
     }
-    /*std::cout<<"G="<<G<<std::endl;
-    std::cout<<"H="<<H<<std::endl;
-    std::cout<<" denom="<<denom<<std::endl;*/
     G = G / sqrt(denom);
-    // std::cout<<G<<std::endl;
     H = H / sqrt(denom);
 
-    // if(Nbpoint==0)std::cout<<"plus de point dans template
-    // suivi"<<std::endl; // cannot occur
-
     try {
-      // vpMatrix::computeHLM(H,lambda,HLM);
-      // dp=1.*HLM.inverseByLU()*G;
       dp = 1. * HLMdesireInverse * G;
     } catch (const vpException &e) {
-      // std::cout<<"probleme inversion"<<std::endl;
       throw(e);
     }
 

--- a/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCForwardAdditional.cpp
+++ b/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCForwardAdditional.cpp
@@ -164,6 +164,13 @@ void vpTemplateTrackerZNCCForwardAdditional::trackNoPyr(const vpImage<unsigned c
   int i, j;
   double i2, j2;
   double alpha = 2.;
+
+  initPosEvalRMS(p);
+
+  double evolRMS_init = 0;
+  double evolRMS_prec = 0;
+  double evolRMS_delta;
+
   do {
     int Nbpoint = 0;
     double erreur = 0;
@@ -257,8 +264,18 @@ void vpTemplateTrackerZNCCForwardAdditional::trackNoPyr(const vpImage<unsigned c
       dp = alpha * dp;
     }
     p -= dp;
+
+    computeEvalRMS(p);
+
+    if (iteration == 0) {
+      evolRMS_init = evolRMS;
+    }
     iteration++;
-  } while (/*( erreur_prec-erreur<50) && */ (iteration < iterationMax));
+
+    evolRMS_delta = std::fabs(evolRMS - evolRMS_prec);
+    evolRMS_prec = evolRMS;
+
+  } while ((iteration < iterationMax) && (evolRMS_delta > std::fabs(evolRMS_init)*evolRMS_eps));
 
   // std::cout<<"erreur "<<erreur<<std::endl;
   nbIteration = iteration;

--- a/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCForwardAdditional.cpp
+++ b/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCForwardAdditional.cpp
@@ -252,7 +252,7 @@ void vpTemplateTrackerZNCCForwardAdditional::trackNoPyr(const vpImage<unsigned c
     H = H / sqrt(denom);
 
     try {
-      dp = 1. * HLMdesireInverse * G;
+      dp = HLMdesireInverse * G;
     } catch (const vpException &e) {
       throw(e);
     }

--- a/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCInverseCompositional.cpp
+++ b/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCInverseCompositional.cpp
@@ -50,8 +50,6 @@ vpTemplateTrackerZNCCInverseCompositional::vpTemplateTrackerZNCCInverseCompositi
 
 void vpTemplateTrackerZNCCInverseCompositional::initCompInverse(const vpImage<unsigned char> &I)
 {
-  // std::cout<<"Initialise precomputed value of Compositionnal
-  // Inverse"<<std::endl;
   vpImageFilter::getGradXGauss2D(I, dIx, fgG, fgdG, taillef);
   vpImageFilter::getGradYGauss2D(I, dIy, fgG, fgdG, taillef);
 
@@ -66,11 +64,9 @@ void vpTemplateTrackerZNCCInverseCompositional::initCompInverse(const vpImage<un
 
     double dx = ptTemplate[point].dx;
     double dy = ptTemplate[point].dy;
-    // std::cout<<ptTemplate[point].dx<<","<<ptTemplate[point].dy<<std::endl;
 
     Warp->getdW0(i, j, dy, dx, ptTemplate[point].dW);
   }
-  // vpTRACE("fin Comp Inverse");
   compoInitialised = true;
 }
 
@@ -191,8 +187,9 @@ void vpTemplateTrackerZNCCInverseCompositional::initHessienDesired(const vpImage
       Warp->dWarp(X1, X2, p, dW);
 
       double *tempt = new double[nbParam];
-      for (unsigned int it = 0; it < nbParam; it++)
+      for (unsigned int it = 0; it < nbParam; it++) {
         tempt[it] = dW[0][it] * dIcx + dW[1][it] * dIcy;
+      }
 
       double prodIc = (Ic - moyIc);
 
@@ -200,13 +197,14 @@ void vpTemplateTrackerZNCCInverseCompositional::initHessienDesired(const vpImage
       double d_Iyy = dIyy.getValue(i2, j2);
       double d_Ixy = dIxy.getValue(i2, j2);
 
-      for (unsigned int it = 0; it < nbParam; it++)
+      for (unsigned int it = 0; it < nbParam; it++) {
         for (unsigned int jt = 0; jt < nbParam; jt++) {
           sIcd2Iref[it][jt] += prodIc * (dW[0][it] * (dW[0][jt] * d_Ixx + dW[1][jt] * d_Ixy) +
                                          dW[1][it] * (dW[0][jt] * d_Ixy + dW[1][jt] * d_Iyy) - moyd2Iref[it][jt]);
           sdIrefdIref[it][jt] +=
               (ptTemplate[point].dW[it] - moydIrefdp[it]) * (ptTemplate[point].dW[jt] - moydIrefdp[jt]);
         }
+      }
 
       delete[] tempt;
 
@@ -224,7 +222,6 @@ void vpTemplateTrackerZNCCInverseCompositional::initHessienDesired(const vpImage
   denom = covarIref * covarIc;
 
   double NCC = sIcIref / denom;
-  // std::cout<<"NCC = "<<NCC<<std::endl;
   vpColVector dcovarIref(nbParam);
   dcovarIref = -sIcdIref / covarIref;
 
@@ -239,7 +236,6 @@ void vpTemplateTrackerZNCCInverseCompositional::initHessienDesired(const vpImage
 #endif
   vpMatrix::computeHLM(Hdesire, lambdaDep, HLMdesire);
   HLMdesireInverse = HLMdesire.inverseByLU();
-  // std::cout<<"Hdesire = "<<Hdesire<<std::endl;
 }
 
 void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigned char> &I)
@@ -247,7 +243,6 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
   if (blur)
     vpImageFilter::filter(I, BI, fgG, taillef);
 
-  // double erreur=0;
   vpColVector dpinv(nbParam);
   double Ic;
   double Iref;
@@ -262,7 +257,6 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
 
   do {
     unsigned int Nbpoint = 0;
-    // erreur=0;
     G = 0;
     Warp->computeCoeff(p);
     double moyIref = 0;
@@ -326,9 +320,6 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
           for (unsigned int it = 0; it < nbParam; it++)
             sIrefdIref[it] += (Iref - moyIref) * (ptTemplate[point].dW[it] - moydIrefdp[it]);
 
-          // double er=(Iref-Ic);
-          // erreur+=(er*er);
-          // denom+=(Iref-moyIref)*(Iref-moyIref)*(Ic-moyIc)*(Ic-moyIc);
           covarIref += (Iref - moyIref) * (Iref - moyIref);
           covarIc += (Ic - moyIc) * (Ic - moyIc);
           sIcIref += (Iref - moyIref) * (Ic - moyIc);
@@ -338,7 +329,6 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
       covarIc = sqrt(covarIc);
       double denom = covarIref * covarIc;
 
-      // if(denom==0.0)
       if (std::fabs(denom) <= std::numeric_limits<double>::epsilon()) {
         diverge = true;
       } else {
@@ -349,9 +339,9 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
 
         try {
           dp = -1. * HLMdesireInverse * G;
-        } catch (...) {
-          std::cout << "probleme inversion" << std::endl;
-          break;
+        }
+        catch (const vpException &e) {
+          throw(e);
         }
 
         Warp->getParamInverse(dp, dpinv);
@@ -372,6 +362,5 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
 
   } while ( (!diverge && (evolRMS_delta > std::fabs(evolRMS_init)*evolRMS_eps) && (iteration < iterationMax)) );
 
-  // std::cout<<"erreur "<<erreur<<std::endl;
   nbIteration = iteration;
 }

--- a/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCInverseCompositional.cpp
+++ b/modules/tracker/tt/src/zncc/vpTemplateTrackerZNCCInverseCompositional.cpp
@@ -335,10 +335,10 @@ void vpTemplateTrackerZNCCInverseCompositional::trackNoPyr(const vpImage<unsigne
         double NCC = sIcIref / denom;
         vpColVector dcovarIref(nbParam);
         dcovarIref = sIrefdIref / covarIref;
-        G = 1. * (sIcdIref / denom - NCC * dcovarIref / covarIref);
+        G = (sIcdIref / denom - NCC * dcovarIref / covarIref);
 
         try {
-          dp = -1. * HLMdesireInverse * G;
+          dp = - HLMdesireInverse * G;
         }
         catch (const vpException &e) {
           throw(e);

--- a/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMI.h
+++ b/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMI.h
@@ -111,6 +111,7 @@ protected:
   void computeHessienNormalized(vpMatrix &H);
   void computeMI(double &MI);
   void computeProba(int &nbpoint);
+
   double getCost(const vpImage<unsigned char> &I, const vpColVector &tp);
   double getCost(const vpImage<unsigned char> &I) { return getCost(I, p); }
   double getNormalizedCost(const vpImage<unsigned char> &I, const vpColVector &tp);

--- a/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIBSpline.h
+++ b/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIBSpline.h
@@ -114,6 +114,10 @@ public:
 
   static double d2Bspline3(double diff);
   static double d2Bspline4(double diff);
+
+  static void computeProbabilities(double *Prt, int &cr, double &er, int &ct, double &et,int &Nc, double *dW,
+                                   unsigned int &NbParam, int &bspline, vpTemplateTrackerMI::vpHessienApproximationType &approx, bool use_hessien_des);
+
 };
 
 #endif

--- a/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIForwardAdditional.h
+++ b/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIForwardAdditional.h
@@ -63,11 +63,6 @@ public:
 
 private:
   vpMinimizationTypeMIForwardAdditional minimizationMethod;
-  // pour eval evolRMS
-  double evolRMS;
-  double *x_pos;
-  double *y_pos;
-  double threshold_RMS;
   // valeur pour calculer Quasi_Newton
   vpColVector p_prec;
   vpColVector G_prec;
@@ -76,37 +71,14 @@ private:
 protected:
   void initHessienDesired(const vpImage<unsigned char> &I);
   void trackNoPyr(const vpImage<unsigned char> &I);
-  void deletePosEvalRMS();
-  void computeEvalRMS(const vpColVector &p);
-  void initPosEvalRMS(const vpColVector &p);
-
-  // private:
-  //#ifndef DOXYGEN_SHOULD_SKIP_THIS
-  //  vpTemplateTrackerMIForwardAdditional(const
-  //  vpTemplateTrackerMIForwardAdditional &)
-  //    : vpTemplateTrackerMI(), minimizationMethod(USE_NEWTON), evolRMS(0),
-  //    x_pos(NULL), y_pos(NULL),
-  //      threshold_RMS(0), p_prec(), G_prec(), KQuasiNewton()
-  //  {
-  //    throw vpException(vpException::functionNotImplementedError, "Not
-  //    implemented!");
-  //  }
-  //  vpTemplateTrackerMIForwardAdditional &operator=(const
-  //  vpTemplateTrackerMIForwardAdditional &){
-  //    throw vpException(vpException::functionNotImplementedError, "Not
-  //    implemented!"); return *this;
-  //  }
-  //#endif
 
 public:
   //! Default constructor.
   vpTemplateTrackerMIForwardAdditional()
-    : vpTemplateTrackerMI(), minimizationMethod(USE_NEWTON), evolRMS(0), x_pos(NULL), y_pos(NULL), threshold_RMS(0),
-      p_prec(), G_prec(), KQuasiNewton()
+    : vpTemplateTrackerMI(), minimizationMethod(USE_NEWTON), p_prec(), G_prec(), KQuasiNewton()
   {
   }
   explicit vpTemplateTrackerMIForwardAdditional(vpTemplateTrackerWarp *_warp);
-  void setThresholdRMS(double threshold) { threshold_RMS = threshold; }
   void setMinimizationMethod(vpMinimizationTypeMIForwardAdditional method) { minimizationMethod = method; }
 };
 

--- a/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIInverseCompositional.h
+++ b/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIInverseCompositional.h
@@ -66,11 +66,6 @@ private:
   bool CompoInitialised;
   bool useTemplateSelect; // use only the strong gradient pixels to compute
                           // the Jabocian
-  // pour eval evolRMS
-  double evolRMS;
-  double *x_pos;
-  double *y_pos;
-  double threshold_RMS;
   // valeur pour calculer Quasi_Newton
   vpColVector p_prec;
   vpColVector G_prec;
@@ -85,34 +80,12 @@ protected:
   void initCompInverse(const vpImage<unsigned char> &I);
   void initHessienDesired(const vpImage<unsigned char> &I);
   void trackNoPyr(const vpImage<unsigned char> &I);
-  void deletePosEvalRMS();
-  void computeEvalRMS(const vpColVector &p);
-  void initPosEvalRMS(const vpColVector &p);
-
-  // private:
-  //#ifndef DOXYGEN_SHOULD_SKIP_THIS
-  //  vpTemplateTrackerMIInverseCompositional(const
-  //  vpTemplateTrackerMIInverseCompositional &)
-  //    : vpTemplateTrackerMI(), minimizationMethod(USE_LMA),
-  //    CompoInitialised(false), useTemplateSelect(false),
-  //      evolRMS(0), x_pos(NULL), y_pos(NULL), threshold_RMS(0), p_prec(),
-  //      G_prec(), KQuasiNewton()//, useAYOptim(false)
-  //  {
-  //    throw vpException(vpException::functionNotImplementedError, "Not
-  //    implemented!");
-  //  }
-  //  vpTemplateTrackerMIInverseCompositional &operator=(const
-  //  vpTemplateTrackerMIInverseCompositional &){
-  //    throw vpException(vpException::functionNotImplementedError, "Not
-  //    implemented!"); return *this;
-  //  }
-  //#endif
 
 public:
   //! Default constructor.
   vpTemplateTrackerMIInverseCompositional()
-    : vpTemplateTrackerMI(), minimizationMethod(USE_LMA), CompoInitialised(false), useTemplateSelect(false), evolRMS(0),
-      x_pos(NULL), y_pos(NULL), threshold_RMS(0), p_prec(), G_prec(), KQuasiNewton() //, useAYOptim(false)
+    : vpTemplateTrackerMI(), minimizationMethod(USE_LMA), CompoInitialised(false), useTemplateSelect(false),
+      p_prec(), G_prec(), KQuasiNewton()
   {
   }
   explicit vpTemplateTrackerMIInverseCompositional(vpTemplateTrackerWarp *_warp);
@@ -120,7 +93,6 @@ public:
   /*! Use only the strong gradient pixels to compute the Jabobian. By default
    * this feature is disabled. */
   void setUseTemplateSelect(bool b) { useTemplateSelect = b; }
-  void setThresholdRMS(double threshold) { threshold_RMS = threshold; }
   void setMinimizationMethod(vpMinimizationTypeMIInverseCompositional method) { minimizationMethod = method; }
 };
 #endif

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIESM.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIESM.cpp
@@ -50,31 +50,25 @@ vpTemplateTrackerMIESM::vpTemplateTrackerMIESM(vpTemplateTrackerWarp *_warp)
 {
   useCompositionnal = false;
   useInverse = false;
-  if (!Warp->isESMcompatible())
-    std::cerr << "The selected warp function is not appropriate for the ESM "
-                 "algorithm..."
-              << std::endl;
+  if (!Warp->isESMcompatible()) {
+    throw(vpException(vpException::badValue,
+                      "The selected warp function is not appropriate for the ESM algorithm..."));
+  }
 }
 
 void vpTemplateTrackerMIESM::initHessienDesired(const vpImage<unsigned char> &I)
 {
   initCompInverse();
-  std::cout << "Initialise Hessian at Desired position..." << std::endl;
 
   dW = 0;
 
-  // double erreur=0;
   int Nbpoint = 0;
 
   double i2, j2;
-  // double Tij;
-  double /*IW,*/ dx, dy;
-  // int cr,ct;
-  // double er,et;
+  double dx, dy;
   int i, j;
 
   Nbpoint = 0;
-  // erreur=0;
 
   if (blur)
     vpImageFilter::filter(I, BI, fgG, taillef);
@@ -96,29 +90,6 @@ void vpTemplateTrackerMIESM::initHessienDesired(const vpImage<unsigned char> &I)
 
     if ((i2 >= 0) && (j2 >= 0) && (i2 < I.getHeight() - 1) && (j2 < I.getWidth() - 1)) {
       Nbpoint++;
-      //      if(blur)
-      //        IW=BI.getValue(i2,j2);
-      //      else
-      //        IW=I.getValue(i2,j2);
-
-      // ct=ptTemplateSupp[point].ct;
-      // et=ptTemplateSupp[point].et;
-      // cr=(int)((IW*(Nc-1))/255.);
-      // er=((double)IW*(Nc-1))/255.-cr;
-
-      //            if(ApproxHessian==vpTemplateTrackerMI::HESSIAN_NONSECOND)
-      //            // cas à tester AY
-      //                vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout,cr,
-      //                er, ct, et, Nc, ptTemplate[point].dW, nbParam,
-      //                bspline);
-      //            else
-      //                vpTemplateTrackerMIBSpline::PutTotPVBspline(PrtTout,cr,
-      //                er, ct, et, Nc, ptTemplate[point].dW, nbParam,
-      //                bspline);
-
-      //            vpTemplateTrackerMIBSpline::computeProbabilities(PrtTout,cr,
-      //            er, ct, et, Nc, ptTemplate[point].dW,
-      //            nbParam,bspline,ApproxHessian,false);
     }
   }
 
@@ -126,10 +97,6 @@ void vpTemplateTrackerMIESM::initHessienDesired(const vpImage<unsigned char> &I)
   computeProba(Nbpoint);
   computeMI(MI);
   computeHessien(HdesireInverse);
-  // std::cout<<"HdesireInverse"<<std::endl<<HdesireInverse<<std::endl;
-
-  /////////////////////////////////////////////////////////////////////////
-  // DIRECT COMPO
 
   vpImageFilter::getGradXGauss2D(I, dIx, fgG, fgdG, taillef);
   vpImageFilter::getGradYGauss2D(I, dIy, fgG, fgdG, taillef);
@@ -141,7 +108,6 @@ void vpTemplateTrackerMIESM::initHessienDesired(const vpImage<unsigned char> &I)
   }
 
   Nbpoint = 0;
-  // erreur=0;
   zeroProbabilities();
 
   Warp->computeCoeff(p);
@@ -159,72 +125,34 @@ void vpTemplateTrackerMIESM::initHessienDesired(const vpImage<unsigned char> &I)
 
     if ((i2 >= 0) && (j2 >= 0) && (i2 < I.getHeight()) && (j2 < I.getWidth())) {
       Nbpoint++;
-      // Tij=ptTemplate[point].val;
-      // if(!blur)
-      //  IW=I.getValue(i2,j2);
-      // else
-      //  IW=BI.getValue(i2,j2);
 
       dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
       dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
-      // cr=ptTemplateSupp[point].ct;
-      // er=ptTemplateSupp[point].et;
-      // ct=(int)((IW*(Nc-1))/255.);
-      // et=((double)IW*(Nc-1))/255.-ct;
-
       Warp->dWarpCompo(X1, X2, p, ptTemplateCompo[point].dW, dW);
 
-      double *tptemp = new double[nbParam];
-      for (unsigned int it = 0; it < nbParam; it++)
-        tptemp[it] = dW[0][it] * dx + dW[1][it] * dy;
+//      double *tptemp = new double[nbParam];
+//      for (unsigned int it = 0; it < nbParam; it++)
+//        tptemp[it] = dW[0][it] * dx + dW[1][it] * dy;
 
-      //                vpTemplateTrackerMIBSpline::computeProbabilities(PrtTout,cr,
-      //                er, ct, et, Nc, ptTemplate[point].dW,
-      //                nbParam,bspline,ApproxHessian,
-      //                                                         hessianComputation==
-      //                                                         vpTemplateTrackerMI::USE_HESSIEN_DESIRE);
-      // calcul de l'erreur
-      // erreur+=(Tij-IW)*(Tij-IW);
-
-      //          if(ApproxHessian==vpTemplateTrackerMI::HESSIAN_NONSECOND) //
-      //          cas à tester AY
-      //              vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout,cr,
-      //              er, ct, et, Nc, tptemp, nbParam, bspline);
-      //          else
-      //              vpTemplateTrackerMIBSpline::PutTotPVBspline(PrtTout,cr,
-      //              er, ct, et, Nc, tptemp, nbParam, bspline);
-
-      //      vpTemplateTrackerMIBSpline::computeProbabilities(PrtTout,cr, er,
-      //      ct, et, Nc, tptemp, nbParam,bspline,ApproxHessian,false);
-
-      delete[] tptemp;
+//      delete[] tptemp;
     }
   }
 
   computeProba(Nbpoint);
   computeMI(MI);
   computeHessien(HdesireDirect);
-  // std::cout<<"HdesireDirect"<<std::endl<<HdesireDirect<<std::endl;
 
   lambda = lambdaDep;
 
   Hdesire = HdesireDirect + HdesireInverse;
-  // Hdesire=HdesireDirect;
-  // Hdesire=HdesireInverse;
 
-  // std::cout<<"HdesireDirect "<<HdesireDirect<<std::endl;
-  // std::cout<<"HdesireInverse "<<HdesireInverse<<std::endl;
   vpMatrix::computeHLM(Hdesire, lambda, HLMdesire);
   HLMdesireInverse = HLMdesire.inverseByLU();
-
-  // std::cout<<"\tEnd initialisation..."<<std::endl;
 }
 
 void vpTemplateTrackerMIESM::initCompInverse()
 {
-  // std::cout<<"Initialise precomputed value of ESM Tracker"<<std::endl;
-
   HDirect.resize(nbParam, nbParam);
   HInverse.resize(nbParam, nbParam);
   HdesireDirect.resize(nbParam, nbParam);
@@ -266,37 +194,23 @@ void vpTemplateTrackerMIESM::initCompInverse()
 
 void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
 {
-  if (!CompoInitialised)
-    std::cout << "Compositionnal tracking no initialised\nUse "
-                 "initCompInverse(vpImage<unsigned char> &I) function"
-              << std::endl;
+  if (!CompoInitialised) {
+    std::cout << "Compositionnal tracking not initialised.\nUse initCompInverse() function."  << std::endl;
+  }
   dW = 0;
 
   if (blur)
     vpImageFilter::filter(I, BI, fgG, taillef);
   vpImageFilter::getGradXGauss2D(I, dIx, fgG, fgdG, taillef);
   vpImageFilter::getGradYGauss2D(I, dIy, fgG, fgdG, taillef);
-  /*	if(ApproxHessian!=HESSIAN_NONSECOND && ApproxHessian!=HESSIAN_0 &&
-  ApproxHessian!=HESSIAN_NEW && ApproxHessian!=HESSIAN_YOUCEF)
-  {
-    getGradX(dIx, d2Ix,fgdG,taillef);
-    getGradY(dIx, d2Ixy,fgdG,taillef);
-    getGradY(dIy, d2Iy,fgdG,taillef);
-  }*/
 
-  // double erreur=0;
   int point;
 
   MI_preEstimation = -getCost(I, p);
 
   lambda = lambdaDep;
-  // double MIprec=-1000;
 
   double i2, j2;
-  // double Tij;
-  // double IW;
-  // int cr,ct;
-  // double er,et;
 
   vpColVector dpinv(nbParam);
 
@@ -306,9 +220,7 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
   unsigned int iteration = 0;
   do {
     int Nbpoint = 0;
-    // MIprec=MI;
     double MI = 0;
-    // erreur=0;
 
     zeroProbabilities();
 
@@ -329,31 +241,10 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
 
       if ((i2 >= 0) && (j2 >= 0) && (i2 < I.getHeight() - 1) && (j2 < I.getWidth() - 1)) {
         Nbpoint++;
-        // Tij=ptTemplate[point].val;
-        // if(!blur)
-        //  IW=I.getValue(i2,j2);
-        // else
-        //  IW=BI.getValue(i2,j2);
-
-        // ct=ptTemplateSupp[point].ct;
-        // et=ptTemplateSupp[point].et;
-        // cr=(int)((IW*(Nc-1))/255.);
-        // er=((double)IW*(Nc-1))/255.-cr;
-
-        //                if(ApproxHessian==vpTemplateTrackerMI::HESSIAN_NONSECOND||hessianComputation==vpTemplateTrackerMI::USE_HESSIEN_DESIRE)
-        //                // cas à tester AY
-        //                    vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout,
-        //                    cr, er, ct, et, Nc, ptTemplate[point].dW,
-        //                    nbParam, bspline);
-        //                else
-        //                    vpTemplateTrackerMIBSpline::PutTotPVBspline(PrtTout,
-        //                    cr, er, ct, et, Nc, ptTemplate[point].dW,
-        //                    nbParam, bspline);
       }
     }
 
     if (Nbpoint == 0) {
-      // std::cout<<"plus de point dans template suivi"<<std::endl;
       diverge = true;
       MI = 0;
       throw(vpTrackingException(vpTrackingException::notEnoughPointError, "No points in the template"));
@@ -369,9 +260,7 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
       // DIRECT
 
       Nbpoint = 0;
-      // MIprec=MI;
       MI = 0;
-      // erreur=0;
 
       zeroProbabilities();
 
@@ -393,41 +282,17 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
         X2[0] = j2;
         X2[1] = i2;
 
-        // Warp->computeDenom(X1,p);
         if ((i2 >= 0) && (j2 >= 0) && (i2 < I.getHeight() - 1) && (j2 < I.getWidth() - 1)) {
           Nbpoint++;
-          // Tij=ptTemplate[point].val;
-          // Tij=Iterateurvecteur->val;
-          // if(!blur)
-          //  IW=I.getValue(i2,j2);
-          // else
-          //  IW=BI.getValue(i2,j2);
 
           double dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
           double dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
-
-          // ct=(int)((IW*(Nc-1))/255.);
-          // et=((double)IW*(Nc-1))/255.-ct;
-          // cr=ptTemplateSupp[point].ct;
-          // er=ptTemplateSupp[point].et;
 
           Warp->dWarpCompo(X1, X2, p, ptTemplateCompo[point].dW, dW);
 
           double *tptemp = new double[nbParam];
           for (unsigned int it = 0; it < nbParam; it++)
             tptemp[it] = dW[0][it] * dx + dW[1][it] * dy;
-
-          // calcul de l'erreur
-          // erreur+=(Tij-IW)*(Tij-IW);
-          //                    if(bspline==3)
-          //                        vpTemplateTrackerMIBSpline::PutTotPVBspline3NoSecond(PrtTout,
-          //                        cr, er, ct, et, Nc, tptemp, nbParam);
-          //                    else
-          //                        vpTemplateTrackerMIBSpline::PutTotPVBspline4NoSecond(PrtTout,
-          //                        cr, er, ct, et, Nc, tptemp, nbParam);
-          //					vpTemplateTrackerMIBSpline::computeProbabilities(PrtTout,cr,
-          // er, ct, et, Nc, tptemp, nbParam,bspline,ApproxHessian,
-          //                               hessianComputation==vpHessienType::USE_HESSIEN_DESIRE);
 
           delete[] tptemp;
         }
@@ -445,8 +310,6 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
         vpMatrix::computeHLM(H, lambda, HLM);
       }
       G = GDirect - GInverse;
-      // G=GDirect;
-      // G=-GInverse;
 
       try {
         if (minimizationMethod == vpTemplateTrackerMIESM::USE_GRADIENT)
@@ -468,7 +331,6 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
           }
         }
       } catch (const vpException &e) {
-        // std::cerr<<"probleme inversion"<<std::endl;
         throw(e);
       }
 
@@ -484,7 +346,7 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
 
       iteration++;
     }
-  } while (/*(MI!=MIprec) &&*/ (iteration < iterationMax));
+  } while ((iteration < iterationMax));
 
   MI_postEstimation = -getCost(I, p);
   if (MI_preEstimation > MI_postEstimation) {

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIESM.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIESM.cpp
@@ -147,8 +147,8 @@ void vpTemplateTrackerMIESM::initHessienDesired(const vpImage<unsigned char> &I)
       else
         IW=BI.getValue(i2,j2);
 
-      dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
-      dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
+      dx = dIx.getValue(i2, j2) * (Nc - 1) / 255.;
+      dy = dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
       cr = ptTemplateSupp[point].ct;
       er = ptTemplateSupp[point].et;
@@ -334,8 +334,8 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
           else
             IW=BI.getValue(i2,j2);
 
-          double dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
-          double dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
+          double dx = dIx.getValue(i2, j2) * (Nc - 1) / 255.;
+          double dy = dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
           ct = static_cast<int>((IW*(Nc-1))/255.);
           et = (IW*(Nc-1))/255.-ct;
@@ -389,7 +389,7 @@ void vpTemplateTrackerMIESM::trackNoPyr(const vpImage<unsigned char> &I)
       }
 
       if (ApproxHessian == HESSIAN_NONSECOND)
-        dp = -1. * dp;
+        dp = - dp;
 
       if (useBrent) {
         alpha = 2.;

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardAdditional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardAdditional.cpp
@@ -159,6 +159,10 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
   unsigned int iteration = 0;
 
   initPosEvalRMS(p);
+  double evolRMS_init = 0;
+  double evolRMS_prec = 0;
+  double evolRMS_delta;
+  const double evolRMS_eps = 1e-4;
   do {
     if (iteration % 5 == 0)
       initHessienDesired(I);
@@ -327,11 +331,20 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
     }
 
     computeEvalRMS(p);
+
+    if (iteration == 0)
+        {
+            evolRMS_init = evolRMS;
+        }
     iteration++;
     iterationGlobale++;
 
+
+    evolRMS_delta = std::fabs(evolRMS - evolRMS_prec);
+    evolRMS_prec = evolRMS;
+
   } while ((std::fabs(MI - MIprec) > std::fabs(MI) * std::numeric_limits<double>::epsilon()) &&
-           (iteration < iterationMax) && (evolRMS > threshold_RMS));
+           (iteration < iterationMax) && (evolRMS_delta > std::fabs(evolRMS_init)*evolRMS_eps));
   // while( (MI!=MIprec) &&(iteration< iterationMax)&&(evolRMS>threshold_RMS)
   // );
   if (Nbpoint == 0) {

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardAdditional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardAdditional.cpp
@@ -92,8 +92,8 @@ void vpTemplateTrackerMIForwardAdditional::initHessienDesired(const vpImage<unsi
       else
         IW = BI.getValue(i2, j2);
 
-      dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
-      dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
+      dx = dIx.getValue(i2, j2) * (Nc - 1) / 255.;
+      dy = dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
       ct = static_cast<int>((IW * (Nc - 1)) / 255.);
       cr = static_cast<int>((Tij * (Nc - 1)) / 255.);
@@ -191,8 +191,8 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
         else
           IW = BI.getValue(i2, j2);
 
-        double dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
-        double dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
+        double dx = dIx.getValue(i2, j2) * (Nc - 1) / 255.;
+        double dy = dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
         int ct = (int)((IW * (Nc - 1)) / 255.);
         int cr = (int)((Tij * (Nc - 1)) / 255.);
@@ -251,7 +251,7 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
       if (ApproxHessian == HESSIAN_NONSECOND)
         p_test_LMA = p - 100000.1 * dp;
       else
-        p_test_LMA = p + 1. * dp;
+        p_test_LMA = p + dp;
       MI = -getCost(I, p);
       double MI_LMA = -getCost(I, p_test_LMA);
       if (MI_LMA > MI) {

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardAdditional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardAdditional.cpp
@@ -52,8 +52,6 @@ vpTemplateTrackerMIForwardAdditional::vpTemplateTrackerMIForwardAdditional(vpTem
 
 void vpTemplateTrackerMIForwardAdditional::initHessienDesired(const vpImage<unsigned char> &I)
 {
-  // std::cout<<"Initialise Hessian at Desired position..."<<std::endl;
-
   dW = 0;
 
   int Nbpoint = 0;
@@ -101,7 +99,6 @@ void vpTemplateTrackerMIForwardAdditional::initHessienDesired(const vpImage<unsi
       cr = static_cast<int>((Tij * (Nc - 1)) / 255.);
       et = (IW * (Nc - 1)) / 255. - ct;
       er = (static_cast<double>(Tij) * (Nc - 1)) / 255. - cr;
-      // std::cout<<"test"<<std::endl;
       Warp->dWarp(X1, X2, p, dW);
 
       double *tptemp = new double[nbParam];
@@ -123,17 +120,12 @@ void vpTemplateTrackerMIForwardAdditional::initHessienDesired(const vpImage<unsi
     computeMI(MI);
     computeHessien(Hdesire);
 
-    //	double conditionnement=GetConditionnement(Hdesire);
-    //	std::cout<<"conditionnement : "<<conditionnement<<std::endl;
     vpMatrix::computeHLM(Hdesire, lambda, HLMdesire);
     try {
       HLMdesireInverse = HLMdesire.inverseByLU();
     } catch (const vpException &e) {
-      // std::cerr<<"probleme inversion"<<std::endl;
       throw(e);
     }
-    // std::cout<<"Hdesire = "<<Hdesire<<std::endl;
-    // std::cout<<"\tEnd initialisation..."<<std::endl;
   }
 }
 
@@ -141,7 +133,6 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
 {
   dW = 0;
 
-  // double erreur=0;
   int Nbpoint = 0;
   if (blur)
     vpImageFilter::filter(I, BI, fgG, taillef);
@@ -208,20 +199,12 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
         double et = (IW * (Nc - 1)) / 255. - ct;
         double er = ((double)Tij * (Nc - 1)) / 255. - cr;
 
-        // calcul de l'erreur
-        // erreur+=(Tij-IW)*(Tij-IW);
-
-        // Calcul de l'histogramme joint par interpolation bilinÃaire
-        // (Bspline ordre 1)
         Warp->dWarp(X1, X2, p, dW);
 
-        // double *tptemp=temp;
         double *tptemp = new double[nbParam];
         ;
         for (unsigned int it = 0; it < nbParam; it++)
           tptemp[it] = (dW[0][it] * dx + dW[1][it] * dy);
-        //*tptemp++ =dW[0][it]*dIWx+dW[1][it]*dIWy;
-        // std::cout<<cr<<"   "<<ct<<"  ; ";
         if (ApproxHessian == HESSIAN_NONSECOND || hessianComputation == vpTemplateTrackerMI::USE_HESSIEN_DESIRE)
           vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout, cr, er, ct, et, Nc, tptemp, nbParam, bspline);
         else if (ApproxHessian == HESSIAN_0 || ApproxHessian == HESSIAN_NEW)
@@ -285,7 +268,7 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
         computeOptimalBrentGain(I, p, -MI, dp, alpha);
         dp = alpha * dp;
       }
-      p += 1. * dp;
+      p += dp;
       break;
     }
 
@@ -294,13 +277,11 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
         vpColVector s_quasi = p - p_prec;
         vpColVector y_quasi = G - G_prec;
         double s_scal_y = s_quasi.t() * y_quasi;
-        // if(s_scal_y!=0)//BFGS
-        //	KQuasiNewton=KQuasiNewton-(s_quasi*y_quasi.t()*KQuasiNewton+KQuasiNewton*y_quasi*s_quasi.t())/s_scal_y+(1.+y_quasi.t()*(KQuasiNewton*y_quasi)/s_scal_y)*s_quasi*s_quasi.t()/s_scal_y;
-        // if(s_scal_y!=0)//DFP
-        if (std::fabs(s_scal_y) > std::numeric_limits<double>::epsilon())
+        if (std::fabs(s_scal_y) > std::numeric_limits<double>::epsilon()) {
           KQuasiNewton = KQuasiNewton + 0.001 * (s_quasi * s_quasi.t() / s_scal_y -
                                                  KQuasiNewton * y_quasi * y_quasi.t() * KQuasiNewton /
-                                                     (y_quasi.t() * KQuasiNewton * y_quasi));
+                                                 (y_quasi.t() * KQuasiNewton * y_quasi));
+        }
       }
       dp = -KQuasiNewton * G;
       p_prec = p;
@@ -317,7 +298,7 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
         dp = alpha * dp;
       }
 
-      p += 1. * dp;
+      p += dp;
       break;
     }
     }
@@ -329,7 +310,6 @@ void vpTemplateTrackerMIForwardAdditional::trackNoPyr(const vpImage<unsigned cha
     }
     iteration++;
     iterationGlobale++;
-
 
     evolRMS_delta = std::fabs(evolRMS - evolRMS_prec);
     evolRMS_prec = evolRMS;

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardCompositional.cpp
@@ -161,12 +161,11 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
               << std::endl;
   dW = 0;
 
-  if (blur)
+  if (blur) {
     vpImageFilter::filter(I, BI, fgG, taillef);
+  }
   vpImageFilter::getGradXGauss2D(I, dIx, fgG, fgdG, taillef);
   vpImageFilter::getGradYGauss2D(I, dIy, fgG, fgdG, taillef);
-
-  // double erreur=0;
 
   lambda = lambdaDep;
   double MI = 0, MIprec = -1000;
@@ -174,9 +173,7 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
   MI_preEstimation = -getCost(I, p);
 
   double i2, j2;
-  // double Tij;
   double IW;
-  // unsigned
   int cr, ct;
   double er, et;
   double dx, dy;
@@ -186,11 +183,11 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
 
   int i, j;
   unsigned int iteration = 0;
+
   do {
     int Nbpoint = 0;
     MIprec = MI;
     MI = 0;
-    // erreur=0;
 
     zeroProbabilities();
 
@@ -208,7 +205,6 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
       Warp->computeDenom(X1, p);
       if ((i2 >= 0) && (j2 >= 0) && (i2 < I.getHeight() - 1) && (j2 < I.getWidth() - 1)) {
         Nbpoint++;
-        // Tij=ptTemplate[point].val;
         if (!blur)
           IW = I.getValue(i2, j2);
         else
@@ -228,9 +224,6 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
         for (unsigned int it = 0; it < nbParam; it++)
           tptemp[it] = dW[0][it] * dx + dW[1][it] * dy;
 
-        // calcul de l'erreur
-        // erreur+=(Tij-IW)*(Tij-IW);
-
         if (ApproxHessian == HESSIAN_NONSECOND || hessianComputation == vpTemplateTrackerMI::USE_HESSIEN_DESIRE)
           vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout, cr, er, ct, et, Nc, tptemp, nbParam, bspline);
         else if (ApproxHessian == HESSIAN_0 || ApproxHessian == HESSIAN_NEW)
@@ -240,7 +233,6 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
       }
     }
     if (Nbpoint == 0) {
-      // std::cout<<"plus de point dans template suivi"<<std::endl;
       diverge = true;
       MI = 0;
       throw(vpTrackingException(vpTrackingException::notEnoughPointError, "No points in the template"));
@@ -269,7 +261,6 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
           break;
         }
       } catch (const vpException &e) {
-        // std::cerr<<"probleme inversion"<<std::endl;
         throw(e);
       }
     }
@@ -287,10 +278,9 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
     Warp->pRondp(p, dp, p);
 
     iteration++;
-
   } while ((std::fabs(MI - MIprec) > std::fabs(MI) * std::numeric_limits<double>::epsilon()) &&
            (iteration < iterationMax));
-  // while( (MI!=MIprec) && (iteration< iterationMax) );
+
   nbIteration = iteration;
 
   MI_postEstimation = -getCost(I, p);

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIForwardCompositional.cpp
@@ -111,8 +111,8 @@ void vpTemplateTrackerMIForwardCompositional::initHessienDesired(const vpImage<u
       else
         IW = BI.getValue(i2, j2);
 
-      dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
-      dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
+      dx = dIx.getValue(i2, j2) * (Nc - 1) / 255.;
+      dy = dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
       cr = ptTemplateSupp[point].ct;
       er = ptTemplateSupp[point].et;
@@ -203,8 +203,8 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
         else
           IW = BI.getValue(i2, j2);
 
-        dx = 1. * dIx.getValue(i2, j2) * (Nc - 1) / 255.;
-        dy = 1. * dIy.getValue(i2, j2) * (Nc - 1) / 255.;
+        dx = dIx.getValue(i2, j2) * (Nc - 1) / 255.;
+        dy = dIy.getValue(i2, j2) * (Nc - 1) / 255.;
 
         ct = (int)((IW * (Nc - 1)) / 255.);
         et = ((double)IW * (Nc - 1)) / 255. - ct;
@@ -260,8 +260,8 @@ void vpTemplateTrackerMIForwardCompositional::trackNoPyr(const vpImage<unsigned 
 
     if (ApproxHessian == HESSIAN_NONSECOND)
       dp = -0.04 * dp;
-    else
-      dp = 1. * dp;
+//    else
+//      dp = 1. * dp;
 
     if (useBrent) {
       alpha = 2.;

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
@@ -96,7 +96,8 @@ void vpTemplateTrackerMIInverseCompositional::initCompInverse(const vpImage<unsi
   if (ApproxHessian != HESSIAN_NONSECOND && ApproxHessian != HESSIAN_0 && ApproxHessian != HESSIAN_NEW &&
       ApproxHessian != HESSIAN_YOUCEF) {
     vpImageFilter::getGradX(dIx, d2Ix, fgdG, taillef);
-    vpImageFilter::getGradY(dIx, d2Ixy, fgdG, taillef);
+    //vpImageFilter::getGradY(dIx, d2Ixy, fgdG, taillef);
+    d2Ixy = d2Ix;
     vpImageFilter::getGradY(dIy, d2Iy, fgdG, taillef);
   }
 
@@ -118,7 +119,6 @@ void vpTemplateTrackerMIInverseCompositional::initCompInverse(const vpImage<unsi
     double Tij = ptTemplate[point].val;
     int ct = static_cast<int>((Tij * (Nc - 1)) / 255.);
     double et = (Tij * (Nc - 1)) / 255. - ct;
-
     ptTemplateSupp[point].et = et;
     ptTemplateSupp[point].ct = ct;
   }

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
@@ -51,7 +51,7 @@ vpTemplateTrackerMIInverseCompositional::vpTemplateTrackerMIInverseCompositional
 
 void vpTemplateTrackerMIInverseCompositional::initTemplateRefBspline(unsigned int ptIndex, double &et) // AY : Optim
 {
-  ptTemplateSupp[ptIndex].BtInit = new double[(1 + nbParam + nbParam * nbParam) * (unsigned int)bspline];
+  ptTemplateSupp[ptIndex].BtInit = new double[(1 + nbParam + nbParam * nbParam) * static_cast<unsigned int>(bspline)];
 
   unsigned int index = 0;
   int endIndex = 1;
@@ -74,13 +74,13 @@ void vpTemplateTrackerMIInverseCompositional::initTemplateRefBspline(unsigned in
   }
 
   for (int it = -1; it <= endIndex; it++) {
-    ptTemplateSupp[ptIndex].BtInit[index++] = (*ptBspFct)((double)(-it) + et);
+    ptTemplateSupp[ptIndex].BtInit[index++] = (*ptBspFct)(static_cast<double>(-it) + et);
 
     for (unsigned int ip = 0; ip < nbParam; ++ip) {
-      ptTemplateSupp[ptIndex].BtInit[index++] = (*ptdBspFct)((double)(-it) + et) * ptTemplate[ptIndex].dW[ip] * (-1.0);
+      ptTemplateSupp[ptIndex].BtInit[index++] = (*ptdBspFct)(static_cast<double>(-it) + et) * ptTemplate[ptIndex].dW[ip] * (-1.0);
       for (unsigned int ip2 = 0; ip2 < nbParam; ++ip2) {
         ptTemplateSupp[ptIndex].BtInit[index++] =
-            (*ptd2BspFct)((double)(-it) + et) * ptTemplate[ptIndex].dW[ip] * ptTemplate[ptIndex].dW[ip2];
+            (*ptd2BspFct)(static_cast<double>(-it) + et) * ptTemplate[ptIndex].dW[ip] * ptTemplate[ptIndex].dW[ip2];
       }
     }
   }
@@ -116,7 +116,7 @@ void vpTemplateTrackerMIInverseCompositional::initCompInverse(const vpImage<unsi
 
     Warp->getdW0(i, j, dy, dx, ptTemplate[point].dW);
     double Tij = ptTemplate[point].val;
-    int ct = (int)((Tij * (Nc - 1)) / 255.);
+    int ct = static_cast<int>((Tij * (Nc - 1)) / 255.);
     double et = (Tij * (Nc - 1)) / 255. - ct;
 
     ptTemplateSupp[point].et = et;
@@ -164,8 +164,8 @@ void vpTemplateTrackerMIInverseCompositional::initHessienDesired(const vpImage<u
 
       ct = ptTemplateSupp[point].ct;
       et = ptTemplateSupp[point].et;
-      cr = (int)((IW * (Nc - 1)) / 255.);
-      er = ((double)IW * (Nc - 1)) / 255. - cr;
+      cr = static_cast<int>((IW * (Nc - 1)) / 255.);
+      er = (IW * (Nc - 1)) / 255. - cr;
 
       if (ApproxHessian == HESSIAN_NONSECOND && (ptTemplateSelect[point] || !useTemplateSelect)) {
         vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout, cr, er, ct, et, Nc, ptTemplate[point].dW, nbParam,
@@ -235,11 +235,11 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
 
     Warp->computeCoeff(p);
 
-    for (int point = 0; point < (int)templateSize; point++) {
+    for (int point = 0; point < static_cast<int>(templateSize); point++) {
       double i2, j2;
 
-      X1[0] = (double)ptTemplate[point].x;
-      X1[1] = (double)ptTemplate[point].y;
+      X1[0] = static_cast<double>(ptTemplate[point].x);
+      X1[1] = static_cast<double>(ptTemplate[point].y);
 
       Warp->computeDenom(X1, p);
       Warp->warpX(X1, X2, p);
@@ -252,15 +252,15 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
         Nbpoint++;
         double IW;
         if (!blur)
-          IW = (double)I.getValue(i2, j2);
+          IW = static_cast<double>(I.getValue(i2, j2));
         else
           IW = BI.getValue(i2, j2);
 
         int ct = ptTemplateSupp[point].ct;
         double et = ptTemplateSupp[point].et;
-        double tmp = IW * (((double)Nc) - 1.f) / 255.f;
-        int cr = (int)tmp;
-        double er = tmp - (double)cr;
+        double tmp = IW * (static_cast<double>(Nc) - 1.) / 255.;
+        int cr = static_cast<int>(tmp);
+        double er = tmp - static_cast<double>(cr);
 
         if ((ApproxHessian == HESSIAN_NONSECOND || hessianComputation == vpTemplateTrackerMI::USE_HESSIEN_DESIRE) &&
             (ptTemplateSelect[point] || !useTemplateSelect)) {
@@ -288,7 +288,7 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
     } else {
       unsigned int indd, indd2;
       indd = indd2 = 0;
-      unsigned int Ncb_ = (unsigned int)Ncb;
+      unsigned int Ncb_ = static_cast<unsigned int>(Ncb);
       for (unsigned int i = 0; i < Ncb_ * Ncb_; i++) {
         Prt[i] = Prt[i] / Nbpoint;
         for (unsigned int j = 0; j < nbParam; j++) {

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
@@ -44,7 +44,7 @@
 
 vpTemplateTrackerMIInverseCompositional::vpTemplateTrackerMIInverseCompositional(vpTemplateTrackerWarp *_warp)
   : vpTemplateTrackerMI(_warp), minimizationMethod(USE_LMA), CompoInitialised(false), useTemplateSelect(false),
-    p_prec(), G_prec(), KQuasiNewton() //, useAYOptim(false)
+    p_prec(), G_prec(), KQuasiNewton()
 {
   useInverse = true;
 }
@@ -121,14 +121,6 @@ void vpTemplateTrackerMIInverseCompositional::initCompInverse(const vpImage<unsi
 
     ptTemplateSupp[point].et = et;
     ptTemplateSupp[point].ct = ct;
-
-    // ###### AY Optim
-    //        if(useAYOptim)
-    //            if(ApproxHessian != HESSIAN_NONSECOND /*&&
-    //            hessianComputation !=
-    //            vpTemplateTrackerMI::USE_HESSIEN_DESIRE*/)
-    //                initTemplateRefBspline(point, et);
-    // ###################
   }
   CompoInitialised = true;
 }
@@ -136,27 +128,19 @@ void vpTemplateTrackerMIInverseCompositional::initHessienDesired(const vpImage<u
 {
   initCompInverse(I);
 
-  // double erreur=0;
   int Nbpoint = 0;
 
-  // double Tij;
   double IW;
   int cr, ct;
   double er, et;
 
   Nbpoint = 0;
-  // erreur=0;
 
   if (blur)
     vpImageFilter::filter(I, BI, fgG, taillef);
 
   zeroProbabilities();
   Warp->computeCoeff(p);
-
-  // AY : Optim
-  //    unsigned int totParam = (bspline *
-  //    bspline)*(1+nbParam+nbParam*nbParam); unsigned int size = (1 + nbParam
-  //    + nbParam*nbParam)*bspline; double *ptb;
 
   for (unsigned int point = 0; point < templateSize; point++) {
     int i = ptTemplate[point].y;
@@ -172,7 +156,6 @@ void vpTemplateTrackerMIInverseCompositional::initHessienDesired(const vpImage<u
 
     if ((i2 >= 0) && (j2 >= 0) && (i2 < I.getHeight() - 1) && (j2 < I.getWidth() - 1)) {
       Nbpoint++;
-      // Tij=ptTemplate[point].val;
 
       if (blur)
         IW = BI.getValue(i2, j2);
@@ -184,9 +167,6 @@ void vpTemplateTrackerMIInverseCompositional::initHessienDesired(const vpImage<u
       cr = (int)((IW * (Nc - 1)) / 255.);
       er = ((double)IW * (Nc - 1)) / 255. - cr;
 
-      // calcul de l'erreur
-      // erreur+=(Tij-IW)*(Tij-IW);
-
       if (ApproxHessian == HESSIAN_NONSECOND && (ptTemplateSelect[point] || !useTemplateSelect)) {
         vpTemplateTrackerMIBSpline::PutTotPVBsplineNoSecond(PrtTout, cr, er, ct, et, Nc, ptTemplate[point].dW, nbParam,
                                                             bspline);
@@ -194,25 +174,8 @@ void vpTemplateTrackerMIInverseCompositional::initHessienDesired(const vpImage<u
                  (ptTemplateSelect[point] || !useTemplateSelect)) {
         if (bspline == 3) {
           vpTemplateTrackerMIBSpline::PutTotPVBspline3(PrtTout, cr, er, ct, et, Nc, ptTemplate[point].dW, nbParam);
-          //                    {
-          //                        if(et>0.5){ct++;}
-          //                        if(er>0.5){cr++;}
-          //                        int index = (cr*Nc+ct)*totParam;
-          //                        double *ptb = &PrtTout[index];
-          //                        vpTemplateTrackerMIBSpline::PutTotPVBspline3(ptb,
-          //                        er, ptTemplateSupp[point].BtInit, size);
-          //                    }
         } else {
           vpTemplateTrackerMIBSpline::PutTotPVBspline4(PrtTout, cr, er, ct, et, Nc, ptTemplate[point].dW, nbParam);
-
-          //                    {
-          //                        // ################### AY : Optim
-          //                        unsigned int index = (cr*Nc+ct)*totParam;
-          //                        ptb = &PrtTout[index];
-          //                        vpTemplateTrackerMIBSpline::PutTotPVBspline4(ptb,
-          //                        er, ptTemplateSupp[point].BtInit, size);
-          //                        // ###################
-          //                    }
         }
       } else if (ptTemplateSelect[point] || !useTemplateSelect)
         vpTemplateTrackerMIBSpline::PutTotPVBsplinePrt(PrtTout, cr, er, ct, et, Nc, nbParam, bspline);
@@ -234,10 +197,10 @@ void vpTemplateTrackerMIInverseCompositional::initHessienDesired(const vpImage<u
 
 void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned char> &I)
 {
-  if (!CompoInitialised)
-    std::cout << "Compositionnal tracking no initialised\nUse "
-                 "InitCompInverse(vpImage<unsigned char> &I) function"
-              << std::endl;
+  if (!CompoInitialised) {
+    std::cout << "Compositionnal tracking not initialised.\nUse initCompInverse() function." << std::endl;
+  }
+
   dW = 0;
 
   if (blur)
@@ -278,9 +241,7 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
       X1[0] = (double)ptTemplate[point].x;
       X1[1] = (double)ptTemplate[point].y;
 
-      Warp->computeDenom(X1, p); // A modif pour parallelisation mais ne
-      // pose pas de pb avec warp utilises dans
-      // DECSA
+      Warp->computeDenom(X1, p);
       Warp->warpX(X1, X2, p);
 
       j2 = X2[0];

--- a/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
+++ b/modules/tracker/tt_mi/src/mi/vpTemplateTrackerMIInverseCompositional.cpp
@@ -339,7 +339,7 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
       if (ApproxHessian == HESSIAN_NONSECOND)
         dp_test_LMA = -100000.1 * dp;
       else
-        dp_test_LMA = 1. * dp;
+        dp_test_LMA = dp;
       Warp->getParamInverse(dp_test_LMA, dpinv_test_LMA);
       Warp->pRondp(p, dpinv_test_LMA, p_test_LMA);
 
@@ -380,7 +380,7 @@ void vpTemplateTrackerMIInverseCompositional::trackNoPyr(const vpImage<unsigned 
         dp = alpha * dp;
       }
       if (ApproxHessian == HESSIAN_NONSECOND)
-        dp = -1. * dp;
+        dp = - dp;
 
       break;
     }

--- a/modules/tracker/tt_mi/src/tools/vpTemplateTrackerMIBSpline.cpp
+++ b/modules/tracker/tt_mi/src/tools/vpTemplateTrackerMIBSpline.cpp
@@ -766,4 +766,21 @@ void vpTemplateTrackerMIBSpline::PutTotPVBspline4Prt(double *Prt, int &cr, doubl
   }
 }
 
+void vpTemplateTrackerMIBSpline::computeProbabilities(double *Prt, int &cr, double &er, int &ct, double &et,int &Nc, double *dW,
+                                               unsigned int &NbParam, int &bspline, vpTemplateTrackerMI::vpHessienApproximationType &approx, bool use_hessien_des)
+{
+  if (approx == vpTemplateTrackerMI::HESSIAN_NONSECOND || use_hessien_des) {
+    if (bspline==3)
+      PutTotPVBspline3NoSecond(Prt, cr, er, ct, et, Nc, dW, NbParam);
+    else
+      PutTotPVBspline4NoSecond(Prt, cr, er, ct, et, Nc, dW, NbParam);
+  }
+  else {
+    if(bspline==3)
+      PutTotPVBspline3(Prt, cr, er, ct, et, Nc, dW, NbParam);
+    else
+      PutTotPVBspline4(Prt, cr, er, ct, et, Nc, dW, NbParam);
+  }
+}
+
 #endif


### PR DESCRIPTION
This pull request relates issue #614

Optimize `vpTemplateTrackerMIInverseCompositional` to reduce the number of iterations used during optimization.

The following images highlights the improvements using `$ ./templateTracker -t 9 -c` example.

Results obtained with `evalRMS_eps=1e-3`: 
![test-10-3](https://user-images.githubusercontent.com/55136051/65892058-f02b7680-e3a5-11e9-87f4-522acf5c667f.png)

Results obtained with `evalRMS_eps=1e-4`: 
![test-10-4](https://user-images.githubusercontent.com/55136051/65892160-1c46f780-e3a6-11e9-90d8-265e5079f391.png)

Results obtained with `evalRMS_eps=1e-5`: 
![test-10-5](https://user-images.githubusercontent.com/55136051/65892190-28cb5000-e3a6-11e9-95d8-033b7baaaf42.png)

Results obtained with `evalRMS_eps=1e-6`: 
![test-10-6](https://user-images.githubusercontent.com/55136051/65892213-2f59c780-e3a6-11e9-9119-c3e75fc59a28.png)

We decided to retain  `evalRMS_eps=1e-4` which gives a good trade off.