### PR TITLE
Fix vpImage<unsigned char>::getValue() on big endian arch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ ViSP 3.3.1 (under development)
     . [#713] 3.3.0 build fails on non-linux systems: fatal error: 'linux/serial.h'
       file not found
     . [#716] Build issue on FreeBSD with g++
+    . [#718] vpImage<unsigned char>::getValue() is not working on big endian arch
 ----------------------------------------------
 ViSP 3.3.0 (released February 14, 2020)
   - Contributors:

--- a/modules/core/include/visp3/core/vpEndian.h
+++ b/modules/core/include/visp3/core/vpEndian.h
@@ -1,0 +1,84 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Image handling.
+ *
+ * Authors:
+ * Eric Marchand
+ *
+ *****************************************************************************/
+
+/*!
+  \file vpEndian.h
+  \brief Determine machine endianess and define VISP_LITTLE_ENDIAN, VISP_BIG_ENDIAN and VISP_PDP_ENDIAN macros.
+*/
+
+#ifndef vpEndian_h
+#define vpEndian_h
+
+// Detect endianness of the host machine
+// Reference: http://www.boost.org/doc/libs/1_36_0/boost/detail/endian.hpp
+#if defined(__GLIBC__) || (defined(__GNUC__) && !defined(__llvm__) && !defined(__MINGW32__) && !defined(__FreeBSD__) && defined(__BYTE_ORDER__))
+#include <endian.h>
+#if (__BYTE_ORDER == __LITTLE_ENDIAN)
+#define VISP_LITTLE_ENDIAN
+#elif (__BYTE_ORDER == __BIG_ENDIAN)
+#define VISP_BIG_ENDIAN
+#elif (__BYTE_ORDER == __PDP_ENDIAN)
+// Currently not supported when reading / writing binary file
+#define VISP_PDP_ENDIAN
+//#error PDP endian is not supported. //Uncomment if needed/happens
+#else
+#error Unknown machine endianness detected.
+#endif
+#elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN) || defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
+#define VISP_BIG_ENDIAN
+#elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN) || defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+#define VISP_LITTLE_ENDIAN
+#elif defined(__sparc) || defined(__sparc__) || defined(_POWER) || defined(__powerpc__) || defined(__ppc__) ||         \
+    defined(__hpux) || defined(_MIPSEB) || defined(_POWER) || defined(__s390__)
+
+#define VISP_BIG_ENDIAN
+#elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) || defined(_M_IX86) ||           \
+    defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) ||            \
+    defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) || defined(__ANDROID__)
+    // It appears that all Android systems are little endian.
+    // Refer https://stackoverflow.com/questions/6212951/endianness-of-android-ndk
+#define VISP_LITTLE_ENDIAN
+#elif defined(WINRT) // For UWP
+// Refer https://social.msdn.microsoft.com/Forums/en-US/04c92ef9-e38e-415f-8958-ec9f7c196fd3/arm-endianess-under-windows-mobile?forum=windowsmobiledev
+#define VISP_LITTLE_ENDIAN
+#else
+#error Cannot detect host machine endianness.
+#endif
+
+#endif
+

--- a/modules/core/src/tools/file/vpIoTools.cpp
+++ b/modules/core/src/tools/file/vpIoTools.cpp
@@ -54,6 +54,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <visp3/core/vpDebug.h>
+#include <visp3/core/vpEndian.h>
 #include <visp3/core/vpIoException.h>
 #include <visp3/core/vpIoTools.h>
 #if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
@@ -81,42 +82,6 @@
 #  else
 #    define PATH_MAX 1024
 #  endif
-#endif
-
-// Detect endianness of the host machine
-// Reference: http://www.boost.org/doc/libs/1_36_0/boost/detail/endian.hpp
-#if defined(__GLIBC__) || (defined(__GNUC__) && !defined(__llvm__) && !defined(__MINGW32__) && !defined(__FreeBSD__) && defined(__BYTE_ORDER__))
-#include <endian.h>
-#if (__BYTE_ORDER == __LITTLE_ENDIAN)
-#define VISP_LITTLE_ENDIAN
-#elif (__BYTE_ORDER == __BIG_ENDIAN)
-#define VISP_BIG_ENDIAN
-#elif (__BYTE_ORDER == __PDP_ENDIAN)
-// Currently not supported when reading / writing binary file
-#define VISP_PDP_ENDIAN
-//#error PDP endian is not supported. //Uncomment if needed/happens
-#else
-#error Unknown machine endianness detected.
-#endif
-#elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN) || defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
-#define VISP_BIG_ENDIAN
-#elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN) || defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
-#define VISP_LITTLE_ENDIAN
-#elif defined(__sparc) || defined(__sparc__) || defined(_POWER) || defined(__powerpc__) || defined(__ppc__) ||         \
-    defined(__hpux) || defined(_MIPSEB) || defined(_POWER) || defined(__s390__)
-
-#define VISP_BIG_ENDIAN
-#elif defined(__i386__) || defined(__alpha__) || defined(__ia64) || defined(__ia64__) || defined(_M_IX86) ||           \
-    defined(_M_IA64) || defined(_M_ALPHA) || defined(__amd64) || defined(__amd64__) || defined(_M_AMD64) ||            \
-    defined(__x86_64) || defined(__x86_64__) || defined(_M_X64) || defined(__ANDROID__)
-    // It appears that all Android systems are little endian.
-    // Refer https://stackoverflow.com/questions/6212951/endianness-of-android-ndk
-#define VISP_LITTLE_ENDIAN
-#elif defined(WINRT) // For UWP
-// Refer https://social.msdn.microsoft.com/Forums/en-US/04c92ef9-e38e-415f-8958-ec9f7c196fd3/arm-endianess-under-windows-mobile?forum=windowsmobiledev
-#define VISP_LITTLE_ENDIAN
-#else
-#error Cannot detect host machine endianness.
 #endif
 
 std::string vpIoTools::baseName = "";


### PR DESCRIPTION
- There is `testImageGetValue.cpp` which is testing `vpImage<unsigned char>::getValue()` that fails with ViSP 3.3.0 on `s390x` debian big endian arch
````
13/275 Test  #14: testImageGetValue .................................................***Failed    0.04 sec
checkPixelAccess<unsigned char>(3, 4, 2, 3): 11
checkPixelAccess<unsigned char>(3, 4, -2, -3): 
checkPixelAccess<unsigned char>(3, 4, 3, 4): 
checkPixelAccess<vpRGBa>(3, 4, 2, 3): (11,11,11,0)
checkPixelAccess<vpRGBa>(3, 4, -2, -3): 
checkPixelAccess<vpRGBa>(3, 4, 3, 4): 
checkPixelAccess<int>(3, 4, 2, 3): 11
checkPixelAccess<int>(3, 4, -2, -3): 
checkPixelAccess<int>(3, 4, 3, 4): 
checkPixelAccess<double>(3, 4, 2, 3): 11
checkPixelAccess<double>(3, 4, -2, -3): 
checkPixelAccess<double>(3, 4, 3, 4): 
diff_round: 1.06428e+07 ; meanDiffRound: 34.6446
diff: 1.06406e+07 ; meanDiff: 34.6372
Too much pixel difference between fixed-point vpImage::getValue(double, double) and old method.
````
- This fix concerns all big endian arch
- `vpImage<unsigned char>::getValue()` is using [reinterpret_cast](https://en.cppreference.com/w/cpp/language/reinterpret_cast) which behavior depends on endianess

- Closes #718