### PR TITLE
Minor improvements for image moments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ VP_OPTION(BUILD_WITH_STATIC_CRT  "" "" "Enables use of staticaly linked CRT for 
 # ----------------------------------------------------------------------------
 VP_OPTION(ENABLE_SOLUTION_FOLDERS "" "" "Solution folder in Visual Studio or in other IDEs" "" (MSVC_IDE OR CMAKE_GENERATOR MATCHES Xcode))
 # Note that it is better to set ENABLE_MOMENTS_COMBINE_MATRICES to OFF
-VP_OPTION(ENABLE_MOMENTS_COMBINE_MATRICES  "" "" "Use linear combination of matrices instead of linear combination of moments to compute interaction matrices." "ENABLE_MOMENTS_COMBINE_MATRICES" OFF)
+VP_OPTION(ENABLE_MOMENTS_COMBINE_MATRICES  "" "" "Use linear combination of matrices instead of linear combination of moments to compute interaction matrices." "" OFF)
 VP_OPTION(ENABLE_TEST_WITHOUT_DISPLAY      "" "" "Don't use display feature when testing" "" ON)
 VP_OPTION(ENABLE_FULL_DOC      "" "" "Build doc with internal classes that are by default not part of the doc" "" OFF)
 

--- a/modules/core/include/visp3/core/vpMomentArea.h
+++ b/modules/core/include/visp3/core/vpMomentArea.h
@@ -50,6 +50,14 @@ class vpMomentCentered; // Required for discrete case of vpMomentObject
 
   \brief Class handling the surface moment.
 
+  For a dense planar object, the area corresponds to the zero-order moment:
+  \f[ a = m_{00} = \mu_{00} \f]
+
+  When considering a discrete set of points, the moment \f$ m_{00} \f$ simply
+  corresponds to the number of points. Since this is of no use in a servoing
+  scheme, this class uses in this case $ a = \mu_{20} + \mu_{02} \f$, which is
+  invariant to planar translation and rotation.
+
 */
 class VISP_EXPORT vpMomentArea : public vpMoment
 {

--- a/modules/core/src/tracking/moments/vpMomentArea.cpp
+++ b/modules/core/src/tracking/moments/vpMomentArea.cpp
@@ -42,7 +42,8 @@
 #include <visp3/core/vpMomentObject.h>
 
 /*!
-  Has the area \f$ a = m_{00} = \mu_{00} \f$.
+  Has the area \f$ a = m_{00} = \mu_{00} \f$ for dense objects,
+  \f$ \mu_{20}+\mu_{02} \f$ for a discrete set of points.
   Gets the value of m00 from vpMomentCentered.
 */
 void vpMomentArea::compute()

--- a/modules/visual_features/include/visp3/visual_features/vpFeatureMomentAlpha.h
+++ b/modules/visual_features/include/visp3/visual_features/vpFeatureMomentAlpha.h
@@ -47,67 +47,6 @@
 #include <visp3/core/vpColVector.h>
 #include <visp3/visual_features/vpFeatureMoment.h>
 
-#ifdef VISP_MOMENTS_COMBINE_MATRICES
-
-class vpMomentDatabase;
-/*!
-  \class vpFeatureMomentAlpha
-
-  \ingroup group_visual_features
-
-  \brief Functionality computation for in-plane rotation moment feature \f$
-  \alpha \f$. Computes the interaction matrix associated with vpMomentAlpha.
-
-  The interaction matrix for the feature can be deduced from \cite Tahri05z.
-
-  This class allows to compute the interaction matrix associated to \f$ \alpha
-  = \frac{1}{2} arctan(\frac{2\mu_{11}}{\mu_{20}-\mu_{02}}) \f$ moment
-  primitive.
-
-  The interaction matrix computed is single-dimension (no selection possible)
-  and can be obtained by calling vpFeatureMomentAlpha::interaction().
-
-  This feature is often used in moment-based visual servoing to control the
-  planar rotation parameter.
-
-  Minimum vpMomentObject order needed to compute this feature: 4.
-
-  This feature depends on:
-  - vpMomentCentered
-  - vpFeatureMomentCentered.
-*/
-class VISP_EXPORT vpFeatureMomentAlpha : public vpFeatureMoment
-{
-public:
-  /*!
-  Initializes the feature with information about the database of moment
-  primitives, the object plane and feature database. \param moments : Moment
-  database. The database of moment primitives (first parameter) is mandatory.
-  It is used to access different moment values later used to compute the final
-  matrix. \param A : Plane coefficient in a \f$ A \times x+B \times y + C =
-  \frac{1}{Z} \f$ plane. \param B : Plane coefficient in a \f$ A \times x+B
-  \times y + C = \frac{1}{Z} \f$ plane. \param C : Plane coefficient in a \f$
-  A \times x+B \times y + C = \frac{1}{Z} \f$ plane. \param featureMoments :
-  Feature database.
-
-  */
-  vpFeatureMomentAlpha(vpMomentDatabase &moments, double A, double B, double C,
-                       vpFeatureMomentDatabase *featureMoments = NULL)
-    : vpFeatureMoment(moments, A, B, C, featureMoments, 1)
-  {
-  }
-
-  void compute_interaction();
-  /*!
-    associated moment name
-    */
-  const char *momentName() const { return "vpMomentAlpha"; }
-  /*!
-    feature name
-    */
-  const char *name() const { return "vpFeatureMomentAlpha"; }
-};
-#else
 class vpMomentDatabase;
 /*!
   \class vpFeatureMomentAlpha
@@ -116,6 +55,8 @@ class vpMomentDatabase;
 
   \brief Functionality computation for in-plane rotation moment feature \f$
 \alpha \f$: computes the interaction matrix associated with vpMomentAlpha.
+
+The interaction matrix for the feature can be deduced from \cite Tahri05z.
 
   This class computes the interaction matrix associated to \f$ \alpha =
 \frac{1}{2} arctan(\frac{2\mu_{11}}{\mu_{20}-\mu_{02}}) \f$ moment primitive.
@@ -193,5 +134,4 @@ public:
 
   vpColVector error(const vpBasicFeature &s_star, const unsigned int select = FEATURE_ALL);
 };
-#endif
 #endif

--- a/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
@@ -78,7 +78,7 @@ void vpFeatureMomentAlpha::compute_interaction()
                             (u11*dinv) * (featureMomentCentered.interaction(0,2)-featureMomentCentered.interaction(2,0));
 }
 
-#else
+#else // #ifdef VISP_MOMENTS_COMBINE_MATRICES
 
 /*!
   Computes interaction matrix for alpha moment. Called internally.
@@ -115,15 +115,7 @@ void vpFeatureMomentAlpha::compute_interaction()
   double Yg = momentGravity.getYg();
 
   double Avx, Avy, Avz, Awx, Awy;
-  double beta, gamma;
-
-  if (momentObject.getType() == vpMomentObject::DISCRETE) {
-    beta = 4;
-    gamma = 2;
-  } else {
-    beta = 5;
-    gamma = 1;
-  }
+  double beta = (momentObject.getType() == vpMomentObject::DISCRETE) ? 2 : 5;
 
   double d = (mu20 - mu02) * (mu20 - mu02) + 4 * mu11 * mu11;
   double DA = mu20 + mu02;
@@ -133,11 +125,11 @@ void vpFeatureMomentAlpha::compute_interaction()
   Avx = mu11 * DA * A / d + (DA * mu02 + (0.5) * d - (0.5) * DA_2) * B / d;
   Avy = (DA * mu02 - (0.5) * d - (.5) * DA_2) * A / d - B * mu11 * DA / d;
 
-  Awx = (beta * (mu12 * (mu20 - mu02) + mu11 * (mu03 - mu21)) + gamma * Xg * (mu02 * (mu20 - mu02) - 2 * mu11_2) +
-         gamma * Yg * mu11 * (mu20 + mu02)) /
+  Awx = (beta * (mu12 * (mu20 - mu02) + mu11 * (mu03 - mu21)) + Xg * (mu02 * (mu20 - mu02) - 2 * mu11_2) +
+         Yg * mu11 * (mu20 + mu02)) /
         d;
-  Awy = (beta * (mu21 * (mu02 - mu20) + mu11 * (mu30 - mu12)) + gamma * Xg * mu11 * (mu20 + mu02) +
-         gamma * Yg * (mu20 * (mu02 - mu20) - 2 * mu11_2)) /
+  Awy = (beta * (mu21 * (mu02 - mu20) + mu11 * (mu30 - mu12)) + Xg * mu11 * (mu20 + mu02) +
+         Yg * (mu20 * (mu02 - mu20) - 2 * mu11_2)) /
         d;
 
   Avz = B * Awx - A * Awy;
@@ -160,7 +152,7 @@ void vpFeatureMomentAlpha::compute_interaction()
   interaction_matrices[0][0][WZ] = -1.;
 }
 
-#endif
+#endif // #ifdef VISP_MOMENTS_COMBINE_MATRICES
 
 vpColVector vpFeatureMomentAlpha::error(const vpBasicFeature &s_star, const unsigned int /* select */)
 {

--- a/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
@@ -70,9 +70,9 @@ void vpFeatureMomentAlpha::compute_interaction()
   if (!found_FeatureMoment_centered)
     throw vpException(vpException::notInitialized, "vpFeatureMomentCentered not found");
 
-  double u11 = vp_centered.get(1,1);
-  double u20_u02 = vp_centered.get(2,0)-vp_centered.get(0,2);
-  double dinv = 1 / (4*u11*u11 + (u20-u02)*(u20-u02));
+  double u11 = momentCentered.get(1,1);
+  double u20_u02 = momentCentered.get(2,0)-momentCentered.get(0,2);
+  double dinv = 1 / (4*u11*u11 + u20_u02*u20_u02);
   interaction_matrices[0].resize(1, 6);
   interaction_matrices[0] = (u20_u02*dinv) * featureMomentCentered.interaction(1,1) +
                             (u11*dinv) * (featureMomentCentered.interaction(0,2)-featureMomentCentered.interaction(2,0));
@@ -160,6 +160,8 @@ void vpFeatureMomentAlpha::compute_interaction()
   interaction_matrices[0][0][WZ] = -1.;
 }
 
+#endif
+
 vpColVector vpFeatureMomentAlpha::error(const vpBasicFeature &s_star, const unsigned int /* select */)
 {
   vpColVector e(0);
@@ -176,4 +178,3 @@ vpColVector vpFeatureMomentAlpha::error(const vpBasicFeature &s_star, const unsi
 
   return e;
 }
-#endif

--- a/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp
@@ -70,16 +70,12 @@ void vpFeatureMomentAlpha::compute_interaction()
   if (!found_FeatureMoment_centered)
     throw vpException(vpException::notInitialized, "vpFeatureMomentCentered not found");
 
-  double multiplier =
-      -1. /
-      (momentCentered.get(2, 0) * momentCentered.get(2, 0) - 2 * momentCentered.get(0, 2) * momentCentered.get(2, 0) +
-       4 * momentCentered.get(1, 1) * momentCentered.get(1, 1) + momentCentered.get(0, 2) * momentCentered.get(0, 2));
-
+  double u11 = vp_centered.get(1,1);
+  double u20_u02 = vp_centered.get(2,0)-vp_centered.get(0,2);
+  double dinv = 1 / (4*u11*u11 + (u20-u02)*(u20-u02));
   interaction_matrices[0].resize(1, 6);
-  interaction_matrices[0] =
-      multiplier * (momentCentered.get(1, 1) * featureMomentCentered.interaction(2, 0) +
-                    (momentCentered.get(0, 2) - momentCentered.get(2, 0)) * featureMomentCentered.interaction(1, 1) -
-                    momentCentered.get(1, 1) * featureMomentCentered.interaction(0, 2));
+  interaction_matrices[0] = (u20_u02*dinv) * featureMomentCentered.interaction(1,1) +
+                            (u11*dinv) * (featureMomentCentered.interaction(0,2)-featureMomentCentered.interaction(2,0));
 }
 
 #else

--- a/modules/visual_features/src/visual-feature/vpFeatureMomentArea.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureMomentArea.cpp
@@ -45,6 +45,7 @@
 #include <visp3/core/vpMomentGravityCenter.h>
 #include <visp3/core/vpMomentObject.h>
 #include <visp3/visual_features/vpFeatureMomentArea.h>
+#include <visp3/visual_features/vpFeatureMomentCentered.h>
 #include <visp3/visual_features/vpFeatureMomentDatabase.h>
 
 /*!
@@ -53,6 +54,9 @@
   feature depends on:
   - vpMomentGravityCenter
   - vpMomentArea
+
+  Note that the interaction matrix corresponds to \f$ L_{m_{00}} \f$ for dense
+  objects and to \f$ L_{\mu_{20}}+L_{\mu_{02}} \f$ for a discrete set of points.
 */
 void vpFeatureMomentArea::compute_interaction()
 {
@@ -63,17 +67,13 @@ void vpFeatureMomentArea::compute_interaction()
   // Retreive the moment object associated with this feature
   vpMomentObject mobj = moment->getObject();
   if (mobj.getType() == vpMomentObject::DISCRETE) {
-    /*
-     *  The interaction matrix for the discrete case is zero
-     *  since the feature m00 is constant.
-     *  Refer thesis of Omar Tahri 2005 [Section 3.4.22]
-     */
-    interaction_matrices[0][0][0] = 0.;
-    interaction_matrices[0][0][1] = 0.;
-    interaction_matrices[0][0][2] = 0.;
-    interaction_matrices[0][0][3] = 0.;
-    interaction_matrices[0][0][4] = 0.;
-    interaction_matrices[0][0][5] = 0.;
+    // Get centered moments
+    bool found_centered;
+    const vpFeatureMomentCentered &momentCentered =
+        static_cast<const vpFeatureMomentCentered &>(featureMomentsDataBase->get("vpFeatureMomentCentered", found_centered));
+    if (!found_centered)
+      throw vpException(vpException::notInitialized, "vpFeatureMomentCentered not found");
+    interaction_matrices[0] = momentCentered.interaction(2,0) + momentCentered.interaction(0,2);
   } else {
     // Get Xg and Yg
     bool found_xgyg;


### PR DESCRIPTION
Following the discussion in #661, here there is a small PR that slightly improves `vpFeatureMomentArea` by making sure that the interaction matrix in the discrete case is that of `mu20+mu02` (as in `vpMomentArea`).

Regarding the evaluation of the interaction matrix of Alpha, I saw that the source code already had a [`vpFeatureMomentAlpha::compute_interaction()`](https://github.com/lagadic/visp/blob/0266a1e6c6a25a83bfda4188ab021435b4043e7a/modules/visual_features/src/visual-feature/vpFeatureMomentAlpha.cpp#L49) method that uses the version I was proposing. It is protected by a `#ifdef VISP_MOMENTS_COMBINE_MATRICES` guard. For the moment, I just edited that version. Before going on, I wanted to know what you prefer to do:
- Keep only one definition (the one that is currently ignored)
- Still give the user the possibility to decide which one to use via the `VISP_MOMENTS_COMBINE_MATRICES`, and fixing the second version (as discussed, using `beta=2` and `gamma=1` should solve the problem)

I would probably go for the second one, since I see that many other moments have this feature.