### PR TITLE
Degeneracy in vpLinProg::rowReduction + faster QP by picking QR over SVD when possible

### DIFF
--- a/modules/core/include/visp3/core/vpQuadProg.h
+++ b/modules/core/include/visp3/core/vpQuadProg.h
@@ -127,6 +127,8 @@ protected:
   */
   vpMatrix Z;
 
+  static vpColVector solveSVDorQR(const vpMatrix &A, const vpColVector &b);
+
   static bool solveByProjection(const vpMatrix &Q, const vpColVector &r,
                                 vpMatrix &A, vpColVector &b,
                                 vpColVector &x, const double &tol = 1e-6);

--- a/modules/core/include/visp3/core/vpQuadProg.h
+++ b/modules/core/include/visp3/core/vpQuadProg.h
@@ -155,8 +155,8 @@ protected:
   {
     // check data consistency
     const unsigned int n = Q.getCols();
-    const bool Ab = (A != NULL && b != NULL && A->getRows());
-    const bool Cd = (C != NULL && d != NULL && C->getRows());
+    const bool Ab = (A != nullptr && b != nullptr && A->getRows());
+    const bool Cd = (C != nullptr && d != nullptr && C->getRows());
 
     if (  (Ab && n != A->getCols()) ||
           (Cd && n != C->getCols()) ||

--- a/modules/core/src/tools/optimization/vpLinProg.cpp
+++ b/modules/core/src/tools/optimization/vpLinProg.cpp
@@ -266,6 +266,19 @@ bool vpLinProg::rowReduction(vpMatrix &A, vpColVector &b, const double &tol)
   const unsigned int m = A.getRows();
   const unsigned int n = A.getCols();
 
+  // degeneracy if A is actually null
+  if(A.infinityNorm() < tol)
+  {
+    if(b.infinityNorm() < tol)
+    {
+      b.resize(0);
+      A.resize(0,n);
+      return true;
+    }
+    else
+      return false;
+  }
+
   vpMatrix Q, R, P;
   const unsigned int r = A.qrPivot(Q, R, P, false, false, tol);
   const vpColVector x = P.transpose() *

--- a/modules/core/src/tools/optimization/vpQuadProg.cpp
+++ b/modules/core/src/tools/optimization/vpQuadProg.cpp
@@ -113,7 +113,7 @@ void vpQuadProg::fromCanonicalCost(const vpMatrix &/*H*/, const vpColVector &/*c
   vpMatrix    V(n,n);
   // Compute the eigenvalues and eigenvectors
   H.eigenValues(d, V);
-  // find first non-null eigen value
+  // find first non-nullptr eigen value
   unsigned int k = 0;
   for(unsigned int i = 0; i < n; ++i)
   {
@@ -325,7 +325,7 @@ bool vpQuadProg::solveQPe (const vpMatrix &Q, const vpColVector &r,
 bool vpQuadProg::solveQPe (const vpMatrix &Q, const vpColVector &r, vpMatrix A, vpColVector b,
                            vpColVector &x, const double &tol)
 {
-  checkDimensions(Q, r, &A, &b, NULL, NULL, "solveQPe");
+  checkDimensions(Q, r, &A, &b, nullptr, nullptr, "solveQPe");
 
   if(!solveByProjection(Q, r, A, b, x, tol))
   {
@@ -467,7 +467,7 @@ bool vpQuadProg::solveQPi(const vpMatrix &Q, const vpColVector &r,
                           vpColVector &x, const bool use_equality,
                           const double &tol)
 {
-  const unsigned int n = checkDimensions(Q, r, NULL, NULL, &C, &d, "solveQPi");
+  const unsigned int n = checkDimensions(Q, r, nullptr, nullptr, &C, &d, "solveQPi");
 
   if(use_equality)
   {

--- a/modules/core/src/tools/optimization/vpQuadProg.cpp
+++ b/modules/core/src/tools/optimization/vpQuadProg.cpp
@@ -711,6 +711,24 @@ bool vpQuadProg::solveQPi(const vpMatrix &Q, const vpColVector &r,
     }
   }
 }
+
+/*!
+  Pick either SVD (over-constrained) or QR (square or under-constrained)
+
+  Assumes A is full rank, hence uses SVD iif A has more row than columns.
+
+  \param A : matrix (dimension m x n)
+  \param b : vector (dimension m)
+
+  \return least-norm solution to \f$\arg\min||\mathbf{A}\mathbf{x} - \mathbf{b}||\f$
+*/
+vpColVector vpQuadProg::solveSVDorQR(const vpMatrix &A, const vpColVector &b)
+{
+  // assume A is full rank
+  if(A.getRows() > A.getCols())
+    return A.solveBySVD(b);
+  return A.solveByQR(b);
+}
 #else
 void dummy_vpQuadProg(){};
 #endif


### PR DESCRIPTION
Fabien, 

I have noticed some edge cases where vpLinProg::rowReduction crashes due to degenerate A matrix.

Also, not that solvebyQR is possible, it is used instead of solveBySVD when possible as it is faster.