### PR TITLE
Fix ctest when Lapack, Eigen3 and OpenCV are not used

### DIFF
--- a/demo/wireframe-simulator/servoSimu4Points.cpp
+++ b/demo/wireframe-simulator/servoSimu4Points.cpp
@@ -67,7 +67,8 @@
 
 #define GETOPTARGS "dhp"
 
-#ifdef VISP_HAVE_DISPLAY
+#if defined(VISP_HAVE_DISPLAY) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 /*!
 
@@ -513,6 +514,12 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
 }
 #else
 int main()

--- a/demo/wireframe-simulator/servoSimuCylinder.cpp
+++ b/demo/wireframe-simulator/servoSimuCylinder.cpp
@@ -67,7 +67,8 @@
 
 #define GETOPTARGS "dhp"
 
-#ifdef VISP_HAVE_DISPLAY
+#if defined(VISP_HAVE_DISPLAY) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 /*!
 
@@ -460,6 +461,12 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
 }
 #else
 int main()

--- a/demo/wireframe-simulator/servoSimuSphere.cpp
+++ b/demo/wireframe-simulator/servoSimuSphere.cpp
@@ -70,7 +70,8 @@
 
 #define GETOPTARGS "dhp"
 
-#ifdef VISP_HAVE_DISPLAY
+#if defined(VISP_HAVE_DISPLAY) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 /*!
 
@@ -495,6 +496,12 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
 }
 #else
 int main()

--- a/example/calibration/calibrate-hand-eye.cpp
+++ b/example/calibration/calibrate-hand-eye.cpp
@@ -56,6 +56,7 @@
 
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // We want to calibrate the hand-eye extrinsic camera parameters from 6
     // couple of poses: cMo and wMe
@@ -145,4 +146,8 @@ int main()
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/direct-visual-servoing/photometricVisualServoing.cpp
+++ b/example/direct-visual-servoing/photometricVisualServoing.cpp
@@ -175,6 +175,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     std::string env_ipath;
     std::string opt_ipath;
@@ -384,6 +385,8 @@ int main(int argc, const char **argv)
     double normError = 0;
     vpColVector v; // camera velocity send to the robot
 
+    vpChrono chrono;
+    chrono.start();
     do {
       std::cout << "--------------------------------------------" << iter++ << std::endl;
 
@@ -418,6 +421,9 @@ int main(int argc, const char **argv)
       cMo = wMc.inverse() * wMo;
     } while (normError > 10000 && iter < opt_niter);
 
+    chrono.stop();
+    std::cout << "Time to convergence: " << chrono.getDurationMs() << " ms" << std::endl;
+
     v = 0;
     robot.setVelocity(vpRobot::CAMERA_FRAME, v);
 
@@ -426,4 +432,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/direct-visual-servoing/photometricVisualServoingWithoutVpServo.cpp
+++ b/example/direct-visual-servoing/photometricVisualServoingWithoutVpServo.cpp
@@ -176,6 +176,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     std::string env_ipath;
     std::string opt_ipath;
@@ -412,6 +413,9 @@ int main(int argc, const char **argv)
     int iterGN = 90; // swicth to Gauss Newton after iterGN iterations
 
     double normeError = 0;
+
+    vpChrono chrono;
+    chrono.start();
     do {
       std::cout << "--------------------------------------------" << iter++ << std::endl;
 
@@ -468,6 +472,9 @@ int main(int argc, const char **argv)
       cMo = wMc.inverse() * wMo;
     } while (normeError > 10000 && iter < opt_niter);
 
+    chrono.stop();
+    std::cout << "Time to convergence: " << chrono.getDurationMs() << " ms" << std::endl;
+
     v = 0;
     robot.setVelocity(vpRobot::CAMERA_FRAME, v);
 
@@ -476,4 +483,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/homography/homographyHLM2DObject.cpp
+++ b/example/homography/homographyHLM2DObject.cpp
@@ -141,6 +141,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -267,4 +268,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/homography/homographyHLM3DObject.cpp
+++ b/example/homography/homographyHLM3DObject.cpp
@@ -142,6 +142,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -239,4 +240,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/homography/homographyHartleyDLT2DObject.cpp
+++ b/example/homography/homographyHartleyDLT2DObject.cpp
@@ -141,6 +141,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -235,4 +236,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/homography/homographyRansac2DObject.cpp
+++ b/example/homography/homographyRansac2DObject.cpp
@@ -140,6 +140,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -230,4 +231,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/pose-estimation/poseVirtualVS.cpp
+++ b/example/pose-estimation/poseVirtualVS.cpp
@@ -65,7 +65,10 @@
 #include <stdlib.h>
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
-#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV))
+
+#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+
 
 #include <visp3/core/vpImage.h>
 #include <visp3/core/vpImagePoint.h>
@@ -618,6 +621,12 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
 }
 #else
 int main()

--- a/example/robot-simulator/afma6/servoSimuAfma6FourPoints2DCamVelocity.cpp
+++ b/example/robot-simulator/afma6/servoSimuAfma6FourPoints2DCamVelocity.cpp
@@ -56,8 +56,9 @@
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
 
-#if ((defined(_WIN32) && !defined(WINRT_8_0)) || defined(VISP_HAVE_PTHREAD)) &&                                        \
-    (defined(VISP_HAVE_X11) || defined(VISP_HAVE_OPENCV) || defined(VISP_HAVE_GDI))
+#if ((defined(_WIN32) && !defined(WINRT_8_0)) || defined(VISP_HAVE_PTHREAD)) \
+  && (defined(VISP_HAVE_X11) || defined(VISP_HAVE_OPENCV) || defined(VISP_HAVE_GDI)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 // We need to use threading capabilities. Thus on Unix-like
 // platforms, the libpthread third-party library need to be
@@ -356,21 +357,28 @@ int main(int argc, const char **argv)
   }
   return EXIT_SUCCESS;
 }
-#else
+#elif !(defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI))
 int main()
 {
-#if (!(defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI)))
-  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) functionalities to display images..." << std::endl;
+  std::cout << "You do not have X11, or GDI (Graphical Device Interface) of OpenCV functionalities to display images..." << std::endl;
   std::cout << "Tip if you are on a unix-like system:" << std::endl;
   std::cout << "- Install X11, configure again ViSP using cmake and build again this example" << std::endl;
   std::cout << "Tip if you are on a windows-like system:" << std::endl;
   std::cout << "- Install GDI, configure again ViSP using cmake and build again this example" << std::endl;
+  return EXIT_SUCCESS;
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
+int main()
+{
   std::cout << "You do not have threading capabilities" << std::endl;
   std::cout << "Tip:" << std::endl;
   std::cout << "- Install pthread, configure again ViSP using cmake and build again this example" << std::endl;
-#endif
   return EXIT_SUCCESS;
 }
-
 #endif

--- a/example/robot-simulator/camera/servoSimu3D_cMcd_CamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimu3D_cMcd_CamVelocity.cpp
@@ -141,6 +141,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -297,4 +298,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimu3D_cdMc_CamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimu3D_cdMc_CamVelocity.cpp
@@ -142,6 +142,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -295,4 +296,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuCircle2DCamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimuCircle2DCamVelocity.cpp
@@ -140,6 +140,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -236,4 +237,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuCircle2DCamVelocityDisplay.cpp
+++ b/example/robot-simulator/camera/servoSimuCircle2DCamVelocityDisplay.cpp
@@ -50,7 +50,8 @@
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
 
-#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV))
+#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -289,10 +290,16 @@ int main(int argc, const char **argv)
     return EXIT_FAILURE;
   }
 }
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {
-  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) functionalities to display images..." << std::endl;
+  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) or OpenCV functionalities to display images..." << std::endl;
   std::cout << "Tip if you are on a unix-like system:" << std::endl;
   std::cout << "- Install X11, configure again ViSP using cmake and build again this example" << std::endl;
   std::cout << "Tip if you are on a windows-like system:" << std::endl;

--- a/example/robot-simulator/camera/servoSimuCylinder2DCamVelocityDisplay.cpp
+++ b/example/robot-simulator/camera/servoSimuCylinder2DCamVelocityDisplay.cpp
@@ -50,7 +50,8 @@
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
 
-#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV))
+#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -331,10 +332,16 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {
-  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) functionalities to display images..." << std::endl;
+  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) or OpenCV functionalities to display images..." << std::endl;
   std::cout << "Tip if you are on a unix-like system:" << std::endl;
   std::cout << "- Install X11, configure again ViSP using cmake and build again this example" << std::endl;
   std::cout << "Tip if you are on a windows-like system:" << std::endl;

--- a/example/robot-simulator/camera/servoSimuCylinder2DCamVelocityDisplaySecondaryTask.cpp
+++ b/example/robot-simulator/camera/servoSimuCylinder2DCamVelocityDisplaySecondaryTask.cpp
@@ -169,6 +169,7 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display,
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     bool opt_display = true;
     bool opt_click_allowed = true;
@@ -468,4 +469,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuFourPoints2DCamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimuFourPoints2DCamVelocity.cpp
@@ -141,6 +141,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -267,4 +268,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuFourPoints2DCamVelocityDisplay.cpp
+++ b/example/robot-simulator/camera/servoSimuFourPoints2DCamVelocityDisplay.cpp
@@ -57,7 +57,8 @@
 
 #include <visp3/core/vpConfig.h>
 
-#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV))
+#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -348,6 +349,12 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
 }
 #else
 int main()

--- a/example/robot-simulator/camera/servoSimuLine2DCamVelocityDisplay.cpp
+++ b/example/robot-simulator/camera/servoSimuLine2DCamVelocityDisplay.cpp
@@ -48,7 +48,8 @@
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
 
-#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV))
+#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -317,6 +318,12 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {

--- a/example/robot-simulator/camera/servoSimuPoint2DCamVelocity1.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint2DCamVelocity1.cpp
@@ -131,6 +131,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -214,4 +215,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuPoint2DCamVelocity2.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint2DCamVelocity2.cpp
@@ -139,6 +139,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -246,4 +247,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuPoint2DCamVelocity3.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint2DCamVelocity3.cpp
@@ -138,6 +138,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -242,4 +243,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuPoint2DhalfCamVelocity1.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint2DhalfCamVelocity1.cpp
@@ -138,6 +138,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -258,4 +259,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_SUCCESS;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuPoint2DhalfCamVelocity2.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint2DhalfCamVelocity2.cpp
@@ -134,6 +134,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -347,4 +348,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuPoint2DhalfCamVelocity3.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint2DhalfCamVelocity3.cpp
@@ -134,6 +134,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -325,4 +326,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_SUCCESS;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuPoint3DCamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimuPoint3DCamVelocity.cpp
@@ -133,6 +133,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -224,4 +225,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuSphere2DCamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimuSphere2DCamVelocity.cpp
@@ -133,6 +133,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -227,4 +228,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuSphere2DCamVelocityDisplay.cpp
+++ b/example/robot-simulator/camera/servoSimuSphere2DCamVelocityDisplay.cpp
@@ -153,6 +153,7 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     bool opt_display = true;
     bool opt_click_allowed = true;
@@ -286,4 +287,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuSphere2DCamVelocityDisplaySecondaryTask.cpp
+++ b/example/robot-simulator/camera/servoSimuSphere2DCamVelocityDisplaySecondaryTask.cpp
@@ -164,6 +164,7 @@ bool getOptions(int argc, const char **argv, bool &click_allowed, bool &display,
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     bool opt_display = true;
     bool opt_click_allowed = true;
@@ -384,4 +385,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/camera/servoSimuSquareLine2DCamVelocityDisplay.cpp
+++ b/example/robot-simulator/camera/servoSimuSquareLine2DCamVelocityDisplay.cpp
@@ -48,7 +48,8 @@
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
 
-#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV))
+#if (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI) || defined(VISP_HAVE_OPENCV)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -328,10 +329,16 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {
-  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) functionalities to display images..." << std::endl;
+  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) or OpenCV functionalities to display images..." << std::endl;
   std::cout << "Tip if you are on a unix-like system:" << std::endl;
   std::cout << "- Install X11, configure again ViSP using cmake and build again this example" << std::endl;
   std::cout << "Tip if you are on a windows-like system:" << std::endl;

--- a/example/robot-simulator/camera/servoSimuThetaUCamVelocity.cpp
+++ b/example/robot-simulator/camera/servoSimuThetaUCamVelocity.cpp
@@ -133,6 +133,7 @@ bool getOptions(int argc, const char **argv)
 
 int main(int argc, const char **argv)
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     // Read the command line options
     if (getOptions(argc, argv) == false) {
@@ -217,4 +218,10 @@ int main(int argc, const char **argv)
     std::cout << "Catch a ViSP exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/example/robot-simulator/viper850/servoSimuViper850FourPoints2DCamVelocity.cpp
+++ b/example/robot-simulator/viper850/servoSimuViper850FourPoints2DCamVelocity.cpp
@@ -56,8 +56,9 @@
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpDebug.h>
 
-#if ((defined(_WIN32) && !defined(WINRT_8_0)) || defined(VISP_HAVE_PTHREAD)) &&                                        \
-    (defined(VISP_HAVE_X11) || defined(VISP_HAVE_OPENCV) || defined(VISP_HAVE_GDI))
+#if ((defined(_WIN32) && !defined(WINRT_8_0)) || defined(VISP_HAVE_PTHREAD)) \
+  && (defined(VISP_HAVE_X11) || defined(VISP_HAVE_OPENCV) || defined(VISP_HAVE_GDI)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 // We need to use threading capabilities. Thus on Unix-like
 // platforms, the libpthread third-party library need to be
@@ -356,20 +357,28 @@ int main(int argc, const char **argv)
     return EXIT_FAILURE;
   }
 }
-#else
+#elif !(defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI))
 int main()
 {
-#if (!(defined(VISP_HAVE_X11) || defined(VISP_HAVE_GTK) || defined(VISP_HAVE_GDI)))
-  std::cout << "You do not have X11, or GTK, or GDI (Graphical Device Interface) functionalities to display images..." << std::endl;
+  std::cout << "You do not have X11, or GDI (Graphical Device Interface) of OpenCV functionalities to display images..." << std::endl;
   std::cout << "Tip if you are on a unix-like system:" << std::endl;
   std::cout << "- Install X11, configure again ViSP using cmake and build again this example" << std::endl;
   std::cout << "Tip if you are on a windows-like system:" << std::endl;
   std::cout << "- Install GDI, configure again ViSP using cmake and build again this example" << std::endl;
+  return EXIT_SUCCESS;
+}
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
+int main()
+{
   std::cout << "You do not have threading capabilities" << std::endl;
   std::cout << "Tip:" << std::endl;
   std::cout << "- Install pthread, configure again ViSP using cmake and build again this example" << std::endl;
-#endif
   return EXIT_SUCCESS;
 }
 #endif

--- a/example/tracking/mbtEdgeMultiTracking.cpp
+++ b/example/tracking/mbtEdgeMultiTracking.cpp
@@ -51,7 +51,8 @@
 
 #if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
 
-#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
+#if (defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -603,13 +604,21 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY))
+int main()
+{
+  std::cout << "Cannot run this example: visp_mbt, visp_gui modules are required."
+            << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {
-  std::cout << "visp_mbt module is required to run this example." << std::endl;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
   return EXIT_SUCCESS;
 }
 #endif
+
 #else
 int main()
 {

--- a/example/tracking/mbtEdgeTracking.cpp
+++ b/example/tracking/mbtEdgeTracking.cpp
@@ -48,7 +48,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
+#if (defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -581,12 +582,17 @@ int main(int argc, const char **argv)
   }
 }
 
-#else
-
+#elif !(defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY))
 int main()
 {
-  std::cout << "visp_mbt module is required to run this example." << std::endl;
+  std::cout << "Cannot run this example: visp_mbt, visp_gui modules are required."
+            << std::endl;
   return EXIT_SUCCESS;
 }
-
+#else
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #endif

--- a/example/tracking/mbtGenericTracking.cpp
+++ b/example/tracking/mbtGenericTracking.cpp
@@ -47,7 +47,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
+#if (defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -654,14 +655,17 @@ int main(int argc, const char **argv)
   }
 }
 
-#else
-
+#elif !(defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY))
 int main()
 {
-  std::cout << "visp_mbt, visp_gui modules and OpenCV are required to run "
-               "this example."
+  std::cout << "Cannot run this example: visp_mbt, visp_gui modules are required."
             << std::endl;
   return EXIT_SUCCESS;
 }
-
+#else
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #endif

--- a/example/tracking/mbtGenericTracking2.cpp
+++ b/example/tracking/mbtGenericTracking2.cpp
@@ -47,7 +47,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
+#if (defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -740,14 +741,17 @@ int main(int argc, const char **argv)
   }
 }
 
-#else
-
+#elif !(defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY))
 int main()
 {
-  std::cout << "visp_mbt, visp_gui modules and OpenCV are required to run "
-               "this example."
+  std::cout << "Cannot run this example: visp_mbt, visp_gui modules are required."
             << std::endl;
   return EXIT_SUCCESS;
 }
-
+#else
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #endif

--- a/example/tracking/mbtGenericTrackingDepth.cpp
+++ b/example/tracking/mbtGenericTrackingDepth.cpp
@@ -43,7 +43,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
+#if (defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -861,12 +862,18 @@ int main(int argc, const char **argv)
   }
 }
 
-#else
+#elif !(defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY))
 int main()
 {
-  std::cerr << "visp_mbt, visp_gui modules and OpenCV are required to run "
-               "this example."
+  std::cout << "Cannot run this example: visp_mbt, visp_gui modules are required."
             << std::endl;
   return EXIT_SUCCESS;
 }
+#else
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #endif
+

--- a/example/tracking/mbtGenericTrackingDepthOnly.cpp
+++ b/example/tracking/mbtGenericTrackingDepthOnly.cpp
@@ -43,7 +43,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)
+#if (defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY)) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpDebug.h>
 #include <visp3/core/vpHomogeneousMatrix.h>
@@ -774,12 +775,17 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_MODULE_MBT) && defined(VISP_HAVE_DISPLAY))
+int main()
+{
+  std::cout << "Cannot run this example: visp_mbt, visp_gui modules are required."
+            << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {
-  std::cerr << "visp_mbt, visp_gui modules and OpenCV are required to run "
-               "this example."
-            << std::endl;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
   return EXIT_SUCCESS;
 }
 #endif

--- a/example/tracking/templateTracker.cpp
+++ b/example/tracking/templateTracker.cpp
@@ -309,6 +309,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
 
 int main(int argc, const char **argv)
 {
+#if defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV)
   try {
     std::string env_ipath;
     std::string opt_ipath;
@@ -596,6 +597,11 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+#endif
 }
 
 #else

--- a/example/tracking/trackMeCircle.cpp
+++ b/example/tracking/trackMeCircle.cpp
@@ -170,6 +170,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
 
 int main(int argc, const char **argv)
 {
+#if defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV)
   try {
     std::string env_ipath;
     std::string opt_ipath;
@@ -322,6 +323,11 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+#endif
 }
 #else
 #include <iostream>

--- a/example/tracking/trackMeEllipse.cpp
+++ b/example/tracking/trackMeEllipse.cpp
@@ -172,6 +172,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
 
 int main(int argc, const char **argv)
 {
+#if defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV)
   try {
     std::string env_ipath;
     std::string opt_ipath;
@@ -345,6 +346,11 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+#endif
 }
 #else
 #include <iostream>

--- a/example/tracking/trackMeLine.cpp
+++ b/example/tracking/trackMeLine.cpp
@@ -176,6 +176,7 @@ bool getOptions(int argc, const char **argv, std::string &ipath, bool &click_all
 
 int main(int argc, const char **argv)
 {
+#if defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV)
   try {
     std::string env_ipath;
     std::string opt_ipath;
@@ -357,6 +358,11 @@ int main(int argc, const char **argv)
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  (void)argc;
+  (void)argv;
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+#endif
 }
 
 #else

--- a/modules/core/src/math/matrix/vpMatrix_lu.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_lu.cpp
@@ -132,17 +132,21 @@ vpMatrix vpMatrix::inverseByLU() const
   if (colNum == 1 && rowNum == 1) {
     vpMatrix inv;
     inv.resize(1, 1, false);
-    inv[0][0] = 1. / det();
+    double d = det();
+    if (std::fabs(d) < std::numeric_limits<double>::epsilon()) {
+      throw(vpException(vpException::fatalError, "Cannot inverse matrix %d by %d by LU. Matrix determinant is 0.", rowNum, colNum));
+    }
+    inv[0][0] = 1. / d;
     return inv;
   }
   else if (colNum == 2 && rowNum == 2) {
     vpMatrix inv;
     inv.resize(2, 2, false);
     double d = det();
-    d = 1. / d;
     if (std::fabs(d) < std::numeric_limits<double>::epsilon()) {
-      throw(vpException(vpException::fatalError, "Cannot inverse by LU. Matrix determinant is 0."));
+      throw(vpException(vpException::fatalError, "Cannot inverse matrix %d by %d by LU. Matrix determinant is 0.", rowNum, colNum));
     }
+    d = 1. / d;
     inv[1][1] =  (*this)[0][0]*d;
     inv[0][0] =  (*this)[1][1]*d;
     inv[0][1] = -(*this)[0][1]*d;
@@ -153,10 +157,10 @@ vpMatrix vpMatrix::inverseByLU() const
     vpMatrix inv;
     inv.resize(3, 3, false);
     double d = det();
-    d = 1. / d;
     if (std::fabs(d) < std::numeric_limits<double>::epsilon()) {
-      throw(vpException(vpException::fatalError, "Cannot inverse by LU. Matrix determinant is 0."));
+      throw(vpException(vpException::fatalError, "Cannot inverse matrix %d by %d by LU. Matrix determinant is 0.", rowNum, colNum));
     }
+    d = 1. / d;
     inv[0][0] = ((*this)[1][1] * (*this)[2][2] - (*this)[1][2] * (*this)[2][1]) * d;
     inv[0][1] = ((*this)[0][2] * (*this)[2][1] - (*this)[0][1] * (*this)[2][2]) * d;
     inv[0][2] = ((*this)[0][1] * (*this)[1][2] - (*this)[0][2] * (*this)[1][1]) * d;

--- a/modules/core/src/math/matrix/vpMatrix_lu.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_lu.cpp
@@ -129,16 +129,59 @@ int main()
 */
 vpMatrix vpMatrix::inverseByLU() const
 {
+  if (colNum == 1 && rowNum == 1) {
+    vpMatrix inv;
+    inv.resize(1, 1, false);
+    inv[0][0] = 1. / det();
+    return inv;
+  }
+  else if (colNum == 2 && rowNum == 2) {
+    vpMatrix inv;
+    inv.resize(2, 2, false);
+    double d = det();
+    d = 1. / d;
+    if (std::fabs(d) < std::numeric_limits<double>::epsilon()) {
+      throw(vpException(vpException::fatalError, "Cannot inverse by LU. Matrix determinant is 0."));
+    }
+    inv[1][1] =  (*this)[0][0]*d;
+    inv[0][0] =  (*this)[1][1]*d;
+    inv[0][1] = -(*this)[0][1]*d;
+    inv[1][0] = -(*this)[1][0]*d;
+    return inv;
+  }
+  else if (colNum == 3 && rowNum == 3) {
+    vpMatrix inv;
+    inv.resize(3, 3, false);
+    double d = det();
+    d = 1. / d;
+    if (std::fabs(d) < std::numeric_limits<double>::epsilon()) {
+      throw(vpException(vpException::fatalError, "Cannot inverse by LU. Matrix determinant is 0."));
+    }
+    inv[0][0] = ((*this)[1][1] * (*this)[2][2] - (*this)[1][2] * (*this)[2][1]) * d;
+    inv[0][1] = ((*this)[0][2] * (*this)[2][1] - (*this)[0][1] * (*this)[2][2]) * d;
+    inv[0][2] = ((*this)[0][1] * (*this)[1][2] - (*this)[0][2] * (*this)[1][1]) * d;
+
+    inv[1][0] = ((*this)[1][2] * (*this)[2][0] - (*this)[1][0] * (*this)[2][2]) * d;
+    inv[1][1] = ((*this)[0][0] * (*this)[2][2] - (*this)[0][2] * (*this)[2][0]) * d;
+    inv[1][2] = ((*this)[0][2] * (*this)[1][0] - (*this)[0][0] * (*this)[1][2]) * d;
+
+    inv[2][0] = ((*this)[1][0] * (*this)[2][1] - (*this)[1][1] * (*this)[2][0]) * d;
+    inv[2][1] = ((*this)[0][1] * (*this)[2][0] - (*this)[0][0] * (*this)[2][1]) * d;
+    inv[2][2] = ((*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0]) * d;
+    return inv;
+  }
+  else {
 #if defined(VISP_HAVE_LAPACK)
-  return inverseByLULapack();
+    return inverseByLULapack();
 #elif defined(VISP_HAVE_EIGEN3)
-  return inverseByLUEigen3();
+    return inverseByLUEigen3();
 #elif (VISP_HAVE_OPENCV_VERSION >= 0x020101)
-  return inverseByLUOpenCV();
+    return inverseByLUOpenCV();
 #else
-  throw(vpException(vpException::fatalError, "Cannot compute matrix determinant. "
-                                             "Install Lapack, Eigen3 or OpenCV 3rd party"));
+    throw(vpException(vpException::fatalError, "Cannot inverse by LU. "
+                                               "Install Lapack, Eigen3 or OpenCV 3rd party"));
 #endif
+  }
 }
 
 /*!
@@ -176,9 +219,13 @@ int main()
 */
 double vpMatrix::detByLU() const
 {
-  if (rowNum == 2 && colNum == 2) {
+  if (rowNum == 1 && colNum == 1) {
+    return (*this)[0][0];
+  }
+  else if (rowNum == 2 && colNum == 2) {
     return ((*this)[0][0] * (*this)[1][1] - (*this)[0][1] * (*this)[1][0]);
-  } else if (rowNum == 3 && colNum == 3) {
+  }
+  else if (rowNum == 3 && colNum == 3) {
     return ((*this)[0][0] * ((*this)[1][1] * (*this)[2][2] - (*this)[1][2] * (*this)[2][1]) -
             (*this)[0][1] * ((*this)[1][0] * (*this)[2][2] - (*this)[1][2] * (*this)[2][0]) +
             (*this)[0][2] * ((*this)[1][0] * (*this)[2][1] - (*this)[1][1] * (*this)[2][0]));
@@ -199,7 +246,7 @@ double vpMatrix::detByLU() const
 #if defined(VISP_HAVE_LAPACK)
 /*!
   Compute the inverse of a n-by-n matrix using the LU decomposition with
-Lapack 3rd party.
+  Lapack 3rd party.
 
   \return The inverse matrix.
 

--- a/modules/core/test/math/testMatrixConditionNumber.cpp
+++ b/modules/core/test/math/testMatrixConditionNumber.cpp
@@ -90,6 +90,7 @@ int test_condition_number(const std::string &test_name, const vpMatrix &M)
 
 int main()
 {
+#if defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV)
   vpMatrix M(3, 3);
   M.eye();
 
@@ -145,7 +146,9 @@ int main()
   else {
     std::cout << "  + Condition number computation succeed" << std::endl;
   }
-
   std::cout << "Test succeed" << std::endl;
+#else
+  std::cout << "Test ignored: install Lapack, Eigen3 or OpenCV" << std::endl;
+#endif
   return EXIT_SUCCESS;
 }

--- a/modules/tracker/mbt/test/testGenericTracker.cpp
+++ b/modules/tracker/mbt/test/testGenericTracker.cpp
@@ -43,7 +43,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT)
+#if defined(VISP_HAVE_MODULE_MBT) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
 #include <type_traits>
@@ -710,9 +711,15 @@ int main(int argc, const char *argv[])
     return EXIT_FAILURE;
   }
 }
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main() {
   std::cout << "Enable MBT module (VISP_HAVE_MODULE_MBT) to launch this test." << std::endl;
-  return 0;
+  return EXIT_SUCCESS;
 }
 #endif

--- a/modules/tracker/mbt/test/testGenericTrackerDepth.cpp
+++ b/modules/tracker/mbt/test/testGenericTrackerDepth.cpp
@@ -43,7 +43,8 @@
 #include <iostream>
 #include <visp3/core/vpConfig.h>
 
-#if defined(VISP_HAVE_MODULE_MBT)
+#if defined(VISP_HAVE_MODULE_MBT) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
 #include <type_traits>
@@ -494,9 +495,14 @@ int main(int argc, const char *argv[])
     return EXIT_FAILURE;
   }
 }
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main() {
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main() {
   std::cout << "Enable MBT module (VISP_HAVE_MODULE_MBT) to launch this test." << std::endl;
-  return 0;
+  return EXIT_SUCCESS;
 }
 #endif

--- a/modules/tracker/mbt/test/testMbtXmlGenericParser.cpp
+++ b/modules/tracker/mbt/test/testMbtXmlGenericParser.cpp
@@ -44,7 +44,8 @@
 
 int main()
 {
-#ifdef VISP_HAVE_PUGIXML
+#if defined(VISP_HAVE_PUGIXML) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   std::string visp_images_dir = vpIoTools::getViSPImagesDataPath();
   if (vpIoTools::checkDirectory(visp_images_dir + "/xml")) {
     double eps = std::numeric_limits<double>::epsilon();
@@ -159,6 +160,8 @@ int main()
       }
     }
   }
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
 #endif
 
   return EXIT_SUCCESS;

--- a/modules/tracker/me/test/testNurbs.cpp
+++ b/modules/tracker/me/test/testNurbs.cpp
@@ -59,7 +59,8 @@
 #include <cstdlib>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/io/vpParseArgv.h>
-#if defined(VISP_HAVE_DISPLAY)
+#if defined(VISP_HAVE_DISPLAY) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 // List of allowed command line options
 #define GETOPTARGS "cdh"
@@ -364,6 +365,12 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {

--- a/modules/vision/test/homography/testDisplacement.cpp
+++ b/modules/vision/test/homography/testDisplacement.cpp
@@ -74,6 +74,7 @@ bool test(const std::string &s, const vpHomography &H, const std::vector<double>
 
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     {
       vpHomography H;
@@ -185,9 +186,13 @@ int main()
       std::cout << "H" << std::endl << H << std::endl;
     }
     std::cout << "All tests succeed" << std::endl;
-    return 0;
+    return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
-    return 1;
+    return EXIT_FAILURE;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/modules/vision/test/pose/testFindMatch.cpp
+++ b/modules/vision/test/pose/testFindMatch.cpp
@@ -57,6 +57,7 @@
 
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     std::cout << "Find Matches using Ransac" << std::endl;
     std::vector<vpPoint> P;
@@ -109,9 +110,13 @@ int main()
 
     std::cout << "Matching is " << (test_fail ? "badly" : "well") << " performed" << std::endl;
 
-    return test_fail;
+    return (test_fail ? EXIT_FAILURE : EXIT_SUCCESS);
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
-    return 1;
+    return EXIT_FAILURE;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/modules/vision/test/pose/testPose.cpp
+++ b/modules/vision/test/pose/testPose.cpp
@@ -115,6 +115,7 @@ int compare_pose(const vpPose &pose, const vpHomogeneousMatrix &cMo_ref, const v
 
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     int test_planar_fail = 0, test_non_planar_fail = 0, fail = 0;
 
@@ -388,4 +389,8 @@ int main()
     std::cout << "Catch an exception: " << e << std::endl;
     return EXIT_FAILURE;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/modules/vision/test/pose/testPoseFeatures.cpp
+++ b/modules/vision/test/pose/testPoseFeatures.cpp
@@ -211,6 +211,7 @@ int test_pose(bool use_robust)
 
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     if (test_pose(false))
       return -1;
@@ -223,4 +224,8 @@ int main()
     std::cout << "Catch an exception: " << e.getStringMessage() << std::endl;
     return -1;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/modules/vision/test/pose/testPoseRansac.cpp
+++ b/modules/vision/test/pose/testPoseRansac.cpp
@@ -57,6 +57,7 @@
 
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     std::cout << "Pose computation with matched points" << std::endl;
     std::vector<vpPoint> P; //  Point to be tracked
@@ -120,9 +121,13 @@ int main()
     }
 
     std::cout << "Pose is " << (test_fail ? "badly" : "well") << " estimated" << std::endl;
-    return test_fail;
+    return (test_fail ? EXIT_FAILURE : EXIT_SUCCESS);
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
-    return 1;
+    return EXIT_FAILURE;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }

--- a/modules/vision/test/pose/testPoseRansac2.cpp
+++ b/modules/vision/test/pose/testPoseRansac2.cpp
@@ -538,6 +538,8 @@ int main(int argc, char* argv[])
   return EXIT_SUCCESS;
 #endif
 
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+
   Catch::Session session; // There must be exactly one instance
 
   // Let Catch (using Clara) parse the command line
@@ -549,6 +551,10 @@ int main(int argc, char* argv[])
   // This clamping has already been applied, so just return it here
   // You can also do any post run clean-up here
   return numFailed;
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }
 #else
 int main()

--- a/modules/vs/test/visual-feature/testFeatureMoment.cpp
+++ b/modules/vs/test/visual-feature/testFeatureMoment.cpp
@@ -60,6 +60,7 @@ int test(double x, double y, double z, double alpha);
 // form;
 int main()
 {
+#if (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
   try {
     int sum = 0;
     for (double i = -0.2; i < 0.2; i += 0.1) {
@@ -72,13 +73,17 @@ int main()
       }
     }
     if (sum < 0)
-      return -1;
+      return EXIT_FAILURE;
     else
-      return 0;
+      return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
-    return 1;
+    return EXIT_FAILURE;
   }
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+#endif
 }
 
 int test(double x, double y, double z, double alpha)

--- a/modules/vs/test/visual-feature/testFeatureSegment.cpp
+++ b/modules/vs/test/visual-feature/testFeatureSegment.cpp
@@ -43,7 +43,8 @@
 
 #include <visp3/core/vpConfig.h>
 
-#ifdef VISP_HAVE_MODULE_ROBOT
+#if defined(VISP_HAVE_MODULE_ROBOT) \
+  && (defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
 
 #include <visp3/core/vpCameraParameters.h>
 #include <visp3/core/vpDisplay.h>
@@ -260,6 +261,12 @@ int main(int argc, const char **argv)
   }
 }
 
+#elif !(defined(VISP_HAVE_LAPACK) || defined(VISP_HAVE_EIGEN3) || defined(VISP_HAVE_OPENCV))
+int main()
+{
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+  return EXIT_SUCCESS;
+}
 #else
 int main()
 {


### PR DESCRIPTION
- protect all tests/examples/demos that require one of these 3rd party
  using preprocessor directives
- concerned files are mainly using svd and pseudo-inverse that
  are missing when none of these 3rd party is used