### PR TITLE
Add perf script / add verbose option in MBT

### DIFF
--- a/modules/tracker/mbt/CMakeLists.txt
+++ b/modules/tracker/mbt/CMakeLists.txt
@@ -270,6 +270,11 @@ if(WITH_PUGIXML)
   include_directories(${PUGIXML_INCLUDE_DIRS})
 endif()
 
+if(WITH_CATCH2)
+  # catch2 is private
+  include_directories(${CATCH2_INCLUDE_DIRS})
+endif()
+
 vp_add_module(mbt visp_vision visp_core visp_me visp_visual_features OPTIONAL visp_ar visp_klt visp_gui PRIVATE_OPTIONAL ${CLIPPER_LIBRARIES} ${PUGIXML_LIBRARIES} WRAP java)
 vp_glob_module_sources()
 
@@ -322,6 +327,7 @@ vp_create_module(${opt_libs})
 
 if(BUILD_TESTS)
   if(USE_OGRE)
+    vp_set_source_file_compile_flag(test/perfGenericTracker.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)
     vp_set_source_file_compile_flag(test/testGenericTracker.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)
     vp_set_source_file_compile_flag(test/testGenericTrackerDepth.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)
     vp_set_source_file_compile_flag(test/testMbtXmlGenericParser.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbDepthDenseTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbDepthDenseTracker.h
@@ -68,13 +68,13 @@ public:
 
   virtual void init(const vpImage<unsigned char> &I);
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name, const vpHomogeneousMatrix &cMo,
-                   bool verbose = false);
+                   int verbose=1);
 #if defined(VISP_HAVE_PCL)
   void reInitModel(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &point_cloud, const std::string &cad_name,
-                   const vpHomogeneousMatrix &cMo, bool verbose = false);
+                   const vpHomogeneousMatrix &cMo, int verbose=1);
 #endif
 
   virtual void resetTracker();

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
@@ -73,13 +73,13 @@ public:
 
   virtual void init(const vpImage<unsigned char> &I);
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name, const vpHomogeneousMatrix &cMo,
-                   bool verbose = false);
+                   int verbose=1);
 #if defined(VISP_HAVE_PCL)
   void reInitModel(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &point_cloud, const std::string &cad_name,
-                   const vpHomogeneousMatrix &cMo, bool verbose = false);
+                   const vpHomogeneousMatrix &cMo, int verbose=1);
 #endif
 
   virtual void resetTracker();

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltMultiTracker.h
@@ -233,27 +233,27 @@ public:
   virtual void initFaceFromCorners(vpMbtPolygon &polygon);
   virtual void initFaceFromLines(vpMbtPolygon &polygon);
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   virtual void loadConfigFile(const std::string &configFile1, const std::string &configFile2,
                               bool firstCameraIsReference = true);
 
   virtual void loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles);
 
-  virtual void loadModel(const std::string &modelFile, bool verbose = false,
+  virtual void loadModel(const std::string &modelFile, int verbose=1,
                          const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   virtual void reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                            const std::string &cad_name, const vpHomogeneousMatrix &c1Mo,
-                           const vpHomogeneousMatrix &c2Mo, bool verbose = false,
+                           const vpHomogeneousMatrix &c2Mo, int verbose=1,
                            bool firstCameraIsReference = true);
   virtual void reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                            const std::string &cad_name,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                           bool verbose = false);
+                           int verbose=1);
 
   virtual void resetTracker();
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeKltTracker.h
@@ -258,10 +258,10 @@ public:
    */
   virtual inline double getNearClippingDistance() const { return vpMbKltTracker::getNearClippingDistance(); }
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose);
 
   void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name, const vpHomogeneousMatrix &cMo,
-                   bool verbose = false, const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
+                   int verbose1=1, const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   void resetTracker();
 
   virtual void setCameraParameters(const vpCameraParameters &cam);

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeMultiTracker.h
@@ -229,27 +229,27 @@ public:
   virtual void initFromPose(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                             const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses);
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   virtual void loadConfigFile(const std::string &configFile1, const std::string &configFile2,
                               bool firstCameraIsReference = true);
 
   virtual void loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles);
 
-  virtual void loadModel(const std::string &modelFile, bool verbose = false,
+  virtual void loadModel(const std::string &modelFile, int verbose=1,
                          const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   virtual void reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                            const std::string &cad_name, const vpHomogeneousMatrix &c1Mo,
-                           const vpHomogeneousMatrix &c2Mo, bool verbose = false,
+                           const vpHomogeneousMatrix &c2Mo, int verbose=1,
                            bool firstCameraIsReference = true);
   virtual void reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                            const std::string &cad_name,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                           bool verbose = false);
+                           int verbose=1);
 
   virtual void resetTracker();
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbEdgeTracker.h
@@ -390,10 +390,10 @@ public:
 
   virtual inline vpColVector getRobustWeights() const { return m_w_edge; }
 
-  void loadConfigFile(const std::string &configFile);
+  void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   void resetTracker();
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -274,41 +274,41 @@ public:
   virtual void initFromPose(const std::map<std::string, const vpImage<vpRGBa> *> &mapOfColorImages,
                             const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses);
 
-  virtual void loadConfigFile(const std::string &configFile);
-  virtual void loadConfigFile(const std::string &configFile1, const std::string &configFile2);
-  virtual void loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
+  virtual void loadConfigFile(const std::string &configFile1, const std::string &configFile2, bool verbose=true);
+  virtual void loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles, bool verbose=true);
 
-  virtual void loadModel(const std::string &modelFile, bool verbose = false, const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
-  virtual void loadModel(const std::string &modelFile1, const std::string &modelFile2, bool verbose = false,
+  virtual void loadModel(const std::string &modelFile, int verbose=1, const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
+  virtual void loadModel(const std::string &modelFile1, const std::string &modelFile2, int verbose=1,
                          const vpHomogeneousMatrix &T1=vpHomogeneousMatrix(), const vpHomogeneousMatrix &T2=vpHomogeneousMatrix());
-  virtual void loadModel(const std::map<std::string, std::string> &mapOfModelFiles, bool verbose = false,
+  virtual void loadModel(const std::map<std::string, std::string> &mapOfModelFiles, int verbose=1,
                          const std::map<std::string, vpHomogeneousMatrix> &mapOfT=std::map<std::string, vpHomogeneousMatrix>());
 
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   virtual void reInitModel(const vpImage<vpRGBa> &I_color, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
   virtual void reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                            const std::string &cad_name1, const std::string &cad_name2, const vpHomogeneousMatrix &c1Mo,
-                           const vpHomogeneousMatrix &c2Mo, bool verbose = false,
+                           const vpHomogeneousMatrix &c2Mo, int verbose=1,
                            const vpHomogeneousMatrix &T1=vpHomogeneousMatrix(), const vpHomogeneousMatrix &T2=vpHomogeneousMatrix());
   virtual void reInitModel(const vpImage<vpRGBa> &I_color1, const vpImage<vpRGBa> &I_color2,
                            const std::string &cad_name1, const std::string &cad_name2, const vpHomogeneousMatrix &c1Mo,
-                           const vpHomogeneousMatrix &c2Mo, bool verbose = false,
+                           const vpHomogeneousMatrix &c2Mo, int verbose=1,
                            const vpHomogeneousMatrix &T1=vpHomogeneousMatrix(), const vpHomogeneousMatrix &T2=vpHomogeneousMatrix());
 
   virtual void reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                            const std::map<std::string, std::string> &mapOfModelFiles,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                           bool verbose = false,
+                           int verbose=1,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfT=std::map<std::string, vpHomogeneousMatrix>());
   virtual void reInitModel(const std::map<std::string, const vpImage<vpRGBa> *> &mapOfColorImages,
                            const std::map<std::string, std::string> &mapOfModelFiles,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                           bool verbose = false,
+                           int verbose=1,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfT=std::map<std::string, vpHomogeneousMatrix>());
 
   virtual void resetTracker();
@@ -534,13 +534,13 @@ private:
 
     virtual void init(const vpImage<unsigned char> &I);
 
-    virtual void loadConfigFile(const std::string &configFile);
+    virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
     virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                             const vpHomogeneousMatrix &cMo, bool verbose = false,
+                             const vpHomogeneousMatrix &cMo, int verbose=1,
                              const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
     virtual void reInitModel(const vpImage<vpRGBa> &I_color, const std::string &cad_name,
-                             const vpHomogeneousMatrix &cMo, bool verbose = false,
+                             const vpHomogeneousMatrix &cMo, int verbose=1,
                              const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
     virtual void resetTracker();
@@ -614,7 +614,7 @@ private:
                              const unsigned int pointcloud_width = 0, const unsigned int pointcloud_height = 0);
 
     virtual void reInitModel(const vpImage<unsigned char> * const I, const vpImage<vpRGBa> * const I_color,
-                             const std::string &cad_name, const vpHomogeneousMatrix &cMo, bool verbose = false,
+                             const std::string &cad_name, const vpHomogeneousMatrix &cMo, int verbose=1,
                              const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
 #ifdef VISP_HAVE_PCL

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbKltMultiTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbKltMultiTracker.h
@@ -229,27 +229,27 @@ public:
   virtual void initFromPose(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                             const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses);
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   virtual void loadConfigFile(const std::string &configFile1, const std::string &configFile2,
                               bool firstCameraIsReference = true);
 
   virtual void loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles);
 
-  virtual void loadModel(const std::string &modelFile, bool verbose = false,
+  virtual void loadModel(const std::string &modelFile, int verbose=1,
                          const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   virtual void reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                            const std::string &cad_name, const vpHomogeneousMatrix &c1Mo,
-                           const vpHomogeneousMatrix &c2Mo, bool verbose = false,
+                           const vpHomogeneousMatrix &c2Mo, int verbose=1,
                            bool firstCameraIsReference = true);
   virtual void reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                            const std::string &cad_name,
                            const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                           bool verbose = false);
+                           int verbose=1);
 
   virtual void resetTracker();
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbKltTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbKltTracker.h
@@ -339,10 +339,10 @@ public:
                                                                const vpCameraParameters &cam,
                                                                bool displayFullModel=false);
 
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                           const vpHomogeneousMatrix &cMo, bool verbose = false,
+                           const vpHomogeneousMatrix &cMo, int verbose=1,
                            const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
   void resetTracker();
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
@@ -451,7 +451,7 @@ public:
   virtual void initFromPose(const vpImage<unsigned char> &I, const vpPoseVector &cPo);
   virtual void initFromPose(const vpImage<vpRGBa> &I_color, const vpPoseVector &cPo);
 
-  virtual void loadModel(const std::string &modelFile, bool verbose = false, const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
+  virtual void loadModel(const std::string &modelFile, int verbose=1, const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
   /*!
     Set the angle used to test polygons appearance.
@@ -699,8 +699,9 @@ public:
     Pure virtual method to adapt to each tracker.
 
     \param configFile : An xml config file to parse.
+    \param verbose : Verbose option.
   */
-  virtual void loadConfigFile(const std::string &configFile);
+  virtual void loadConfigFile(const std::string &configFile, bool verbose=true);
 
   /*!
     Reset the tracker.
@@ -888,7 +889,7 @@ protected:
 
   virtual void loadVRMLModel(const std::string &modelFile);
   virtual void loadCAOModel(const std::string &modelFile, std::vector<std::string> &vectorOfModelFilename,
-                            int &startIdFace, bool verbose = false, bool parent = true,
+                            int &startIdFace, int verbose = 1, bool parent = true,
                             const vpHomogeneousMatrix &T=vpHomogeneousMatrix());
 
   void projectionErrorInitMovingEdge(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &_cMo);

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtXmlGenericParser.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtXmlGenericParser.h
@@ -154,6 +154,8 @@ public:
   void setProjectionErrorMe(const vpMe &me);
   void setProjectionErrorKernelSize(const unsigned int &size);
 
+  void setVerbose(bool verbose);
+
 private:
   vpMbtXmlGenericParser(const vpMbtXmlGenericParser &);            // noncopyable
   vpMbtXmlGenericParser &operator=(const vpMbtXmlGenericParser &); //
@@ -161,6 +163,8 @@ private:
   // PIMPL idiom
   class Impl;
   Impl *m_impl;
+
+  bool m_verbose;
 };
 
 #endif

--- a/modules/tracker/mbt/src/depth/vpMbDepthDenseTracker.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbDepthDenseTracker.cpp
@@ -387,7 +387,7 @@ void vpMbDepthDenseTracker::init(const vpImage<unsigned char> &I)
   computeVisibility(I.getWidth(), I.getHeight());
 }
 
-void vpMbDepthDenseTracker::loadConfigFile(const std::string &configFile)
+void vpMbDepthDenseTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp(vpMbtXmlGenericParser::DEPTH_DENSE_PARSER);
@@ -400,7 +400,10 @@ void vpMbDepthDenseTracker::loadConfigFile(const std::string &configFile)
   xmlp.setDepthDenseSamplingStepY(m_depthDenseSamplingStepY);
 
   try {
-    std::cout << " *********** Parsing XML for Mb Depth Dense Tracker ************ " << std::endl;
+    if (verbose) {
+      std::cout << " *********** Parsing XML for Mb Depth Dense Tracker ************ " << std::endl;
+    }
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile);
   } catch (const vpException &e) {
     std::cerr << "Exception: " << e.what() << std::endl;
@@ -430,7 +433,7 @@ void vpMbDepthDenseTracker::loadConfigFile(const std::string &configFile)
 }
 
 void vpMbDepthDenseTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                        const vpHomogeneousMatrix &cMo, bool verbose)
+                                        const vpHomogeneousMatrix &cMo, int verbose)
 {
   m_cMo.eye();
 
@@ -448,7 +451,7 @@ void vpMbDepthDenseTracker::reInitModel(const vpImage<unsigned char> &I, const s
 #if defined(VISP_HAVE_PCL)
 void vpMbDepthDenseTracker::reInitModel(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &point_cloud,
                                         const std::string &cad_name, const vpHomogeneousMatrix &cMo,
-                                        bool verbose)
+                                        int verbose)
 {
   vpImage<unsigned char> I_dummy(point_cloud->height, point_cloud->width);
   reInitModel(I_dummy, cad_name, cMo, verbose);

--- a/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
@@ -416,7 +416,7 @@ void vpMbDepthNormalTracker::init(const vpImage<unsigned char> &I)
   computeVisibility(I.getWidth(), I.getHeight());
 }
 
-void vpMbDepthNormalTracker::loadConfigFile(const std::string &configFile)
+void vpMbDepthNormalTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp(vpMbtXmlGenericParser::DEPTH_NORMAL_PARSER);
@@ -433,7 +433,10 @@ void vpMbDepthNormalTracker::loadConfigFile(const std::string &configFile)
   xmlp.setDepthNormalSamplingStepY(m_depthNormalSamplingStepY);
 
   try {
-    std::cout << " *********** Parsing XML for Mb Depth Tracker ************ " << std::endl;
+    if (verbose) {
+      std::cout << " *********** Parsing XML for Mb Depth Tracker ************ " << std::endl;
+    }
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile);
   } catch (const vpException &e) {
     std::cerr << "Exception: " << e.what() << std::endl;
@@ -467,7 +470,7 @@ void vpMbDepthNormalTracker::loadConfigFile(const std::string &configFile)
 }
 
 void vpMbDepthNormalTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                         const vpHomogeneousMatrix &cMo, bool verbose)
+                                         const vpHomogeneousMatrix &cMo, int verbose)
 {
   m_cMo.eye();
 
@@ -485,7 +488,7 @@ void vpMbDepthNormalTracker::reInitModel(const vpImage<unsigned char> &I, const 
 #if defined(VISP_HAVE_PCL)
 void vpMbDepthNormalTracker::reInitModel(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &point_cloud,
                                          const std::string &cad_name, const vpHomogeneousMatrix &cMo,
-                                         bool verbose)
+                                         int verbose)
 {
   vpImage<unsigned char> I_dummy(point_cloud->height, point_cloud->width);
   reInitModel(I_dummy, cad_name, cMo, verbose);

--- a/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeMultiTracker.cpp
@@ -1662,6 +1662,7 @@ objects: moving-edges, camera and visibility angles.
 not found or wrong format for the data).
 
   \param configFile : full name of the xml file.
+  \param verbose : verbose option.
 
   The XML configuration file has the following form:
   \code
@@ -1698,12 +1699,12 @@ not found or wrong format for the data).
 </conf>
   \endcode
 */
-void vpMbEdgeMultiTracker::loadConfigFile(const std::string &configFile)
+void vpMbEdgeMultiTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
   std::map<std::string, vpMbEdgeTracker *>::const_iterator it = m_mapOfEdgeTrackers.find(m_referenceCameraName);
   if (it != m_mapOfEdgeTrackers.end()) {
     // Load ConfigFile for reference camera
-    it->second->loadConfigFile(configFile);
+    it->second->loadConfigFile(configFile, verbose);
     it->second->getCameraParameters(m_cam);
 
     // Set Moving Edge parameters
@@ -1843,7 +1844,7 @@ CAO model files which include other CAO model files.
   \param T : optional transformation matrix (currently only for .cao) to transform
   3D points expressed in the original object frame to the desired object frame.
 */
-void vpMbEdgeMultiTracker::loadModel(const std::string &modelFile, bool verbose,
+void vpMbEdgeMultiTracker::loadModel(const std::string &modelFile, int verbose,
                                      const vpHomogeneousMatrix &T)
 {
   for (std::map<std::string, vpMbEdgeTracker *>::const_iterator it = m_mapOfEdgeTrackers.begin();
@@ -1867,7 +1868,7 @@ void vpMbEdgeMultiTracker::loadModel(const std::string &modelFile, bool verbose,
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbEdgeMultiTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                       const vpHomogeneousMatrix &cMo, bool verbose,
+                                       const vpHomogeneousMatrix &cMo, int verbose,
                                        const vpHomogeneousMatrix &T)
 {
   if (m_mapOfEdgeTrackers.size() != 1) {
@@ -1902,7 +1903,7 @@ void vpMbEdgeMultiTracker::reInitModel(const vpImage<unsigned char> &I, const st
 */
 void vpMbEdgeMultiTracker::reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                                        const std::string &cad_name, const vpHomogeneousMatrix &c1Mo,
-                                       const vpHomogeneousMatrix &c2Mo, bool verbose,
+                                       const vpHomogeneousMatrix &c2Mo, int verbose,
                                        bool firstCameraIsReference)
 {
   if (m_mapOfEdgeTrackers.size() == 2) {
@@ -1941,7 +1942,7 @@ void vpMbEdgeMultiTracker::reInitModel(const vpImage<unsigned char> &I1, const v
 void vpMbEdgeMultiTracker::reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                                        const std::string &cad_name,
                                        const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                                       bool verbose)
+                                       int verbose)
 {
   std::map<std::string, vpMbEdgeTracker *>::const_iterator it_edge = m_mapOfEdgeTrackers.find(m_referenceCameraName);
   std::map<std::string, const vpImage<unsigned char> *>::const_iterator it_img =

--- a/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbEdgeTracker.cpp
@@ -1218,13 +1218,14 @@ void vpMbEdgeTracker::setPose(const vpImage<vpRGBa> &I_color, const vpHomogeneou
   and visibility angles.
 
   \param configFile : full name of the xml file.
+  \param verbose : verbose option.
 
   \sa loadConfigFile(const char*)
 */
-void vpMbEdgeTracker::loadConfigFile(const std::string &configFile)
+void vpMbEdgeTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
   // Load projection error config
-  vpMbTracker::loadConfigFile(configFile);
+  vpMbTracker::loadConfigFile(configFile, verbose);
 
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp(vpMbtXmlGenericParser::EDGE_PARSER);
@@ -1235,7 +1236,10 @@ void vpMbEdgeTracker::loadConfigFile(const std::string &configFile)
   xmlp.setEdgeMe(me);
 
   try {
-    std::cout << " *********** Parsing XML for Mb Edge Tracker ************ " << std::endl;
+    if (verbose) {
+      std::cout << " *********** Parsing XML for Mb Edge Tracker ************ " << std::endl;
+    }
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile);
   } catch (...) {
     throw vpException(vpException::ioError, "Cannot open XML file \"%s\"", configFile.c_str());
@@ -2448,7 +2452,7 @@ void vpMbEdgeTracker::resetTracker()
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbEdgeTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                  const vpHomogeneousMatrix &cMo, bool verbose,
+                                  const vpHomogeneousMatrix &cMo, int verbose,
                                   const vpHomogeneousMatrix &T)
 {
   m_cMo.eye();

--- a/modules/tracker/mbt/src/hybrid/vpMbEdgeKltMultiTracker.cpp
+++ b/modules/tracker/mbt/src/hybrid/vpMbEdgeKltMultiTracker.cpp
@@ -1249,6 +1249,7 @@ vpMbEdgeKltMultiTracker::initMbtTracking(std::map<std::string, const vpImage<uns
   not found or wrong format for the data).
 
   \param configFile : full name of the xml file.
+  \param verbose : verbose option.
 
   The XML configuration file has the following form:
   \code
@@ -1282,10 +1283,10 @@ vpMbEdgeKltMultiTracker::initMbtTracking(std::map<std::string, const vpImage<uns
 </conf>
   \endcode
 */
-void vpMbEdgeKltMultiTracker::loadConfigFile(const std::string &configFile)
+void vpMbEdgeKltMultiTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
-  vpMbEdgeMultiTracker::loadConfigFile(configFile);
-  vpMbKltMultiTracker::loadConfigFile(configFile);
+  vpMbEdgeMultiTracker::loadConfigFile(configFile, verbose);
+  vpMbKltMultiTracker::loadConfigFile(configFile, verbose);
 }
 
 /*!
@@ -1351,7 +1352,7 @@ int main()
   \param T : optional transformation matrix (currently only for .cao) to transform
   3D points expressed in the original object frame to the desired object frame.
 */
-void vpMbEdgeKltMultiTracker::loadModel(const std::string &modelFile, bool verbose,
+void vpMbEdgeKltMultiTracker::loadModel(const std::string &modelFile, int verbose,
                                         const vpHomogeneousMatrix &T)
 {
   vpMbEdgeMultiTracker::loadModel(modelFile, verbose, T);
@@ -1436,7 +1437,7 @@ void vpMbEdgeKltMultiTracker::reinit(/*const vpImage<unsigned char>& I */)
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbEdgeKltMultiTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                          const vpHomogeneousMatrix &cMo, bool verbose,
+                                          const vpHomogeneousMatrix &cMo, int verbose,
                                           const vpHomogeneousMatrix &T)
 {
   vpMbEdgeMultiTracker::reInitModel(I, cad_name, cMo, verbose, T);
@@ -1458,7 +1459,7 @@ void vpMbEdgeKltMultiTracker::reInitModel(const vpImage<unsigned char> &I, const
 */
 void vpMbEdgeKltMultiTracker::reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                                           const std::string &cad_name, const vpHomogeneousMatrix &c1Mo,
-                                          const vpHomogeneousMatrix &c2Mo, bool verbose,
+                                          const vpHomogeneousMatrix &c2Mo, int verbose,
                                           bool firstCameraIsReference)
 {
   vpMbEdgeMultiTracker::reInitModel(I1, I2, cad_name, c1Mo, c2Mo, verbose, firstCameraIsReference);
@@ -1478,7 +1479,7 @@ void vpMbEdgeKltMultiTracker::reInitModel(const vpImage<unsigned char> &I1, cons
 void vpMbEdgeKltMultiTracker::reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                                           const std::string &cad_name,
                                           const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                                          bool verbose)
+                                          int verbose)
 {
   vpMbEdgeMultiTracker::reInitModel(mapOfImages, cad_name, mapOfCameraPoses, verbose);
   vpMbKltMultiTracker::reInitModel(mapOfImages, cad_name, mapOfCameraPoses, verbose);

--- a/modules/tracker/mbt/src/hybrid/vpMbEdgeKltTracker.cpp
+++ b/modules/tracker/mbt/src/hybrid/vpMbEdgeKltTracker.cpp
@@ -223,6 +223,7 @@ objects: moving-edges, KLT, camera.
 not found or wrong format for the data).
 
   \param configFile : full name of the xml file.
+  \param verbose : verbose option.
 
   The XML configuration file has the following form:
   \code
@@ -273,10 +274,10 @@ not found or wrong format for the data).
 </conf>
   \endcode
 */
-void vpMbEdgeKltTracker::loadConfigFile(const std::string &configFile)
+void vpMbEdgeKltTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
   // Load projection error config
-  vpMbTracker::loadConfigFile(configFile);
+  vpMbTracker::loadConfigFile(configFile, verbose);
 
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp(vpMbtXmlGenericParser::EDGE_PARSER | vpMbtXmlGenericParser::KLT_PARSER);
@@ -297,7 +298,10 @@ void vpMbEdgeKltTracker::loadConfigFile(const std::string &configFile)
   xmlp.setKltMaskBorder(maskBorder);
 
   try {
-    std::cout << " *********** Parsing XML for Mb Edge KLT Tracker ************ " << std::endl;
+    if (verbose) {
+      std::cout << " *********** Parsing XML for Mb Edge KLT Tracker ************ " << std::endl;
+    }
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile.c_str());
   } catch (...) {
     vpERROR_TRACE("Can't open XML file \"%s\"\n ", configFile.c_str());
@@ -1381,7 +1385,7 @@ std::vector<std::vector<double> > vpMbEdgeKltTracker::getModelForDisplay(unsigne
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbEdgeKltTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                     const vpHomogeneousMatrix &cMo, bool verbose,
+                                     const vpHomogeneousMatrix &cMo, int verbose,
                                      const vpHomogeneousMatrix &T)
 {
   // Reinit klt

--- a/modules/tracker/mbt/src/klt/vpMbKltMultiTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltMultiTracker.cpp
@@ -1517,6 +1517,7 @@ void vpMbKltMultiTracker::initFromPose(const std::map<std::string, const vpImage
   not found or wrong format for the data).
 
   \param configFile : full name of the xml file.
+  \param verbose : verbose option.
 
   The XML configuration file has the following form:
   \code
@@ -1550,12 +1551,12 @@ void vpMbKltMultiTracker::initFromPose(const std::map<std::string, const vpImage
 </conf>
   \endcode
 */
-void vpMbKltMultiTracker::loadConfigFile(const std::string &configFile)
+void vpMbKltMultiTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
   std::map<std::string, vpMbKltTracker *>::const_iterator it = m_mapOfKltTrackers.find(m_referenceCameraName);
   if (it != m_mapOfKltTrackers.end()) {
     // Load ConfigFile for reference camera
-    it->second->loadConfigFile(configFile);
+    it->second->loadConfigFile(configFile, verbose);
     it->second->getCameraParameters(m_cam);
 
     // Set clipping
@@ -1683,7 +1684,7 @@ int main()
   \param T : optional transformation matrix (currently only for .cao) to transform
   3D points expressed in the original object frame to the desired object frame.
 */
-void vpMbKltMultiTracker::loadModel(const std::string &modelFile, bool verbose,
+void vpMbKltMultiTracker::loadModel(const std::string &modelFile, int verbose,
                                     const vpHomogeneousMatrix &T)
 {
   for (std::map<std::string, vpMbKltTracker *>::const_iterator it = m_mapOfKltTrackers.begin();
@@ -1758,7 +1759,7 @@ void vpMbKltMultiTracker::reinit(/* const vpImage<unsigned char>& I*/)
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbKltMultiTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                      const vpHomogeneousMatrix &cMo, bool verbose,
+                                      const vpHomogeneousMatrix &cMo, int verbose,
                                       const vpHomogeneousMatrix &T)
 {
   if (m_mapOfKltTrackers.size() != 1) {
@@ -1799,7 +1800,7 @@ void vpMbKltMultiTracker::reInitModel(const vpImage<unsigned char> &I, const std
 */
 void vpMbKltMultiTracker::reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                                       const std::string &cad_name, const vpHomogeneousMatrix &c1Mo,
-                                      const vpHomogeneousMatrix &c2Mo, bool verbose,
+                                      const vpHomogeneousMatrix &c2Mo, int verbose,
                                       bool firstCameraIsReference)
 {
   if (m_mapOfKltTrackers.size() == 2) {
@@ -1841,7 +1842,7 @@ void vpMbKltMultiTracker::reInitModel(const vpImage<unsigned char> &I1, const vp
 void vpMbKltMultiTracker::reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                                       const std::string &cad_name,
                                       const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                                      bool verbose)
+                                      int verbose)
 {
   std::map<std::string, vpMbKltTracker *>::const_iterator it_klt = m_mapOfKltTrackers.find(m_referenceCameraName);
   std::map<std::string, const vpImage<unsigned char> *>::const_iterator it_img =

--- a/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
+++ b/modules/tracker/mbt/src/klt/vpMbKltTracker.cpp
@@ -970,6 +970,7 @@ objects: KLT, camera.
 not found or wrong format for the data).
 
   \param configFile : full name of the xml file.
+  \param verbose : verbose option.
 
   The XML configuration file has the following form:
   \code
@@ -1003,10 +1004,10 @@ not found or wrong format for the data).
 </conf>
   \endcode
 */
-void vpMbKltTracker::loadConfigFile(const std::string &configFile)
+void vpMbKltTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
   // Load projection error config
-  vpMbTracker::loadConfigFile(configFile);
+  vpMbTracker::loadConfigFile(configFile, verbose);
 
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp(vpMbtXmlGenericParser::KLT_PARSER);
@@ -1023,7 +1024,10 @@ void vpMbKltTracker::loadConfigFile(const std::string &configFile)
   xmlp.setAngleDisappear(vpMath::deg(angleDisappears));
 
   try {
-    std::cout << " *********** Parsing XML for MBT KLT Tracker ************ " << std::endl;
+    if (verbose) {
+      std::cout << " *********** Parsing XML for MBT KLT Tracker ************ " << std::endl;
+    }
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile.c_str());
   } catch (...) {
     vpERROR_TRACE("Can't open XML file \"%s\"\n ", configFile.c_str());
@@ -1393,7 +1397,7 @@ void vpMbKltTracker::addCircle(const vpPoint &P1, const vpPoint &P2, const vpPoi
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbKltTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                 const vpHomogeneousMatrix &cMo, bool verbose,
+                                 const vpHomogeneousMatrix &cMo, int verbose,
                                  const vpHomogeneousMatrix &T)
 {
   m_cMo.eye();

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -2766,13 +2766,14 @@ void vpMbGenericTracker::initFromPose(const std::map<std::string, const vpImage<
   not found).
 
   \param configFile : full name of the xml file.
+  \param verbose : Print config info if verbose is set to true.
 */
-void vpMbGenericTracker::loadConfigFile(const std::string &configFile)
+void vpMbGenericTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
   for (std::map<std::string, TrackerWrapper *>::const_iterator it = m_mapOfTrackers.begin();
        it != m_mapOfTrackers.end(); ++it) {
     TrackerWrapper *tracker = it->second;
-    tracker->loadConfigFile(configFile);
+    tracker->loadConfigFile(configFile, verbose);
   }
 
   if (m_mapOfTrackers.find(m_referenceCameraName) == m_mapOfTrackers.end()) {
@@ -2795,10 +2796,11 @@ void vpMbGenericTracker::loadConfigFile(const std::string &configFile)
 
   \param configFile1 : Full name of the xml file for the first camera.
   \param configFile2 : Full name of the xml file for the second camera.
+  \param verbose : Print config info if verbose is set to true.
 
   \note This function assumes a stereo configuration of the generic tracker.
 */
-void vpMbGenericTracker::loadConfigFile(const std::string &configFile1, const std::string &configFile2)
+void vpMbGenericTracker::loadConfigFile(const std::string &configFile1, const std::string &configFile2, bool verbose)
 {
   if (m_mapOfTrackers.size() != 2) {
     throw vpException(vpException::fatalError, "The tracker is not set in a stereo configuration!");
@@ -2806,11 +2808,11 @@ void vpMbGenericTracker::loadConfigFile(const std::string &configFile1, const st
 
   std::map<std::string, TrackerWrapper *>::const_iterator it_tracker = m_mapOfTrackers.begin();
   TrackerWrapper *tracker = it_tracker->second;
-  tracker->loadConfigFile(configFile1);
+  tracker->loadConfigFile(configFile1, verbose);
 
   ++it_tracker;
   tracker = it_tracker->second;
-  tracker->loadConfigFile(configFile2);
+  tracker->loadConfigFile(configFile2, verbose);
 
   if (m_mapOfTrackers.find(m_referenceCameraName) == m_mapOfTrackers.end()) {
     throw vpException(vpException::fatalError, "Cannot find the reference camera:  %s!", m_referenceCameraName.c_str());
@@ -2831,10 +2833,11 @@ void vpMbGenericTracker::loadConfigFile(const std::string &configFile1, const st
   not found).
 
   \param mapOfConfigFiles : Map of xml files.
+  \param verbose : Print config info if verbose is set to true.
 
   \note Configuration files must be supplied for all the cameras.
 */
-void vpMbGenericTracker::loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles)
+void vpMbGenericTracker::loadConfigFile(const std::map<std::string, std::string> &mapOfConfigFiles, bool verbose)
 {
   for (std::map<std::string, TrackerWrapper *>::const_iterator it_tracker = m_mapOfTrackers.begin();
        it_tracker != m_mapOfTrackers.end(); ++it_tracker) {
@@ -2842,7 +2845,7 @@ void vpMbGenericTracker::loadConfigFile(const std::map<std::string, std::string>
 
     std::map<std::string, std::string>::const_iterator it_config = mapOfConfigFiles.find(it_tracker->first);
     if (it_config != mapOfConfigFiles.end()) {
-      tracker->loadConfigFile(it_config->second);
+      tracker->loadConfigFile(it_config->second, verbose);
     } else {
       throw vpException(vpTrackingException::initializationError, "Missing configuration file for camera: %s!",
                         it_tracker->first.c_str());
@@ -2887,15 +2890,15 @@ is not wrl or cao.
 
   \param modelFile : the file containing the 3D model description.
   The extension of this file is either .wrl or .cao.
-  \param verbose : verbose option to print additional information when loading
-CAO model files which include other CAO model files.
+  \param verbose : verbose option to print additional information (0: no print, 1: intermediate, 2: full)
+when loading CAO model files which include other CAO model files.
   \param T : optional transformation matrix (currently only for .cao) to transform
   3D points expressed in the original object frame to the desired object frame.
 
   \note All the trackers will use the same model in case of stereo / multiple
 cameras configuration.
 */
-void vpMbGenericTracker::loadModel(const std::string &modelFile, bool verbose, const vpHomogeneousMatrix &T)
+void vpMbGenericTracker::loadModel(const std::string &modelFile, int verbose, const vpHomogeneousMatrix &T)
 {
   for (std::map<std::string, TrackerWrapper *>::const_iterator it = m_mapOfTrackers.begin();
        it != m_mapOfTrackers.end(); ++it) {
@@ -2928,8 +2931,8 @@ is not wrl or cao.
 first camera. The extension of this file is either .wrl or .cao.
   \param modelFile2 : the file containing the the 3D model description for the second
 camera. The extension of this file is either .wrl or .cao.
-  \param verbose : verbose option to print additional information when loading CAO model files
-which include other CAO model files.
+  \param verbose : verbose option to print additional information (0: no print, 1: intermediate, 2: full)
+when loading CAO model files which include other CAO model files.
   \param T1 : optional transformation matrix (currently only for .cao) to transform
   3D points in \a modelFile1 expressed in the original object frame to the desired object frame.
   \param T2 : optional transformation matrix (currently only for .cao) to transform
@@ -2938,7 +2941,7 @@ which include other CAO model files.
 
   \note This function assumes a stereo configuration of the generic tracker.
 */
-void vpMbGenericTracker::loadModel(const std::string &modelFile1, const std::string &modelFile2, bool verbose,
+void vpMbGenericTracker::loadModel(const std::string &modelFile1, const std::string &modelFile2, int verbose,
                                    const vpHomogeneousMatrix &T1, const vpHomogeneousMatrix &T2)
 {
   if (m_mapOfTrackers.size() != 2) {
@@ -2976,8 +2979,8 @@ is not wrl or cao.
 
   \param mapOfModelFiles : map of files containing the 3D model description.
   The extension of this file is either .wrl or .cao.
-  \param verbose : verbose option to print additional information when loading
-CAO model files which include other CAO model files.
+  \param verbose : verbose option to print additional information (0: no print, 1: intermediate, 2: full)
+when loading CAO model files which include other CAO model files.
   \param mapOfT : optional map of transformation matrices (currently only for .cao)
   to transform 3D points in \a mapOfModelFiles expressed in the original object frame to
   the desired object frame (if the models have the same object frame which should be the
@@ -2985,7 +2988,7 @@ CAO model files which include other CAO model files.
 
   \note Each camera must have a model file.
 */
-void vpMbGenericTracker::loadModel(const std::map<std::string, std::string> &mapOfModelFiles, bool verbose,
+void vpMbGenericTracker::loadModel(const std::map<std::string, std::string> &mapOfModelFiles, int verbose,
                                    const std::map<std::string, vpHomogeneousMatrix> &mapOfT)
 {
   for (std::map<std::string, TrackerWrapper *>::const_iterator it_tracker = m_mapOfTrackers.begin();
@@ -3044,7 +3047,7 @@ void vpMbGenericTracker::preTracking(std::map<std::string, const vpImage<unsigne
   \param T : optional transformation matrix (currently only for .cao).
 */
 void vpMbGenericTracker::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                     const vpHomogeneousMatrix &cMo, bool verbose,
+                                     const vpHomogeneousMatrix &cMo, int verbose,
                                      const vpHomogeneousMatrix &T)
 {
   if (m_mapOfTrackers.size() != 1) {
@@ -3078,7 +3081,7 @@ void vpMbGenericTracker::reInitModel(const vpImage<unsigned char> &I, const std:
   \param T : optional transformation matrix (currently only for .cao).
 */
 void vpMbGenericTracker::reInitModel(const vpImage<vpRGBa> &I_color, const std::string &cad_name,
-                                     const vpHomogeneousMatrix &cMo, bool verbose,
+                                     const vpHomogeneousMatrix &cMo, int verbose,
                                      const vpHomogeneousMatrix &T)
 {
   if (m_mapOfTrackers.size() != 1) {
@@ -3123,7 +3126,7 @@ void vpMbGenericTracker::reInitModel(const vpImage<vpRGBa> &I_color, const std::
 void vpMbGenericTracker::reInitModel(const vpImage<unsigned char> &I1, const vpImage<unsigned char> &I2,
                                      const std::string &cad_name1, const std::string &cad_name2,
                                      const vpHomogeneousMatrix &c1Mo, const vpHomogeneousMatrix &c2Mo,
-                                     bool verbose,
+                                     int verbose,
                                      const vpHomogeneousMatrix &T1, const vpHomogeneousMatrix &T2)
 {
   if (m_mapOfTrackers.size() == 2) {
@@ -3170,7 +3173,7 @@ void vpMbGenericTracker::reInitModel(const vpImage<unsigned char> &I1, const vpI
 void vpMbGenericTracker::reInitModel(const vpImage<vpRGBa> &I_color1, const vpImage<vpRGBa> &I_color2,
                                      const std::string &cad_name1, const std::string &cad_name2,
                                      const vpHomogeneousMatrix &c1Mo, const vpHomogeneousMatrix &c2Mo,
-                                     bool verbose,
+                                     int verbose,
                                      const vpHomogeneousMatrix &T1, const vpHomogeneousMatrix &T2)
 {
   if (m_mapOfTrackers.size() == 2) {
@@ -3211,7 +3214,7 @@ void vpMbGenericTracker::reInitModel(const vpImage<vpRGBa> &I_color1, const vpIm
 void vpMbGenericTracker::reInitModel(const std::map<std::string, const vpImage<unsigned char> *> &mapOfImages,
                                      const std::map<std::string, std::string> &mapOfModelFiles,
                                      const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                                     bool verbose,
+                                     int verbose,
                                      const std::map<std::string, vpHomogeneousMatrix> &mapOfT)
 {
   std::map<std::string, TrackerWrapper *>::const_iterator it_tracker = m_mapOfTrackers.find(m_referenceCameraName);
@@ -3285,7 +3288,7 @@ void vpMbGenericTracker::reInitModel(const std::map<std::string, const vpImage<u
 void vpMbGenericTracker::reInitModel(const std::map<std::string, const vpImage<vpRGBa> *> &mapOfColorImages,
                                      const std::map<std::string, std::string> &mapOfModelFiles,
                                      const std::map<std::string, vpHomogeneousMatrix> &mapOfCameraPoses,
-                                     bool verbose,
+                                     int verbose,
                                      const std::map<std::string, vpHomogeneousMatrix> &mapOfT)
 {
   std::map<std::string, TrackerWrapper *>::const_iterator it_tracker = m_mapOfTrackers.find(m_referenceCameraName);
@@ -6210,10 +6213,10 @@ void vpMbGenericTracker::TrackerWrapper::initMbtTracking(const vpImage<unsigned 
   }
 }
 
-void vpMbGenericTracker::TrackerWrapper::loadConfigFile(const std::string &configFile)
+void vpMbGenericTracker::TrackerWrapper::loadConfigFile(const std::string &configFile, bool verbose)
 {
   // Load projection error config
-  vpMbTracker::loadConfigFile(configFile);
+  vpMbTracker::loadConfigFile(configFile, verbose);
 
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp((vpMbtXmlGenericParser::vpParserType)m_trackerType);
@@ -6250,7 +6253,9 @@ void vpMbGenericTracker::TrackerWrapper::loadConfigFile(const std::string &confi
   xmlp.setDepthDenseSamplingStepY(m_depthDenseSamplingStepY);
 
   try {
-    std::cout << " *********** Parsing XML for";
+    if (verbose) {
+      std::cout << " *********** Parsing XML for";
+    }
 
     std::vector<std::string> tracker_names;
     if (m_trackerType & EDGE_TRACKER)
@@ -6264,14 +6269,20 @@ void vpMbGenericTracker::TrackerWrapper::loadConfigFile(const std::string &confi
     if (m_trackerType & DEPTH_DENSE_TRACKER)
       tracker_names.push_back("Depth Dense");
 
-    for (size_t i = 0; i < tracker_names.size(); i++) {
-      std::cout << " " << tracker_names[i];
-      if (i == tracker_names.size() - 1) {
-        std::cout << " ";
+    if (verbose) {
+      for (size_t i = 0; i < tracker_names.size(); i++) {
+        std::cout << " " << tracker_names[i];
+        if (i == tracker_names.size() - 1) {
+          std::cout << " ";
+        }
+      }
+
+      if (verbose) {
+        std::cout << "Model-Based Tracker ************ " << std::endl;
       }
     }
 
-    std::cout << "Model-Based Tracker ************ " << std::endl;
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile);
   } catch (...) {
     throw vpException(vpException::ioError, "Can't open XML file \"%s\"\n ", configFile.c_str());
@@ -6520,7 +6531,7 @@ void vpMbGenericTracker::TrackerWrapper::preTracking(const vpImage<unsigned char
 }
 
 void vpMbGenericTracker::TrackerWrapper::reInitModel(const vpImage<unsigned char> * const I, const vpImage<vpRGBa> * const I_color,
-                                                     const std::string &cad_name, const vpHomogeneousMatrix &cMo, bool verbose,
+                                                     const std::string &cad_name, const vpHomogeneousMatrix &cMo, int verbose,
                                                      const vpHomogeneousMatrix &T)
 {
   m_cMo.eye();
@@ -6633,14 +6644,14 @@ void vpMbGenericTracker::TrackerWrapper::reInitModel(const vpImage<unsigned char
 }
 
 void vpMbGenericTracker::TrackerWrapper::reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
-                                                     const vpHomogeneousMatrix &cMo, bool verbose,
+                                                     const vpHomogeneousMatrix &cMo, int verbose,
                                                      const vpHomogeneousMatrix &T)
 {
   reInitModel(&I, NULL, cad_name, cMo, verbose, T);
 }
 
 void vpMbGenericTracker::TrackerWrapper::reInitModel(const vpImage<vpRGBa> &I_color, const std::string &cad_name,
-                                                     const vpHomogeneousMatrix &cMo, bool verbose,
+                                                     const vpHomogeneousMatrix &cMo, int verbose,
                                                      const vpHomogeneousMatrix &T)
 {
   reInitModel(NULL, &I_color, cad_name, cMo, verbose, T);

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -1458,12 +1458,12 @@ is not wrl or cao.
 
   \param modelFile : the file containing the the 3D model description.
   The extension of this file is either .wrl or .cao.
-  \param verbose : verbose option to print additional information when loading
-CAO model files which include other CAO model files.
+  \param verbose : verbose option (0: no print, 1: intermediate print, 2: full print)
+to print additional information when loading CAO model files which include other CAO model files.
   \param odTo : optional transformation matrix (currently only for .cao) to transform
   3D points expressed in the original object frame to the desired object frame.
 */
-void vpMbTracker::loadModel(const std::string &modelFile, bool verbose, const vpHomogeneousMatrix &odTo)
+void vpMbTracker::loadModel(const std::string &modelFile, int verbose, const vpHomogeneousMatrix &odTo)
 {
   std::string::const_iterator it;
 
@@ -1678,8 +1678,8 @@ std::map<std::string, std::string> vpMbTracker::parseParameters(std::string &end
   \param modelFile : Full name of the main *.cao file containing the model.
   \param vectorOfModelFilename : A vector of *.cao files.
   \param startIdFace : Current Id of the face.
-  \param verbose : If true, will print additional information with CAO model
-  files which include other CAO model files.
+  \param verbose : Print additional information (0: no print, 1: intermediate, 2: full)
+   with CAO model files which include other CAO model files.
   \param parent : This parameter is
   set to true when parsing a parent CAO model file, and false when parsing an
   included CAO model file.
@@ -1687,18 +1687,20 @@ std::map<std::string, std::string> vpMbTracker::parseParameters(std::string &end
   3D points expressed in the original object frame to the desired object frame.
 */
 void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::string> &vectorOfModelFilename,
-                               int &startIdFace, bool verbose, bool parent,
+                               int &startIdFace, int verbose, bool parent,
                                const vpHomogeneousMatrix &odTo)
 {
   std::ifstream fileId;
   fileId.exceptions(std::ifstream::failbit | std::ifstream::eofbit);
   fileId.open(modelFile.c_str(), std::ifstream::in);
   if (fileId.fail()) {
-    std::cout << "cannot read CAO model file: " << modelFile << std::endl;
+    if (verbose > 0) {
+      std::cout << "cannot read CAO model file: " << modelFile << std::endl;
+    }
     throw vpException(vpException::ioError, "cannot read CAO model file");
   }
 
-  if (verbose) {
+  if (verbose > 1) {
     std::cout << "Model file : " << modelFile << std::endl;
   }
   vectorOfModelFilename.push_back(modelFile);
@@ -1717,8 +1719,10 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
       fileId >> caoVersion;
       fileId.ignore(256, '\n'); // skip the rest of the line
     } else {
-      std::cout << "in vpMbTracker::loadCAOModel() -> Bad parameter header "
-                   "file : use V0, V1, ...";
+      if (verbose > 0) {
+        std::cout << "in vpMbTracker::loadCAOModel() -> Bad parameter header "
+                     "file : use V0, V1, ...";
+      }
       throw vpException(vpException::badValue, "in vpMbTracker::loadCAOModel() -> Bad parameter "
                                                "header file : use V0, V1, ...");
     }
@@ -1829,8 +1833,10 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
               throw vpException(vpException::ioError, "file cannot be open");
             }
           } else {
-            std::cout << "WARNING Cyclic dependency detected with file " << headerPath << " declared in " << modelFile
-                      << std::endl;
+            if (verbose > 0) {
+              std::cout << "WARNING Cyclic dependency detected with file " << headerPath << " declared in " << modelFile
+                        << std::endl;
+            }
           }
         }
       }
@@ -1846,7 +1852,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
     fileId.ignore(256, '\n'); // skip the rest of the line
 
     nbPoints += caoNbrPoint;
-    if (verbose || (parent && !header)) {
+    if (verbose > 1 || (verbose > 0 && (parent && !header))) {
       std::cout << "> " << caoNbrPoint << " points" << std::endl;
     }
 
@@ -1892,7 +1898,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
 
     nbLines += caoNbrLine;
     unsigned int *caoLinePoints = NULL;
-    if (verbose || (parent && !header)) {
+    if (verbose > 1 || (verbose > 0 && (parent && !header))) {
       std::cout << "> " << caoNbrLine << " lines" << std::endl;
     }
 
@@ -1970,7 +1976,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
     fileId.ignore(256, '\n'); // skip the rest of the line
 
     nbPolygonLines += caoNbrPolygonLine;
-    if (verbose || (parent && !header)) {
+    if (verbose > 1 || (verbose > 0 && (parent && !header))) {
       std::cout << "> " << caoNbrPolygonLine << " polygon lines" << std::endl;
     }
 
@@ -2055,7 +2061,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
     fileId.ignore(256, '\n'); // skip the rest of the line
 
     nbPolygonPoints += caoNbrPolygonPoint;
-    if (verbose || (parent && !header)) {
+    if (verbose > 1 || (verbose > 0 && (parent && !header))) {
       std::cout << "> " << caoNbrPolygonPoint << " polygon points" << std::endl;
     }
 
@@ -2124,7 +2130,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
       fileId.ignore(256, '\n'); // skip the rest of the line
 
       nbCylinders += caoNbCylinder;
-      if (verbose || (parent && !header)) {
+      if (verbose > 1 || (verbose > 0 && (parent && !header))) {
         std::cout << "> " << caoNbCylinder << " cylinders" << std::endl;
       }
 
@@ -2200,7 +2206,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
       fileId.ignore(256, '\n'); // skip the rest of the line
 
       nbCircles += caoNbCircle;
-      if (verbose || (parent && !header)) {
+      if (verbose > 1 || (verbose > 0 && (parent && !header))) {
         std::cout << "> " << caoNbCircle << " circles" << std::endl;
       }
 
@@ -2259,7 +2265,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
     delete[] caoLinePoints;
 
     if (header && parent) {
-      if (verbose) {
+      if (verbose > 1) {
         std::cout << "Global information for " << vpIoTools::getName(modelFile) << " :" << std::endl;
         std::cout << "Total nb of points : " << nbPoints << std::endl;
         std::cout << "Total nb of lines : " << nbLines << std::endl;
@@ -2267,7 +2273,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
         std::cout << "Total nb of polygon points : " << nbPolygonPoints << std::endl;
         std::cout << "Total nb of cylinders : " << nbCylinders << std::endl;
         std::cout << "Total nb of circles : " << nbCircles << std::endl;
-      } else {
+      } else if (verbose > 0) {
         std::cout << "> " << nbPoints << " points" << std::endl;
         std::cout << "> " << nbLines << " lines" << std::endl;
         std::cout << "> " << nbPolygonLines << " polygon lines" << std::endl;
@@ -3782,7 +3788,7 @@ void vpMbTracker::projectionErrorInitMovingEdge(const vpImage<unsigned char> &I,
   }
 }
 
-void vpMbTracker::loadConfigFile(const std::string &configFile)
+void vpMbTracker::loadConfigFile(const std::string &configFile, bool verbose)
 {
 #ifdef VISP_HAVE_PUGIXML
   vpMbtXmlGenericParser xmlp(vpMbtXmlGenericParser::PROJECTION_ERROR_PARSER);
@@ -3790,7 +3796,10 @@ void vpMbTracker::loadConfigFile(const std::string &configFile)
   xmlp.setProjectionErrorKernelSize(m_projectionErrorKernelSize);
 
   try {
-    std::cout << " *********** Parsing XML for ME projection error ************ " << std::endl;
+    if (verbose) {
+      std::cout << " *********** Parsing XML for ME projection error ************ " << std::endl;
+    }
+    xmlp.setVerbose(verbose);
     xmlp.parse(configFile);
   } catch (...) {
     throw vpException(vpException::ioError, "Cannot open XML file \"%s\"", configFile.c_str());

--- a/modules/tracker/mbt/src/vpMbtXmlGenericParser.cpp
+++ b/modules/tracker/mbt/src/vpMbtXmlGenericParser.cpp
@@ -49,7 +49,7 @@ class vpMbtXmlGenericParser::Impl
 {
 public:
   Impl(int type = EDGE_PARSER) :
-        m_parserType(type),
+        m_parserType(type), m_verbose(true),
         //<camera>
         m_cam(),
         //<face>
@@ -165,68 +165,70 @@ public:
       }
     }
 
-    if (m_parserType == PROJECTION_ERROR_PARSER) {
-      if (!projection_error_node) {
-        std::cout << "projection_error : sample_step : " << m_projectionErrorMe.getSampleStep() << " (default)" << std::endl;
-        std::cout << "projection_error : kernel_size : " << m_projectionErrorKernelSize*2+1 << "x"
-                  << m_projectionErrorKernelSize*2+1 << " (default)" << std::endl;
-      }
-    } else {
-      if (!camera_node) {
-        std::cout << "camera : u0 : " << m_cam.get_u0() << " (default)" << std::endl;
-        std::cout << "camera : v0 : " << m_cam.get_v0() << " (default)" << std::endl;
-        std::cout << "camera : px : " << m_cam.get_px() << " (default)" << std::endl;
-        std::cout << "camera : py : " << m_cam.get_py() << " (default)" << std::endl;
-      }
+    if (m_verbose) {
+      if (m_parserType == PROJECTION_ERROR_PARSER) {
+        if (!projection_error_node) {
+          std::cout << "projection_error : sample_step : " << m_projectionErrorMe.getSampleStep() << " (default)" << std::endl;
+          std::cout << "projection_error : kernel_size : " << m_projectionErrorKernelSize*2+1 << "x"
+                    << m_projectionErrorKernelSize*2+1 << " (default)" << std::endl;
+        }
+      } else {
+        if (!camera_node) {
+          std::cout << "camera : u0 : " << m_cam.get_u0() << " (default)" << std::endl;
+          std::cout << "camera : v0 : " << m_cam.get_v0() << " (default)" << std::endl;
+          std::cout << "camera : px : " << m_cam.get_px() << " (default)" << std::endl;
+          std::cout << "camera : py : " << m_cam.get_py() << " (default)" << std::endl;
+        }
 
-      if (!face_node) {
-        std::cout << "face : Angle Appear : " << m_angleAppear << " (default)" << std::endl;
-        std::cout << "face : Angle Disappear : " << m_angleDisappear << " (default)" << std::endl;
-      }
+        if (!face_node) {
+          std::cout << "face : Angle Appear : " << m_angleAppear << " (default)" << std::endl;
+          std::cout << "face : Angle Disappear : " << m_angleDisappear << " (default)" << std::endl;
+        }
 
-      if (!lod_node) {
-        std::cout << "lod : use lod : " << m_useLod << " (default)" << std::endl;
-        std::cout << "lod : min line length threshold : " << m_minLineLengthThreshold << " (default)" << std::endl;
-        std::cout << "lod : min polygon area threshold : " << m_minPolygonAreaThreshold << " (default)" << std::endl;
-      }
+        if (!lod_node) {
+          std::cout << "lod : use lod : " << m_useLod << " (default)" << std::endl;
+          std::cout << "lod : min line length threshold : " << m_minLineLengthThreshold << " (default)" << std::endl;
+          std::cout << "lod : min polygon area threshold : " << m_minPolygonAreaThreshold << " (default)" << std::endl;
+        }
 
-      if (!ecm_node && (m_parserType & EDGE_PARSER)) {
-        std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << " (default)" << std::endl;
-        std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << " (default)" << std::endl;
-        std::cout << "ecm : range : tracking : " << m_ecm.getRange() << " (default)" << std::endl;
-        std::cout << "ecm : contrast : threshold : " << m_ecm.getThreshold() << " (default)" << std::endl;
-        std::cout << "ecm : contrast : mu1 : " << m_ecm.getMu1() << " (default)" << std::endl;
-        std::cout << "ecm : contrast : mu2 : " << m_ecm.getMu2() << " (default)" << std::endl;
-        std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
-      }
+        if (!ecm_node && (m_parserType & EDGE_PARSER)) {
+          std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << " (default)" << std::endl;
+          std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << " (default)" << std::endl;
+          std::cout << "ecm : range : tracking : " << m_ecm.getRange() << " (default)" << std::endl;
+          std::cout << "ecm : contrast : threshold : " << m_ecm.getThreshold() << " (default)" << std::endl;
+          std::cout << "ecm : contrast : mu1 : " << m_ecm.getMu1() << " (default)" << std::endl;
+          std::cout << "ecm : contrast : mu2 : " << m_ecm.getMu2() << " (default)" << std::endl;
+          std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
+        }
 
-      if (!klt_node && (m_parserType & KLT_PARSER)) {
-        std::cout << "klt : Mask Border : " << m_kltMaskBorder << " (default)" << std::endl;
-        std::cout << "klt : Max Features : " << m_kltMaxFeatures << " (default)" << std::endl;
-        std::cout << "klt : Windows Size : " << m_kltWinSize << " (default)" << std::endl;
-        std::cout << "klt : Quality : " << m_kltQualityValue << " (default)" << std::endl;
-        std::cout << "klt : Min Distance : " << m_kltMinDist << " (default)" << std::endl;
-        std::cout << "klt : Harris Parameter : " << m_kltHarrisParam << " (default)" << std::endl;
-        std::cout << "klt : Block Size : " << m_kltBlockSize << " (default)" << std::endl;
-        std::cout << "klt : Pyramid Levels : " << m_kltPyramidLevels << " (default)" << std::endl;
-      }
+        if (!klt_node && (m_parserType & KLT_PARSER)) {
+          std::cout << "klt : Mask Border : " << m_kltMaskBorder << " (default)" << std::endl;
+          std::cout << "klt : Max Features : " << m_kltMaxFeatures << " (default)" << std::endl;
+          std::cout << "klt : Windows Size : " << m_kltWinSize << " (default)" << std::endl;
+          std::cout << "klt : Quality : " << m_kltQualityValue << " (default)" << std::endl;
+          std::cout << "klt : Min Distance : " << m_kltMinDist << " (default)" << std::endl;
+          std::cout << "klt : Harris Parameter : " << m_kltHarrisParam << " (default)" << std::endl;
+          std::cout << "klt : Block Size : " << m_kltBlockSize << " (default)" << std::endl;
+          std::cout << "klt : Pyramid Levels : " << m_kltPyramidLevels << " (default)" << std::endl;
+        }
 
-      if (!depth_normal_node && (m_parserType & DEPTH_NORMAL_PARSER)) {
-        std::cout << "depth normal : feature_estimation_method : " << m_depthNormalFeatureEstimationMethod << " (default)"
-                  << std::endl;
-        std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
-                  << " (default)" << std::endl;
-        std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
-                  << " (default)" << std::endl;
-        std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
-                  << m_depthNormalPclPlaneEstimationRansacThreshold << " (default)" << std::endl;
-        std::cout << "depth normal : sampling_step : step_X " << m_depthNormalSamplingStepX << " (default)" << std::endl;
-        std::cout << "depth normal : sampling_step : step_Y " << m_depthNormalSamplingStepY << " (default)" << std::endl;
-      }
+        if (!depth_normal_node && (m_parserType & DEPTH_NORMAL_PARSER)) {
+          std::cout << "depth normal : feature_estimation_method : " << m_depthNormalFeatureEstimationMethod << " (default)"
+                    << std::endl;
+          std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
+                    << " (default)" << std::endl;
+          std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
+                    << " (default)" << std::endl;
+          std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
+                    << m_depthNormalPclPlaneEstimationRansacThreshold << " (default)" << std::endl;
+          std::cout << "depth normal : sampling_step : step_X " << m_depthNormalSamplingStepX << " (default)" << std::endl;
+          std::cout << "depth normal : sampling_step : step_Y " << m_depthNormalSamplingStepY << " (default)" << std::endl;
+        }
 
-      if (!depth_dense_node && (m_parserType & DEPTH_DENSE_PARSER)) {
-        std::cout << "depth dense : sampling_step : step_X " << m_depthDenseSamplingStepX << " (default)" << std::endl;
-        std::cout << "depth dense : sampling_step : step_Y " << m_depthDenseSamplingStepY << " (default)" << std::endl;
+        if (!depth_dense_node && (m_parserType & DEPTH_DENSE_PARSER)) {
+          std::cout << "depth dense : sampling_step : step_X " << m_depthDenseSamplingStepX << " (default)" << std::endl;
+          std::cout << "depth dense : sampling_step : step_Y " << m_depthDenseSamplingStepY << " (default)" << std::endl;
+        }
       }
     }
   }
@@ -283,25 +285,27 @@ public:
 
     m_cam.initPersProjWithoutDistortion(d_px, d_py, d_u0, d_v0);
 
-    if (!u0_node)
-      std::cout << "camera : u0 : " << m_cam.get_u0() << " (default)" << std::endl;
-    else
-      std::cout << "camera : u0 : " << m_cam.get_u0() << std::endl;
+    if (m_verbose) {
+      if (!u0_node)
+        std::cout << "camera : u0 : " << m_cam.get_u0() << " (default)" << std::endl;
+      else
+        std::cout << "camera : u0 : " << m_cam.get_u0() << std::endl;
 
-    if (!v0_node)
-      std::cout << "camera : v0 : " << m_cam.get_v0() << " (default)" << std::endl;
-    else
-      std::cout << "camera : v0 : " << m_cam.get_v0() << std::endl;
+      if (!v0_node)
+        std::cout << "camera : v0 : " << m_cam.get_v0() << " (default)" << std::endl;
+      else
+        std::cout << "camera : v0 : " << m_cam.get_v0() << std::endl;
 
-    if (!px_node)
-      std::cout << "camera : px : " << m_cam.get_px() << " (default)" << std::endl;
-    else
-      std::cout << "camera : px : " << m_cam.get_px() << std::endl;
+      if (!px_node)
+        std::cout << "camera : px : " << m_cam.get_px() << " (default)" << std::endl;
+      else
+        std::cout << "camera : px : " << m_cam.get_px() << std::endl;
 
-    if (!py_node)
-      std::cout << "camera : py : " << m_cam.get_py() << " (default)" << std::endl;
-    else
-      std::cout << "camera : py : " << m_cam.get_py() << std::endl;
+      if (!py_node)
+        std::cout << "camera : py : " << m_cam.get_py() << " (default)" << std::endl;
+      else
+        std::cout << "camera : py : " << m_cam.get_py() << std::endl;
+    }
   }
 
   /*!
@@ -343,24 +347,26 @@ public:
       }
     }
 
-    if (!feature_estimation_method_node)
-      std::cout << "depth normal : feature_estimation_method : " << m_depthNormalFeatureEstimationMethod << " (default)"
-                << std::endl;
-    else
-      std::cout << "depth normal : feature_estimation_method : " << m_depthNormalFeatureEstimationMethod << std::endl;
+    if (m_verbose) {
+      if (!feature_estimation_method_node)
+        std::cout << "depth normal : feature_estimation_method : " << m_depthNormalFeatureEstimationMethod << " (default)"
+                  << std::endl;
+      else
+        std::cout << "depth normal : feature_estimation_method : " << m_depthNormalFeatureEstimationMethod << std::endl;
 
-    if (!PCL_plane_estimation_node) {
-      std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
-                << " (default)" << std::endl;
-      std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
-                << " (default)" << std::endl;
-      std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
-                << m_depthNormalPclPlaneEstimationRansacThreshold << " (default)" << std::endl;
-    }
+      if (!PCL_plane_estimation_node) {
+        std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
+                  << " (default)" << std::endl;
+        std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
+                  << " (default)" << std::endl;
+        std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
+                  << m_depthNormalPclPlaneEstimationRansacThreshold << " (default)" << std::endl;
+      }
 
-    if (!sampling_step_node) {
-      std::cout << "depth normal : sampling_step : step_X " << m_depthNormalSamplingStepX << " (default)" << std::endl;
-      std::cout << "depth normal : sampling_step : step_Y " << m_depthNormalSamplingStepY << " (default)" << std::endl;
+      if (!sampling_step_node) {
+        std::cout << "depth normal : sampling_step : step_X " << m_depthNormalSamplingStepX << " (default)" << std::endl;
+        std::cout << "depth normal : sampling_step : step_Y " << m_depthNormalSamplingStepY << " (default)" << std::endl;
+      }
     }
   }
 
@@ -402,26 +408,28 @@ public:
       }
     }
 
-    if (!PCL_plane_estimation_method_node)
-      std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
-                << " (default)" << std::endl;
-    else
-      std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
-                << std::endl;
+    if (m_verbose) {
+      if (!PCL_plane_estimation_method_node)
+        std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
+                  << " (default)" << std::endl;
+      else
+        std::cout << "depth normal : PCL_plane_estimation : method : " << m_depthNormalPclPlaneEstimationMethod
+                  << std::endl;
 
-    if (!PCL_plane_estimation_ransac_max_iter_node)
-      std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
-                << " (default)" << std::endl;
-    else
-      std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
-                << std::endl;
+      if (!PCL_plane_estimation_ransac_max_iter_node)
+        std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
+                  << " (default)" << std::endl;
+      else
+        std::cout << "depth normal : PCL_plane_estimation : max_iter : " << m_depthNormalPclPlaneEstimationRansacMaxIter
+                  << std::endl;
 
-    if (!PCL_plane_estimation_ransac_threshold_node)
-      std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
-                << m_depthNormalPclPlaneEstimationRansacThreshold << " (default)" << std::endl;
-    else
-      std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
-                << m_depthNormalPclPlaneEstimationRansacThreshold << std::endl;
+      if (!PCL_plane_estimation_ransac_threshold_node)
+        std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
+                  << m_depthNormalPclPlaneEstimationRansacThreshold << " (default)" << std::endl;
+      else
+        std::cout << "depth normal : PCL_plane_estimation : ransac_threshold : "
+                  << m_depthNormalPclPlaneEstimationRansacThreshold << std::endl;
+    }
   }
 
   /*!
@@ -456,15 +464,17 @@ public:
       }
     }
 
-    if (!sampling_step_X_node)
-      std::cout << "depth normal : sampling_step : step_X : " << m_depthNormalSamplingStepX << " (default)" << std::endl;
-    else
-      std::cout << "depth normal : sampling_step : step_X : " << m_depthNormalSamplingStepX << std::endl;
+    if (m_verbose) {
+      if (!sampling_step_X_node)
+        std::cout << "depth normal : sampling_step : step_X : " << m_depthNormalSamplingStepX << " (default)" << std::endl;
+      else
+        std::cout << "depth normal : sampling_step : step_X : " << m_depthNormalSamplingStepX << std::endl;
 
-    if (!sampling_step_Y_node)
-      std::cout << "depth normal : sampling_step : step_Y : " << m_depthNormalSamplingStepY << " (default)" << std::endl;
-    else
-      std::cout << "depth normal : sampling_step : step_Y : " << m_depthNormalSamplingStepY << std::endl;
+      if (!sampling_step_Y_node)
+        std::cout << "depth normal : sampling_step : step_Y : " << m_depthNormalSamplingStepY << " (default)" << std::endl;
+      else
+        std::cout << "depth normal : sampling_step : step_Y : " << m_depthNormalSamplingStepY << std::endl;
+    }
   }
 
   /*!
@@ -493,9 +503,11 @@ public:
       }
     }
 
-    if (!sampling_step_node) {
-      std::cout << "depth dense : sampling_step : step_X " << m_depthDenseSamplingStepX << " (default)" << std::endl;
-      std::cout << "depth dense : sampling_step : step_Y " << m_depthDenseSamplingStepY << " (default)" << std::endl;
+    if (m_verbose) {
+      if (!sampling_step_node) {
+        std::cout << "depth dense : sampling_step : step_X " << m_depthDenseSamplingStepX << " (default)" << std::endl;
+        std::cout << "depth dense : sampling_step : step_Y " << m_depthDenseSamplingStepY << " (default)" << std::endl;
+      }
     }
   }
 
@@ -531,15 +543,17 @@ public:
       }
     }
 
-    if (!sampling_step_X_node)
-      std::cout << "depth dense : sampling_step : step_X : " << m_depthDenseSamplingStepX << " (default)" << std::endl;
-    else
-      std::cout << "depth dense : sampling_step : step_X : " << m_depthDenseSamplingStepX << std::endl;
+    if (m_verbose) {
+      if (!sampling_step_X_node)
+        std::cout << "depth dense : sampling_step : step_X : " << m_depthDenseSamplingStepX << " (default)" << std::endl;
+      else
+        std::cout << "depth dense : sampling_step : step_X : " << m_depthDenseSamplingStepX << std::endl;
 
-    if (!sampling_step_Y_node)
-      std::cout << "depth dense : sampling_step : step_Y : " << m_depthDenseSamplingStepY << " (default)" << std::endl;
-    else
-      std::cout << "depth dense : sampling_step : step_Y : " << m_depthDenseSamplingStepY << std::endl;
+      if (!sampling_step_Y_node)
+        std::cout << "depth dense : sampling_step : step_Y : " << m_depthDenseSamplingStepY << " (default)" << std::endl;
+      else
+        std::cout << "depth dense : sampling_step : step_Y : " << m_depthDenseSamplingStepY << std::endl;
+    }
   }
 
   /*!
@@ -586,23 +600,25 @@ public:
       }
     }
 
-    if (!mask_node) {
-      std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << " (default)" << std::endl;
-      std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << " (default)" << std::endl;
-    }
+    if (m_verbose) {
+      if (!mask_node) {
+        std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << " (default)" << std::endl;
+        std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << " (default)" << std::endl;
+      }
 
-    if (!range_node) {
-      std::cout << "ecm : range : tracking : " << m_ecm.getRange() << " (default)" << std::endl;
-    }
+      if (!range_node) {
+        std::cout << "ecm : range : tracking : " << m_ecm.getRange() << " (default)" << std::endl;
+      }
 
-    if (!contrast_node) {
-      std::cout << "ecm : contrast : threshold " << m_ecm.getThreshold() << " (default)" << std::endl;
-      std::cout << "ecm : contrast : mu1 " << m_ecm.getMu1() << " (default)" << std::endl;
-      std::cout << "ecm : contrast : mu2 " << m_ecm.getMu2() << " (default)" << std::endl;
-    }
+      if (!contrast_node) {
+        std::cout << "ecm : contrast : threshold " << m_ecm.getThreshold() << " (default)" << std::endl;
+        std::cout << "ecm : contrast : mu1 " << m_ecm.getMu1() << " (default)" << std::endl;
+        std::cout << "ecm : contrast : mu2 " << m_ecm.getMu2() << " (default)" << std::endl;
+      }
 
-    if (!sample_node) {
-      std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
+      if (!sample_node) {
+        std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
+      }
     }
   }
 
@@ -653,20 +669,22 @@ public:
     m_ecm.setMu2(d_mu2);
     m_ecm.setThreshold(d_edge_threshold);
 
-    if (!edge_threshold_node)
-      std::cout << "ecm : contrast : threshold " << m_ecm.getThreshold() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : contrast : threshold " << m_ecm.getThreshold() << std::endl;
+    if (m_verbose) {
+      if (!edge_threshold_node)
+        std::cout << "ecm : contrast : threshold " << m_ecm.getThreshold() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : contrast : threshold " << m_ecm.getThreshold() << std::endl;
 
-    if (!mu1_node)
-      std::cout << "ecm : contrast : mu1 " << m_ecm.getMu1() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : contrast : mu1 " << m_ecm.getMu1() << std::endl;
+      if (!mu1_node)
+        std::cout << "ecm : contrast : mu1 " << m_ecm.getMu1() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : contrast : mu1 " << m_ecm.getMu1() << std::endl;
 
-    if (!mu2_node)
-      std::cout << "ecm : contrast : mu2 " << m_ecm.getMu2() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : contrast : mu2 " << m_ecm.getMu2() << std::endl;
+      if (!mu2_node)
+        std::cout << "ecm : contrast : mu2 " << m_ecm.getMu2() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : contrast : mu2 " << m_ecm.getMu2() << std::endl;
+    }
   }
 
   /*!
@@ -714,15 +732,17 @@ public:
                                                "from zero in xml file"));
     m_ecm.setMaskNumber(d_nb_mask);
 
-    if (!size_node)
-      std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << std::endl;
+    if (m_verbose) {
+      if (!size_node)
+        std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : mask : size : " << m_ecm.getMaskSize() << std::endl;
 
-    if (!nb_mask_node)
-      std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << std::endl;
+      if (!nb_mask_node)
+        std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : mask : nb_mask : " << m_ecm.getMaskNumber() << std::endl;
+    }
   }
 
   /*!
@@ -756,10 +776,12 @@ public:
 
     m_ecm.setRange(m_range_tracking);
 
-    if (!tracking_node)
-      std::cout << "ecm : range : tracking : " << m_ecm.getRange() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : range : tracking : " << m_ecm.getRange() << std::endl;
+    if (m_verbose) {
+      if (!tracking_node)
+        std::cout << "ecm : range : tracking : " << m_ecm.getRange() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : range : tracking : " << m_ecm.getRange() << std::endl;
+    }
   }
 
   /*!
@@ -793,10 +815,12 @@ public:
 
     m_ecm.setSampleStep(d_stp);
 
-    if (!step_node)
-      std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
-    else
-      std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << std::endl;
+    if (m_verbose) {
+      if (!step_node)
+        std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
+      else
+        std::cout << "ecm : sample : sample_step : " << m_ecm.getSampleStep() << std::endl;
+    }
   }
 
   /*!
@@ -856,27 +880,29 @@ public:
       }
     }
 
-    if (!angle_appear_node)
-      std::cout << "face : Angle Appear : " << m_angleAppear << " (default)" << std::endl;
-    else
-      std::cout << "face : Angle Appear : " << m_angleAppear << std::endl;
-
-    if (!angle_disappear_node)
-      std::cout << "face : Angle Disappear : " << m_angleDisappear << " (default)" << std::endl;
-    else
-      std::cout << "face : Angle Disappear : " << m_angleDisappear << std::endl;
-
-    if (near_clipping_node)
-      std::cout << "face : Near Clipping : " << m_nearClipping << std::endl;
-
-    if (far_clipping_node)
-      std::cout << "face : Far Clipping : " << m_farClipping << std::endl;
-
-    if (fov_clipping_node) {
-      if (m_fovClipping)
-        std::cout << "face : Fov Clipping : True" << std::endl;
+    if (m_verbose) {
+      if (!angle_appear_node)
+        std::cout << "face : Angle Appear : " << m_angleAppear << " (default)" << std::endl;
       else
-        std::cout << "face : Fov Clipping : False" << std::endl;
+        std::cout << "face : Angle Appear : " << m_angleAppear << std::endl;
+
+      if (!angle_disappear_node)
+        std::cout << "face : Angle Disappear : " << m_angleDisappear << " (default)" << std::endl;
+      else
+        std::cout << "face : Angle Disappear : " << m_angleDisappear << std::endl;
+
+      if (near_clipping_node)
+        std::cout << "face : Near Clipping : " << m_nearClipping << std::endl;
+
+      if (far_clipping_node)
+        std::cout << "face : Far Clipping : " << m_farClipping << std::endl;
+
+      if (fov_clipping_node) {
+        if (m_fovClipping)
+          std::cout << "face : Fov Clipping : True" << std::endl;
+        else
+          std::cout << "face : Fov Clipping : False" << std::endl;
+      }
     }
   }
 
@@ -948,45 +974,47 @@ public:
       }
     }
 
-    if (!mask_border_node)
-      std::cout << "klt : Mask Border : " << m_kltMaskBorder << " (default)" << std::endl;
-    else
-      std::cout << "klt : Mask Border : " << m_kltMaskBorder << std::endl;
+    if (m_verbose) {
+      if (!mask_border_node)
+        std::cout << "klt : Mask Border : " << m_kltMaskBorder << " (default)" << std::endl;
+      else
+        std::cout << "klt : Mask Border : " << m_kltMaskBorder << std::endl;
 
-    if (!max_features_node)
-      std::cout << "klt : Max Features : " << m_kltMaxFeatures << " (default)" << std::endl;
-    else
-      std::cout << "klt : Max Features : " << m_kltMaxFeatures << std::endl;
+      if (!max_features_node)
+        std::cout << "klt : Max Features : " << m_kltMaxFeatures << " (default)" << std::endl;
+      else
+        std::cout << "klt : Max Features : " << m_kltMaxFeatures << std::endl;
 
-    if (!window_size_node)
-      std::cout << "klt : Windows Size : " << m_kltWinSize << " (default)" << std::endl;
-    else
-      std::cout << "klt : Windows Size : " << m_kltWinSize << std::endl;
+      if (!window_size_node)
+        std::cout << "klt : Windows Size : " << m_kltWinSize << " (default)" << std::endl;
+      else
+        std::cout << "klt : Windows Size : " << m_kltWinSize << std::endl;
 
-    if (!quality_node)
-      std::cout << "klt : Quality : " << m_kltQualityValue << " (default)" << std::endl;
-    else
-      std::cout << "klt : Quality : " << m_kltQualityValue << std::endl;
+      if (!quality_node)
+        std::cout << "klt : Quality : " << m_kltQualityValue << " (default)" << std::endl;
+      else
+        std::cout << "klt : Quality : " << m_kltQualityValue << std::endl;
 
-    if (!min_distance_node)
-      std::cout << "klt : Min Distance : " << m_kltMinDist << " (default)" << std::endl;
-    else
-      std::cout << "klt : Min Distance : " << m_kltMinDist << std::endl;
+      if (!min_distance_node)
+        std::cout << "klt : Min Distance : " << m_kltMinDist << " (default)" << std::endl;
+      else
+        std::cout << "klt : Min Distance : " << m_kltMinDist << std::endl;
 
-    if (!harris_node)
-      std::cout << "klt : Harris Parameter : " << m_kltHarrisParam << " (default)" << std::endl;
-    else
-      std::cout << "klt : Harris Parameter : " << m_kltHarrisParam << std::endl;
+      if (!harris_node)
+        std::cout << "klt : Harris Parameter : " << m_kltHarrisParam << " (default)" << std::endl;
+      else
+        std::cout << "klt : Harris Parameter : " << m_kltHarrisParam << std::endl;
 
-    if (!size_block_node)
-      std::cout << "klt : Block Size : " << m_kltBlockSize << " (default)" << std::endl;
-    else
-      std::cout << "klt : Block Size : " << m_kltBlockSize << std::endl;
+      if (!size_block_node)
+        std::cout << "klt : Block Size : " << m_kltBlockSize << " (default)" << std::endl;
+      else
+        std::cout << "klt : Block Size : " << m_kltBlockSize << std::endl;
 
-    if (!pyramid_lvl_node)
-      std::cout << "klt : Pyramid Levels : " << m_kltPyramidLevels << " (default)" << std::endl;
-    else
-      std::cout << "klt : Pyramid Levels : " << m_kltPyramidLevels << std::endl;
+      if (!pyramid_lvl_node)
+        std::cout << "klt : Pyramid Levels : " << m_kltPyramidLevels << " (default)" << std::endl;
+      else
+        std::cout << "klt : Pyramid Levels : " << m_kltPyramidLevels << std::endl;
+    }
   }
 
   void read_lod(const pugi::xml_node &node)
@@ -1022,20 +1050,22 @@ public:
       }
     }
 
-    if (!use_lod_node)
-      std::cout << "lod : use lod : " << m_useLod << " (default)" << std::endl;
-    else
-      std::cout << "lod : use lod : " << m_useLod << std::endl;
+    if (m_verbose) {
+      if (!use_lod_node)
+        std::cout << "lod : use lod : " << m_useLod << " (default)" << std::endl;
+      else
+        std::cout << "lod : use lod : " << m_useLod << std::endl;
 
-    if (!min_line_length_threshold_node)
-      std::cout << "lod : min line length threshold : " << m_minLineLengthThreshold << " (default)" << std::endl;
-    else
-      std::cout << "lod : min line length threshold : " << m_minLineLengthThreshold << std::endl;
+      if (!min_line_length_threshold_node)
+        std::cout << "lod : min line length threshold : " << m_minLineLengthThreshold << " (default)" << std::endl;
+      else
+        std::cout << "lod : min line length threshold : " << m_minLineLengthThreshold << std::endl;
 
-    if (!min_polygon_area_threshold_node)
-      std::cout << "lod : min polygon area threshold : " << m_minPolygonAreaThreshold << " (default)" << std::endl;
-    else
-      std::cout << "lod : min polygon area threshold : " << m_minPolygonAreaThreshold << std::endl;
+      if (!min_polygon_area_threshold_node)
+        std::cout << "lod : min polygon area threshold : " << m_minPolygonAreaThreshold << " (default)" << std::endl;
+      else
+        std::cout << "lod : min polygon area threshold : " << m_minPolygonAreaThreshold << std::endl;
+    }
   }
 
   void read_projection_error(const pugi::xml_node &node)
@@ -1089,16 +1119,18 @@ public:
       std::cerr << "Unsupported kernel size." << std::endl;
     }
 
-    if (!step_node)
-      std::cout << "projection_error : sample_step : " << m_projectionErrorMe.getSampleStep() << " (default)" << std::endl;
-    else
-      std::cout << "projection_error : sample_step : " << m_projectionErrorMe.getSampleStep() << std::endl;
+    if (m_verbose) {
+      if (!step_node)
+        std::cout << "projection_error : sample_step : " << m_projectionErrorMe.getSampleStep() << " (default)" << std::endl;
+      else
+        std::cout << "projection_error : sample_step : " << m_projectionErrorMe.getSampleStep() << std::endl;
 
-    if (!kernel_size_node)
-      std::cout << "projection_error : kernel_size : " << m_projectionErrorKernelSize*2+1 << "x"
-                << m_projectionErrorKernelSize*2+1 << " (default)" << std::endl;
-    else
-      std::cout << "projection_error : kernel_size : " << kernel_size_str << std::endl;
+      if (!kernel_size_node)
+        std::cout << "projection_error : kernel_size : " << m_projectionErrorKernelSize*2+1 << "x"
+                  << m_projectionErrorKernelSize*2+1 << " (default)" << std::endl;
+      else
+        std::cout << "projection_error : kernel_size : " << kernel_size_str << std::endl;
+    }
   }
 
   /*!
@@ -1133,13 +1165,15 @@ public:
 
     m_ecm.setSampleStep(d_stp);
 
-    if (!step_node)
-      std::cout << "[DEPRECATED] sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
-    else
-      std::cout << "[DEPRECATED] sample : sample_step : " << m_ecm.getSampleStep() << std::endl;
+    if (m_verbose) {
+      if (!step_node)
+        std::cout << "[DEPRECATED] sample : sample_step : " << m_ecm.getSampleStep() << " (default)" << std::endl;
+      else
+        std::cout << "[DEPRECATED] sample : sample_step : " << m_ecm.getSampleStep() << std::endl;
 
-    std::cout << "  WARNING : This node (sample) is deprecated." << std::endl;
-    std::cout << "  It should be moved in the ecm node (ecm : sample)." << std::endl;
+      std::cout << "  WARNING : This node (sample) is deprecated." << std::endl;
+      std::cout << "  It should be moved in the ecm node (ecm : sample)." << std::endl;
+    }
   }
 
   double getAngleAppear() const { return m_angleAppear; }
@@ -1236,9 +1270,13 @@ public:
   void setProjectionErrorMe(const vpMe &me) { m_projectionErrorMe = me; }
   void setProjectionErrorKernelSize(const unsigned int &kernel_size) { m_projectionErrorKernelSize = kernel_size; }
 
+  void setVerbose(bool verbose) { m_verbose = verbose; }
+
 protected:
   //! Parser type
   int m_parserType;
+  //! Verbose option
+  bool m_verbose;
   //! Camera parameters.
   vpCameraParameters m_cam;
   //! Angle to determine if a face appeared
@@ -1948,6 +1986,14 @@ void vpMbtXmlGenericParser::setProjectionErrorMe(const vpMe &me)
 void vpMbtXmlGenericParser::setProjectionErrorKernelSize(const unsigned int &size)
 {
   m_impl->setProjectionErrorKernelSize(size);
+}
+
+/*!
+  Set verbose option.
+*/
+void vpMbtXmlGenericParser::setVerbose(bool verbose)
+{
+  m_impl->setVerbose(verbose);
 }
 
 #elif !defined(VISP_BUILD_SHARED_LIBS)

--- a/modules/tracker/mbt/test/perfGenericTracker.cpp
+++ b/modules/tracker/mbt/test/perfGenericTracker.cpp
@@ -1,0 +1,327 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Benchmark generic tracker.
+ *
+ *****************************************************************************/
+
+#include <visp3/core/vpConfig.h>
+
+#if defined(VISP_HAVE_CATCH2) && defined(VISP_HAVE_PUGIXML)
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+#include <visp3/core/vpIoTools.h>
+#include <visp3/io/vpImageIo.h>
+#include <visp3/mbt/vpMbGenericTracker.h>
+
+//#define DEBUG_DISPLAY // uncomment to check that the tracking is correct
+#ifdef DEBUG_DISPLAY
+#include <visp3/gui/vpDisplayX.h>
+#endif
+
+namespace
+{
+bool runBenchmark = false;
+
+template <typename Type>
+bool read_data(const std::string &input_directory, int cpt, const vpCameraParameters &cam_depth,
+               vpImage<Type> &I, vpImage<uint16_t> &I_depth,
+               std::vector<vpColVector> &pointcloud, vpHomogeneousMatrix &cMo)
+{
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  static_assert(std::is_same<Type, unsigned char>::value || std::is_same<Type, vpRGBa>::value,
+                "Template function supports only unsigned char and vpRGBa images!");
+#endif
+  char buffer[256];
+  sprintf(buffer, std::string(input_directory + "/Images/Image_%04d.pgm").c_str(), cpt);
+  std::string image_filename = buffer;
+
+  sprintf(buffer, std::string(input_directory + "/Depth/Depth_%04d.bin").c_str(), cpt);
+  std::string depth_filename = buffer;
+
+  sprintf(buffer, std::string(input_directory + "/CameraPose/Camera_%03d.txt").c_str(), cpt);
+  std::string pose_filename = buffer;
+
+  if (!vpIoTools::checkFilename(image_filename) || !vpIoTools::checkFilename(depth_filename)
+      || !vpIoTools::checkFilename(pose_filename))
+    return false;
+
+  vpImageIo::read(I, image_filename);
+
+  unsigned int depth_width = 0, depth_height = 0;
+  std::ifstream file_depth(depth_filename.c_str(), std::ios::in | std::ios::binary);
+  if (!file_depth.is_open())
+    return false;
+
+  vpIoTools::readBinaryValueLE(file_depth, depth_height);
+  vpIoTools::readBinaryValueLE(file_depth, depth_width);
+  I_depth.resize(depth_height, depth_width);
+  pointcloud.resize(depth_height*depth_width);
+
+  const float depth_scale = 0.000030518f;
+  for (unsigned int i = 0; i < I_depth.getHeight(); i++) {
+    for (unsigned int j = 0; j < I_depth.getWidth(); j++) {
+      vpIoTools::readBinaryValueLE(file_depth, I_depth[i][j]);
+      double x = 0.0, y = 0.0, Z = I_depth[i][j] * depth_scale;
+      vpPixelMeterConversion::convertPoint(cam_depth, j, i, x, y);
+      vpColVector pt3d(4, 1.0);
+      pt3d[0] = x*Z;
+      pt3d[1] = y*Z;
+      pt3d[2] = Z;
+      pointcloud[i*I_depth.getWidth()+j] = pt3d;
+    }
+  }
+
+  std::ifstream file_pose(pose_filename.c_str());
+  if (!file_pose.is_open()) {
+    return false;
+  }
+
+  for (unsigned int i = 0; i < 4; i++) {
+    for (unsigned int j = 0; j < 4; j++) {
+      file_pose >> cMo[i][j];
+    }
+  }
+
+  return true;
+}
+} //anonymous namespace
+
+TEST_CASE("Benchmark generic tracker", "[benchmark]") {
+  if (runBenchmark) {
+    std::vector<int> tracker_type(2);
+    tracker_type[0] = vpMbGenericTracker::EDGE_TRACKER;
+    tracker_type[1] = vpMbGenericTracker::DEPTH_DENSE_TRACKER;
+    vpMbGenericTracker tracker(tracker_type);
+
+    const std::string input_directory = vpIoTools::createFilePath(vpIoTools::getViSPImagesDataPath(), "mbt-depth/Castle-simu");
+    const std::string configFileCam1 = input_directory + std::string("/Config/chateau.xml");
+    const std::string configFileCam2 = input_directory + std::string("/Config/chateau_depth.xml");
+    tracker.loadConfigFile(configFileCam1, configFileCam2);
+    tracker.loadModel(input_directory + "/Models/chateau.cao", input_directory + "/Models/chateau.cao");
+
+    vpHomogeneousMatrix T;
+    T[0][0] = -1;
+    T[0][3] = -0.2;
+    T[1][1] = 0;
+    T[1][2] = 1;
+    T[1][3] = 0.12;
+    T[2][1] = 1;
+    T[2][2] = 0;
+    T[2][3] = -0.15;
+    tracker.loadModel(input_directory + "/Models/cube.cao", false, T);
+
+    vpImage<unsigned char> I;
+    vpImage<uint16_t> I_depth_raw;
+    vpHomogeneousMatrix cMo_truth;
+    std::vector<vpColVector> pointcloud;
+
+    vpCameraParameters cam_color, cam_depth;
+    tracker.getCameraParameters(cam_color, cam_depth);
+
+    vpHomogeneousMatrix depth_M_color;
+    depth_M_color[0][3] = -0.05;
+    tracker.setCameraTransformationMatrix("Camera2", depth_M_color);
+
+    // load all the data in memory to not take into account I/O from disk
+    std::vector<vpImage<unsigned char>> images;
+    std::vector<vpImage<uint16_t>> depth_raws;
+    std::vector<std::vector<vpColVector>> pointclouds;
+    std::vector<vpHomogeneousMatrix> cMo_truth_all;
+    // forward
+    for (int i = 1; i <= 40; i++) {
+      if (read_data(input_directory, i, cam_depth, I, I_depth_raw, pointcloud, cMo_truth)) {
+        images.push_back(I);
+        depth_raws.push_back(I_depth_raw);
+        pointclouds.push_back(pointcloud);
+        cMo_truth_all.push_back(cMo_truth);
+      }
+    }
+    // backward
+    for (int i = 40; i >= 1; i--) {
+      if (read_data(input_directory, i, cam_depth, I, I_depth_raw, pointcloud, cMo_truth)) {
+        images.push_back(I);
+        depth_raws.push_back(I_depth_raw);
+        pointclouds.push_back(pointcloud);
+        cMo_truth_all.push_back(cMo_truth);
+      }
+    }
+
+    // Stereo MBT
+    {
+      std::vector<std::map<std::string, int>> mapOfTrackerTypes;
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+  #if defined(VISP_HAVE_OPENCV)
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::KLT_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+  #endif
+
+      std::vector<std::string> benchmarkNames = {
+        "Edge MBT",
+        "Edge + Depth dense MBT",
+  #if defined(VISP_HAVE_OPENCV)
+        "KLT MBT",
+        "KLT + depth dense MBT",
+        "Edge + KLT + depth dense MBT"
+  #endif
+      };
+
+      std::vector<bool> monoculars = {
+        true,
+        false,
+  #if defined(VISP_HAVE_OPENCV)
+        true,
+        false,
+        false
+  #endif
+      };
+
+      for (size_t idx = 0; idx < mapOfTrackerTypes.size(); idx++) {
+        tracker.resetTracker();
+        tracker.setTrackerType(mapOfTrackerTypes[idx]);
+
+        const int verbose = 0;
+        tracker.loadConfigFile(configFileCam1, configFileCam2, verbose);
+        tracker.loadModel(input_directory + "/Models/chateau.cao", input_directory + "/Models/chateau.cao", verbose);
+        tracker.loadModel(input_directory + "/Models/cube.cao", verbose, T);
+        tracker.initFromPose(images.front(), cMo_truth_all.front());
+
+        std::map<std::string, unsigned int> mapOfWidths, mapOfHeights;
+        mapOfWidths["Camera2"] = monoculars[idx] ? 0 : I_depth_raw.getWidth();
+        mapOfHeights["Camera2"] = monoculars[idx] ? 0 : I_depth_raw.getHeight();
+
+        vpHomogeneousMatrix cMo;
+    #ifndef DEBUG_DISPLAY
+        BENCHMARK(benchmarkNames[idx].c_str())
+    #else
+        vpImage<unsigned char> I_depth;
+        vpImageConvert::createDepthHistogram(I_depth_raw, I_depth);
+
+        vpDisplayX d_color(I, 0, 0, "Color image");
+        vpDisplayX d_depth(I_depth, I.getWidth(), 0, "Depth image");
+        tracker.setDisplayFeatures(true);
+    #endif
+        {
+          tracker.initFromPose(images.front(), cMo_truth_all.front());
+
+          for (size_t i = 0; i < images.size(); i++) {
+            const vpImage<unsigned char>& I_current = images[i];
+            const std::vector<vpColVector>& pointcloud_current = pointclouds[i];
+
+      #ifdef DEBUG_DISPLAY
+            vpImageConvert::createDepthHistogram(depth_raws[i], I_depth);
+            I = I_current;
+            vpDisplay::display(I);
+            vpDisplay::display(I_depth);
+      #endif
+
+            std::map<std::string, const vpImage<unsigned char> *> mapOfImages;
+            mapOfImages["Camera1"] = &I_current;
+
+            std::map<std::string, const std::vector<vpColVector> *> mapOfPointclouds;
+            mapOfPointclouds["Camera2"] = &pointcloud_current;
+
+            tracker.track(mapOfImages, mapOfPointclouds, mapOfWidths, mapOfHeights);
+            cMo = tracker.getPose();
+
+      #ifdef DEBUG_DISPLAY
+            tracker.display(I, I_depth, cMo, depth_M_color*cMo, cam_color, cam_depth, vpColor::red, 3);
+            vpDisplay::displayFrame(I, cMo, cam_color, 0.05, vpColor::none, 3);
+            vpDisplay::displayFrame(I_depth, depth_M_color*cMo, cam_depth, 0.05, vpColor::none, 3);
+            vpDisplay::displayText(I, 20, 20, benchmarkNames[idx], vpColor::red);
+            vpDisplay::displayText(I, 40, 20, std::string("Nb features: " + std::to_string(tracker.getError().getRows())), vpColor::red);
+
+            vpDisplay::flush(I);
+            vpDisplay::flush(I_depth);
+            vpTime::wait(33);
+      #endif
+          }
+
+    #ifndef DEBUG_DISPLAY
+          return cMo;
+        };
+    #else
+        }
+    #endif
+
+        vpPoseVector pose_est(cMo);
+        vpPoseVector pose_truth(cMo_truth);
+        vpColVector t_err(3), tu_err(3);
+        for (unsigned int i = 0; i < 3; i++) {
+          t_err[i] = pose_est[i] - pose_truth[i];
+          tu_err[i] = pose_est[i+3] - pose_truth[i+3];
+        }
+
+        const double max_translation_error = 0.005;
+        const double max_rotation_error = 0.03;
+        CHECK(sqrt(t_err.sumSquare()) < max_translation_error);
+        CHECK(sqrt(tu_err.sumSquare()) < max_rotation_error);
+      }
+    }
+  } //if (runBenchmark)
+}
+
+int main(int argc, char *argv[])
+{
+  Catch::Session session; // There must be exactly one instance
+
+  // Build a new parser on top of Catch's
+  using namespace Catch::clara;
+  auto cli = session.cli()   // Get Catch's composite command line parser
+      | Opt(runBenchmark)    // bind variable to a new option, with a hint string
+      ["--benchmark"]        // the option names it will respond to
+      ("run benchmark comparing naive code with ViSP implementation");     // description string for the help output
+
+  // Now pass the new composite back to Catch so it uses that
+  session.cli(cli);
+
+  // Let Catch (using Clara) parse the command line
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+
+  // numFailed is clamped to 255 as some unices only use the lower 8 bits.
+  // This clamping has already been applied, so just return it here
+  // You can also do any post run clean-up here
+  return numFailed;
+}
+#else
+#include <iostream>
+
+int main()
+{
+  return 0;
+}
+#endif

--- a/script/PerfCompare.py
+++ b/script/PerfCompare.py
@@ -1,0 +1,118 @@
+from __future__ import print_function
+from __future__ import division
+
+import argparse
+from enum import Enum
+import xml.etree.ElementTree as ET
+from collections import OrderedDict
+
+def nanoToMilli(nano):
+    return nano / 1000
+
+class BenchmarkResult:
+    """BenchmarkResult class to hold perf numbers"""
+
+    def __init__(self, name, mean_value, mean_lower_bound, mean_upper_bound, \
+                 std_val, std_lower_bound, std_upper_bound):
+        self.name = name
+        self.mean_value = nanoToMilli(mean_value)
+        self.mean_lower_bound = nanoToMilli(mean_lower_bound)
+        self.mean_upper_bound = nanoToMilli(mean_upper_bound)
+        self.std_val = nanoToMilli(std_val)
+        self.std_lower_bound = nanoToMilli(std_lower_bound)
+        self.std_upper_bound = nanoToMilli(std_upper_bound)
+
+    def __str__(self):
+        return "BenchmarkResults %s\nmean value=%f, lowerBound=%f, upperBound=%f\nstd:%f, lowerBound=%f, upperBound=%f" \
+                % (self.name, self.mean_value, self.mean_lower_bound, self.mean_upper_bound, \
+                   self.std_val, self.std_lower_bound, self.std_upper_bound)
+
+class TestCase:
+    """TestCase class to hold the list of benchmark results"""
+
+    def __init__(self, name):
+        self.name = name
+        self.results = OrderedDict()
+
+    def __str__(self):
+        return "TestCase %s\nBenchmark result:\n%s" % (self.name, self.results)
+
+class Metric(Enum):
+    mean = 'mean'
+    lowMean = 'low_mean'
+    highMean = 'high_mean'
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--before", help="Path to XML perf log for before comparison.", required=True)
+parser.add_argument("--after", help="Path to XML perf log for after comparison.", required=True)
+parser.add_argument("--before-label", help="Label for before column.", default='Before')
+parser.add_argument("--after-label", help="Label for after column.", default='After')
+parser.add_argument("--metric", help="Benchmark metric (mean, low_mean, high_mean).", type=Metric, choices=list(Metric), default=Metric.mean)
+
+args = parser.parse_args()
+
+file_before = args.before
+file_after = args.after
+print('Path to XML perf log for before comparison:', file_before)
+print('Path to XML perf log for after comparison:', file_after)
+print()
+
+tree_before = ET.parse(file_before)
+tree_after = ET.parse(file_after)
+
+root_before = tree_before.getroot()
+root_after = tree_after.getroot()
+
+def loadResults(root):
+    results = OrderedDict()
+
+    for test_case in root.iter('TestCase'):
+        test_name = test_case.attrib['name']
+
+        current_test = TestCase(test_name)
+
+        for bench_res in test_case.iter('BenchmarkResults'):
+            bench_name = bench_res.attrib['name']
+
+            mean_node = bench_res.find('mean')
+            mean = float(mean_node.attrib['value'])
+            mean_lower = float(mean_node.attrib['lowerBound'])
+            mean_upper = float(mean_node.attrib['upperBound'])
+
+            std_node = bench_res.find('standardDeviation')
+            std = float(std_node.attrib['value'])
+            std_lower = float(std_node.attrib['lowerBound'])
+            std_upper = float(std_node.attrib['upperBound'])
+
+            current_test.results[bench_name] = BenchmarkResult(bench_name, mean, mean_lower, mean_upper, std, std_lower, std_upper)
+
+        results[test_name] = current_test
+
+    return results
+
+results_before = loadResults(root_before)
+results_after = loadResults(root_after)
+
+for r_before_name, r_before in results_before.items():
+    print('| {} | {} | {} | Speed-up |'.format(r_before_name, args.before_label, args.after_label))
+    print('| --- | --- | --- | --- |')
+    if r_before_name in results_after:
+        r_after = results_after[r_before_name]
+
+        for b_before_name, b_before in r_before.results.items():
+            if b_before_name in r_after.results:
+                b_after = r_after.results[b_before_name]
+
+                metric_before = b_before.mean_value
+                metric_after = b_after.mean_value
+
+                if args.metric == Metric.lowMean:
+                    metric_before = b_before.mean_lower_bound
+                    metric_after = b_after.mean_lower_bound
+                elif args.metric == Metric.highMean:
+                    metric_before = b_before.mean_upper_bound
+                    metric_after = b_after.mean_upper_bound
+
+                speed_up = metric_before / metric_after
+                print('| {} | {:.2f} | {:.2f} | {:.2f} |'.format(b_before_name, metric_before, metric_after, speed_up))
+        print()


### PR DESCRIPTION
Add verbose option to avoid having print info when loading a config file or a CAO model for MBT.
Good solution would be to adopt a logger library in ViSP. This would allow having `INFO`, `WARNING`, `ERROR` print info instead of the current `std::cout` / `std::cerr` code.

We should completely remove `vpMbEdgeKltMultiTracker`, `vpMbEdgeMultiTracker`, `vpMbKltMultiTracker` classes. As soon as we add or modify something in `vpMbTracker` or `vpMbGenericTracker`, we have to update these obsolete classes.

Also, I am wondering if the copy constructor and the assignment operator for `vpMbTracker` or `vpMbGenericTracker` should not be made private? I am remembering that something like:
```
vpMbGenericTracker *tracker1 = new vpMbGenericTracker;
vpMbGenericTracker 2 = *tracker1;
delete tracker1;
```

would not work, mainly due to `vpMbHiddenFaces` and the pointers used inside.

---

Add `perfGenericTracker` to have a first benchmark file.
Add `PerfCompare.py` Python script.

It works like this:
```
./perfMatrixMultiplication --benchmark --reporter xml --out log_perfMatrixMultiplication_MKL.xml
./perfMatrixMultiplication --benchmark --reporter xml --out log_perfMatrixMultiplication_OpenBLAS.xml
python PerfCompare.py --before log_perfMatrixMultiplication_OpenBLAS.xml --after log_perfMatrixMultiplication_MKL.xml --before-label OpenBLAS --after-label MKL
```

The idea is to have first some benchmark with the `perf*` files and a script to compare between two ViSP revisions or platforms, and to ensure that there is no regression.
Output is markdown table, see below.

---

<details><summary>perfMatrixMultiplication OpenBLAS 0.2.20 vs MKL</summary>
<p>

| Benchmark matrix-matrix multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.08 | 0.13 | 0.62 |
| (3x3)x(3x3) - ViSP | 0.21 | 0.28 | 0.76 |
| (6x6)x(6x6) - Naive code | 0.21 | 0.32 | 0.66 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.26 | 1.02 |
| (8x8)x(8x8) - Naive code | 0.38 | 0.49 | 0.77 |
| (8x8)x(8x8) - ViSP | 0.30 | 0.32 | 0.96 |
| (10x10)x(10x10) - Naive code | 0.65 | 0.83 | 0.78 |
| (10x10)x(10x10) - ViSP | 0.42 | 0.46 | 0.92 |
| (20x20)x(20x20) - Naive code | 5.29 | 5.25 | 1.01 |
| (20x20)x(20x20) - ViSP | 1.10 | 0.78 | 1.42 |
| (6x200)x(200x6) - Naive code | 6.86 | 6.99 | 0.98 |
| (6x200)x(200x6) - ViSP | 1.79 | 0.63 | 2.84 |
| (200x6)x(6x200) - Naive code | 150.08 | 150.31 | 1.00 |
| (200x6)x(6x200) - ViSP | 41.03 | 25.21 | 1.63 |
| (207x119)x(119x207) - Naive code | 4722.32 | 4663.43 | 1.01 |
| (207x119)x(119x207) - ViSP | 84.29 | 199.37 | 0.42 |
| (83x201)x(201x83) - Naive code | 1296.67 | 1305.83 | 0.99 |
| (83x201)x(201x83) - ViSP | 37.23 | 62.04 | 0.60 |
| (600x400)x(400x600) - Naive code | 145025.97 | 143874.63 | 1.01 |
| (600x400)x(400x600) - ViSP | 1395.79 | 5089.98 | 0.27 |
| (400x600)x(600x400) - Naive code | 97906.05 | 98174.56 | 1.00 |
| (400x600)x(600x400) - ViSP | 912.74 | 3304.28 | 0.28 |

| Benchmark matrix-rotation matrix multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.11 | 0.29 | 0.38 |
| (3x3)x(3x3) - ViSP | 0.08 | 0.19 | 0.40 |

| Benchmark matrix-homogeneous matrix multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (4x4)x(4x4) - Naive code | 0.14 | 0.32 | 0.43 |
| (4x4)x(4x4) - ViSP | 0.10 | 0.23 | 0.45 |

| Benchmark matrix-vector multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x1) - Naive code | 0.07 | 0.18 | 0.38 |
| (3x3)x(3x1) - ViSP | 0.09 | 0.21 | 0.44 |
| (6x6)x(6x1) - Naive code | 0.09 | 0.20 | 0.44 |
| (6x6)x(6x1) - ViSP | 0.11 | 0.22 | 0.52 |
| (8x8)x(8x1) - Naive code | 0.10 | 0.22 | 0.48 |
| (8x8)x(8x1) - ViSP | 0.11 | 0.22 | 0.48 |
| (10x10)x(10x1) - Naive code | 0.12 | 0.24 | 0.51 |
| (10x10)x(10x1) - ViSP | 0.13 | 0.23 | 0.56 |
| (20x20)x(20x1) - Naive code | 0.30 | 0.54 | 0.54 |
| (20x20)x(20x1) - ViSP | 0.16 | 0.31 | 0.51 |
| (6x200)x(200x1) - Naive code | 0.79 | 1.24 | 0.64 |
| (6x200)x(200x1) - ViSP | 0.24 | 0.29 | 0.85 |
| (200x6)x(6x1) - Naive code | 1.10 | 1.37 | 0.80 |
| (200x6)x(6x1) - ViSP | 0.88 | 0.78 | 1.13 |
| (207x119)x(119x1) - Naive code | 14.77 | 19.45 | 0.76 |
| (207x119)x(119x1) - ViSP | 3.86 | 3.16 | 1.22 |
| (83x201)x(201x1) - Naive code | 9.94 | 13.95 | 0.71 |
| (83x201)x(201x1) - ViSP | 3.19 | 2.17 | 1.47 |
| (600x400)x(400x1) - Naive code | 211.39 | 204.74 | 1.03 |
| (600x400)x(400x1) - ViSP | 9.80 | 33.33 | 0.29 |
| (400x600)x(600x1) - Naive code | 154.12 | 192.78 | 0.80 |
| (400x600)x(600x1) - ViSP | 9.49 | 32.97 | 0.29 |

| Benchmark AtA | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.19 | 0.40 |
| (3x3) - ViSP | 0.21 | 0.27 | 0.78 |
| (6x6) - Naive code | 0.15 | 0.27 | 0.55 |
| (6x6) - ViSP | 0.27 | 0.30 | 0.90 |
| (8x8) - Naive code | 0.26 | 0.37 | 0.69 |
| (8x8) - ViSP | 0.31 | 0.31 | 0.99 |
| (10x10) - Naive code | 0.45 | 0.63 | 0.71 |
| (10x10) - ViSP | 0.43 | 0.45 | 0.96 |
| (20x20) - Naive code | 2.98 | 2.94 | 1.01 |
| (20x20) - ViSP | 1.13 | 1.04 | 1.09 |
| (6x200) - Naive code | 91.37 | 90.54 | 1.01 |
| (6x200) - ViSP | 40.61 | 25.21 | 1.61 |
| (200x6) - Naive code | 3.98 | 4.09 | 0.97 |
| (200x6) - ViSP | 1.96 | 0.73 | 2.69 |
| (207x119) - Naive code | 1380.70 | 1374.57 | 1.00 |
| (207x119) - ViSP | 54.12 | 120.66 | 0.45 |
| (83x201) - Naive code | 1444.74 | 1429.71 | 1.01 |
| (83x201) - ViSP | 61.09 | 133.76 | 0.46 |
| (600x400) - Naive code | 54764.11 | 52935.26 | 1.03 |
| (600x400) - ViSP | 912.44 | 3258.97 | 0.28 |
| (400x600) - Naive code | 72913.58 | 73568.12 | 0.99 |
| (400x600) - ViSP | 1322.87 | 4910.70 | 0.27 |

| Benchmark AAt | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.19 | 0.42 |
| (3x3) - ViSP | 0.21 | 0.28 | 0.73 |
| (6x6) - Naive code | 0.15 | 0.26 | 0.58 |
| (6x6) - ViSP | 0.26 | 0.31 | 0.85 |
| (8x8) - Naive code | 0.26 | 0.38 | 0.68 |
| (8x8) - ViSP | 0.30 | 0.33 | 0.92 |
| (10x10) - Naive code | 0.43 | 0.63 | 0.69 |
| (10x10) - ViSP | 0.41 | 0.47 | 0.86 |
| (20x20) - Naive code | 2.68 | 2.73 | 0.98 |
| (20x20) - ViSP | 1.15 | 0.85 | 1.35 |
| (6x200) - Naive code | 3.93 | 4.08 | 0.96 |
| (6x200) - ViSP | 1.67 | 1.00 | 1.67 |
| (200x6) - Naive code | 85.29 | 87.26 | 0.98 |
| (200x6) - ViSP | 40.27 | 24.69 | 1.63 |

| Benchmark matrix-velocity twist multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.41 | 0.56 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.26 | 1.01 |
| (20x6)x(6x6) - Naive code | 0.55 | 0.87 | 0.63 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.37 | 1.12 |
| (207x6)x(6x6) - Naive code | 5.11 | 5.47 | 0.93 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.24 | 2.04 |
| (600x6)x(6x6) - Naive code | 14.49 | 15.12 | 0.96 |
| (600x6)x(6x6) - ViSP | 6.71 | 3.13 | 2.14 |
| (1201x6)x(6x6) - Naive code | 28.74 | 29.74 | 0.97 |
| (1201x6)x(6x6) - ViSP | 13.21 | 5.80 | 2.28 |

| Benchmark matrix-force twist multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.41 | 0.57 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.26 | 1.03 |
| (20x6)x(6x6) - Naive code | 0.56 | 0.84 | 0.67 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.37 | 1.10 |
| (207x6)x(6x6) - Naive code | 5.10 | 5.46 | 0.94 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.24 | 2.04 |
| (600x6)x(6x6) - Naive code | 14.46 | 15.12 | 0.96 |
| (600x6)x(6x6) - ViSP | 6.83 | 3.09 | 2.21 |
| (1201x6)x(6x6) - Naive code | 29.11 | 29.73 | 0.98 |
| (1201x6)x(6x6) - ViSP | 13.31 | 5.81 | 2.29 |

</p>
</details>


<details><summary>perfMatrixMultiplication OpenBLAS 0.2.20 vs OpenBLAS @e7f0da92</summary>
<p>

| Benchmark matrix-matrix multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.08 | 0.09 | 0.94 |
| (3x3)x(3x3) - ViSP | 0.21 | 0.17 | 1.20 |
| (6x6)x(6x6) - Naive code | 0.21 | 0.21 | 0.99 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.22 | 1.20 |
| (8x8)x(8x8) - Naive code | 0.38 | 0.38 | 0.99 |
| (8x8)x(8x8) - ViSP | 0.30 | 0.24 | 1.28 |
| (10x10)x(10x10) - Naive code | 0.65 | 0.67 | 0.97 |
| (10x10)x(10x10) - ViSP | 0.42 | 0.34 | 1.24 |
| (20x20)x(20x20) - Naive code | 5.29 | 5.21 | 1.01 |
| (20x20)x(20x20) - ViSP | 1.10 | 0.91 | 1.21 |
| (6x200)x(200x6) - Naive code | 6.86 | 6.82 | 1.00 |
| (6x200)x(200x6) - ViSP | 1.79 | 1.73 | 1.04 |
| (200x6)x(6x200) - Naive code | 150.08 | 149.64 | 1.00 |
| (200x6)x(6x200) - ViSP | 41.03 | 33.09 | 1.24 |
| (207x119)x(119x207) - Naive code | 4722.32 | 4560.03 | 1.04 |
| (207x119)x(119x207) - ViSP | 84.29 | 77.77 | 1.08 |
| (83x201)x(201x83) - Naive code | 1296.67 | 1337.78 | 0.97 |
| (83x201)x(201x83) - ViSP | 37.23 | 28.68 | 1.30 |
| (600x400)x(400x600) - Naive code | 145025.97 | 142958.55 | 1.01 |
| (600x400)x(400x600) - ViSP | 1395.79 | 1340.60 | 1.04 |
| (400x600)x(600x400) - Naive code | 97906.05 | 98675.75 | 0.99 |
| (400x600)x(600x400) - ViSP | 912.74 | 832.24 | 1.10 |

| Benchmark matrix-rotation matrix multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.11 | 0.11 | 0.99 |
| (3x3)x(3x3) - ViSP | 0.08 | 0.08 | 0.96 |

| Benchmark matrix-homogeneous matrix multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (4x4)x(4x4) - Naive code | 0.14 | 0.14 | 0.96 |
| (4x4)x(4x4) - ViSP | 0.10 | 0.11 | 0.94 |

| Benchmark matrix-vector multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x1) - Naive code | 0.07 | 0.07 | 0.96 |
| (3x3)x(3x1) - ViSP | 0.09 | 0.09 | 1.02 |
| (6x6)x(6x1) - Naive code | 0.09 | 0.08 | 1.04 |
| (6x6)x(6x1) - ViSP | 0.11 | 0.12 | 0.98 |
| (8x8)x(8x1) - Naive code | 0.10 | 0.10 | 1.07 |
| (8x8)x(8x1) - ViSP | 0.11 | 0.11 | 0.96 |
| (10x10)x(10x1) - Naive code | 0.12 | 0.12 | 1.03 |
| (10x10)x(10x1) - ViSP | 0.13 | 0.13 | 1.02 |
| (20x20)x(20x1) - Naive code | 0.30 | 0.29 | 1.02 |
| (20x20)x(20x1) - ViSP | 0.16 | 0.16 | 1.01 |
| (6x200)x(200x1) - Naive code | 0.79 | 0.75 | 1.06 |
| (6x200)x(200x1) - ViSP | 0.24 | 0.25 | 0.99 |
| (200x6)x(6x1) - Naive code | 1.10 | 1.07 | 1.02 |
| (200x6)x(6x1) - ViSP | 0.88 | 0.87 | 1.01 |
| (207x119)x(119x1) - Naive code | 14.77 | 14.52 | 1.02 |
| (207x119)x(119x1) - ViSP | 3.86 | 2.25 | 1.72 |
| (83x201)x(201x1) - Naive code | 9.94 | 10.02 | 0.99 |
| (83x201)x(201x1) - ViSP | 3.19 | 1.61 | 1.99 |
| (600x400)x(400x1) - Naive code | 211.39 | 201.55 | 1.05 |
| (600x400)x(400x1) - ViSP | 9.80 | 7.41 | 1.32 |
| (400x600)x(600x1) - Naive code | 154.12 | 155.06 | 0.99 |
| (400x600)x(600x1) - ViSP | 9.49 | 7.43 | 1.28 |

| Benchmark AtA | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.07 | 1.01 |
| (3x3) - ViSP | 0.21 | 0.17 | 1.24 |
| (6x6) - Naive code | 0.15 | 0.15 | 1.01 |
| (6x6) - ViSP | 0.27 | 0.22 | 1.22 |
| (8x8) - Naive code | 0.26 | 0.26 | 0.99 |
| (8x8) - ViSP | 0.31 | 0.25 | 1.23 |
| (10x10) - Naive code | 0.45 | 0.45 | 1.00 |
| (10x10) - ViSP | 0.43 | 0.37 | 1.17 |
| (20x20) - Naive code | 2.98 | 2.92 | 1.02 |
| (20x20) - ViSP | 1.13 | 1.04 | 1.09 |
| (6x200) - Naive code | 91.37 | 93.58 | 0.98 |
| (6x200) - ViSP | 40.61 | 33.56 | 1.21 |
| (200x6) - Naive code | 3.98 | 3.98 | 1.00 |
| (200x6) - ViSP | 1.96 | 1.84 | 1.06 |
| (207x119) - Naive code | 1380.70 | 1389.71 | 0.99 |
| (207x119) - ViSP | 54.12 | 54.52 | 0.99 |
| (83x201) - Naive code | 1444.74 | 1448.31 | 1.00 |
| (83x201) - ViSP | 61.09 | 62.15 | 0.98 |
| (600x400) - Naive code | 54764.11 | 52523.58 | 1.04 |
| (600x400) - ViSP | 912.44 | 835.05 | 1.09 |
| (400x600) - Naive code | 72913.58 | 73687.02 | 0.99 |
| (400x600) - ViSP | 1322.87 | 1312.16 | 1.01 |

| Benchmark AAt | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.08 | 1.01 |
| (3x3) - ViSP | 0.21 | 0.17 | 1.23 |
| (6x6) - Naive code | 0.15 | 0.15 | 1.01 |
| (6x6) - ViSP | 0.26 | 0.22 | 1.17 |
| (8x8) - Naive code | 0.26 | 0.27 | 0.99 |
| (8x8) - ViSP | 0.30 | 0.23 | 1.31 |
| (10x10) - Naive code | 0.43 | 0.44 | 0.98 |
| (10x10) - ViSP | 0.41 | 0.33 | 1.24 |
| (20x20) - Naive code | 2.68 | 2.73 | 0.98 |
| (20x20) - ViSP | 1.15 | 0.94 | 1.23 |
| (6x200) - Naive code | 3.93 | 4.04 | 0.97 |
| (6x200) - ViSP | 1.67 | 1.64 | 1.02 |
| (200x6) - Naive code | 85.29 | 87.45 | 0.98 |
| (200x6) - ViSP | 40.27 | 32.50 | 1.24 |

| Benchmark matrix-velocity twist multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.24 | 0.95 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.22 | 1.19 |
| (20x6)x(6x6) - Naive code | 0.55 | 0.58 | 0.95 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.32 | 1.29 |
| (207x6)x(6x6) - Naive code | 5.11 | 5.42 | 0.94 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.88 | 1.34 |
| (600x6)x(6x6) - Naive code | 14.49 | 15.36 | 0.94 |
| (600x6)x(6x6) - ViSP | 6.71 | 5.07 | 1.32 |
| (1201x6)x(6x6) - Naive code | 28.74 | 29.83 | 0.96 |
| (1201x6)x(6x6) - ViSP | 13.21 | 10.15 | 1.30 |

| Benchmark matrix-force twist multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.24 | 0.97 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.22 | 1.22 |
| (20x6)x(6x6) - Naive code | 0.56 | 0.58 | 0.97 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.33 | 1.24 |
| (207x6)x(6x6) - Naive code | 5.10 | 5.40 | 0.94 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.87 | 1.35 |
| (600x6)x(6x6) - Naive code | 14.46 | 15.24 | 0.95 |
| (600x6)x(6x6) - ViSP | 6.83 | 5.09 | 1.34 |
| (1201x6)x(6x6) - Naive code | 29.11 | 30.09 | 0.97 |
| (1201x6)x(6x6) - ViSP | 13.31 | 10.30 | 1.29 |

</p>
</details>

---

<details><summary>perfGenericTracker OpenBLAS vs MKL</summary>
<p>

| Benchmark generic tracker | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| Edge MBT | 161677.49 | 166364.90 | 0.97 |
| Edge + Depth dense MBT | 333057.51 | 308968.60 | 1.08 |

</p>
</details>

<details><summary>perfGenericTracker OpenBLAS 0.2.20 vs OpenBLAS @e7f0da92</summary>
<p>

| Benchmark generic tracker | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| Edge MBT | 161677.49 | 161156.84 | 1.00 |
| Edge + Depth dense MBT | 333057.51 | 332829.89 | 1.00 |

</p>
</details>