### PR TITLE
Add perfGenericTracker and perf script for comparison

### DIFF
--- a/modules/tracker/mbt/CMakeLists.txt
+++ b/modules/tracker/mbt/CMakeLists.txt
@@ -270,6 +270,11 @@ if(WITH_PUGIXML)
   include_directories(${PUGIXML_INCLUDE_DIRS})
 endif()
 
+if(WITH_CATCH2)
+  # catch2 is private
+  include_directories(${CATCH2_INCLUDE_DIRS})
+endif()
+
 vp_add_module(mbt visp_vision visp_core visp_me visp_visual_features OPTIONAL visp_ar visp_klt visp_gui PRIVATE_OPTIONAL ${CLIPPER_LIBRARIES} ${PUGIXML_LIBRARIES} WRAP java)
 vp_glob_module_sources()
 
@@ -322,6 +327,7 @@ vp_create_module(${opt_libs})
 
 if(BUILD_TESTS)
   if(USE_OGRE)
+    vp_set_source_file_compile_flag(test/perfGenericTracker.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)
     vp_set_source_file_compile_flag(test/testGenericTracker.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)
     vp_set_source_file_compile_flag(test/testGenericTrackerDepth.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)
     vp_set_source_file_compile_flag(test/testMbtXmlGenericParser.cpp -Wno-unused-parameter -Wno-unused-but-set-parameter -Wno-overloaded-virtual -Wno-float-equal -Wno-deprecated-copy)

--- a/modules/tracker/mbt/test/perfGenericTracker.cpp
+++ b/modules/tracker/mbt/test/perfGenericTracker.cpp
@@ -1,0 +1,329 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Benchmark generic tracker.
+ *
+ *****************************************************************************/
+
+#include <visp3/core/vpConfig.h>
+
+#if defined(VISP_HAVE_CATCH2) && defined(VISP_HAVE_PUGIXML)
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+#include <visp3/core/vpIoTools.h>
+#include <visp3/io/vpImageIo.h>
+#include <visp3/mbt/vpMbGenericTracker.h>
+
+//#define DEBUG_DISPLAY // uncomment to check that the tracking is correct
+#ifdef DEBUG_DISPLAY
+#include <visp3/gui/vpDisplayX.h>
+#endif
+
+namespace
+{
+bool runBenchmark = false;
+
+template <typename Type>
+bool read_data(const std::string &input_directory, int cpt, const vpCameraParameters &cam_depth,
+               vpImage<Type> &I, vpImage<uint16_t> &I_depth,
+               std::vector<vpColVector> &pointcloud, vpHomogeneousMatrix &cMo)
+{
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  static_assert(std::is_same<Type, unsigned char>::value || std::is_same<Type, vpRGBa>::value,
+                "Template function supports only unsigned char and vpRGBa images!");
+#endif
+  char buffer[256];
+  sprintf(buffer, std::string(input_directory + "/Images/Image_%04d.pgm").c_str(), cpt);
+  std::string image_filename = buffer;
+
+  sprintf(buffer, std::string(input_directory + "/Depth/Depth_%04d.bin").c_str(), cpt);
+  std::string depth_filename = buffer;
+
+  sprintf(buffer, std::string(input_directory + "/CameraPose/Camera_%03d.txt").c_str(), cpt);
+  std::string pose_filename = buffer;
+
+  if (!vpIoTools::checkFilename(image_filename) || !vpIoTools::checkFilename(depth_filename)
+      || !vpIoTools::checkFilename(pose_filename))
+    return false;
+
+  vpImageIo::read(I, image_filename);
+
+  unsigned int depth_width = 0, depth_height = 0;
+  std::ifstream file_depth(depth_filename.c_str(), std::ios::in | std::ios::binary);
+  if (!file_depth.is_open())
+    return false;
+
+  vpIoTools::readBinaryValueLE(file_depth, depth_height);
+  vpIoTools::readBinaryValueLE(file_depth, depth_width);
+  I_depth.resize(depth_height, depth_width);
+  pointcloud.resize(depth_height*depth_width);
+
+  const float depth_scale = 0.000030518f;
+  for (unsigned int i = 0; i < I_depth.getHeight(); i++) {
+    for (unsigned int j = 0; j < I_depth.getWidth(); j++) {
+      vpIoTools::readBinaryValueLE(file_depth, I_depth[i][j]);
+      double x = 0.0, y = 0.0, Z = I_depth[i][j] * depth_scale;
+      vpPixelMeterConversion::convertPoint(cam_depth, j, i, x, y);
+      vpColVector pt3d(4, 1.0);
+      pt3d[0] = x*Z;
+      pt3d[1] = y*Z;
+      pt3d[2] = Z;
+      pointcloud[i*I_depth.getWidth()+j] = pt3d;
+    }
+  }
+
+  std::ifstream file_pose(pose_filename.c_str());
+  if (!file_pose.is_open()) {
+    return false;
+  }
+
+  for (unsigned int i = 0; i < 4; i++) {
+    for (unsigned int j = 0; j < 4; j++) {
+      file_pose >> cMo[i][j];
+    }
+  }
+
+  return true;
+}
+} //anonymous namespace
+
+TEST_CASE("Benchmark generic tracker", "[benchmark]") {
+  if (runBenchmark) {
+    std::vector<int> tracker_type(2);
+    tracker_type[0] = vpMbGenericTracker::EDGE_TRACKER;
+    tracker_type[1] = vpMbGenericTracker::DEPTH_DENSE_TRACKER;
+    vpMbGenericTracker tracker(tracker_type);
+
+    const std::string input_directory = vpIoTools::createFilePath(vpIoTools::getViSPImagesDataPath(), "mbt-depth/Castle-simu");
+    const std::string configFileCam1 = input_directory + std::string("/Config/chateau.xml");
+    const std::string configFileCam2 = input_directory + std::string("/Config/chateau_depth.xml");
+    REQUIRE(vpIoTools::checkFilename(configFileCam1));
+    REQUIRE(vpIoTools::checkFilename(configFileCam2));
+    tracker.loadConfigFile(configFileCam1, configFileCam2);
+    REQUIRE(vpIoTools::checkFilename(input_directory + "/Models/chateau.cao"));
+    tracker.loadModel(input_directory + "/Models/chateau.cao", input_directory + "/Models/chateau.cao");
+
+    vpHomogeneousMatrix T;
+    T[0][0] = -1;
+    T[0][3] = -0.2;
+    T[1][1] = 0;
+    T[1][2] = 1;
+    T[1][3] = 0.12;
+    T[2][1] = 1;
+    T[2][2] = 0;
+    T[2][3] = -0.15;
+    tracker.loadModel(input_directory + "/Models/cube.cao", false, T);
+
+    vpImage<unsigned char> I;
+    vpImage<uint16_t> I_depth_raw;
+    vpHomogeneousMatrix cMo_truth;
+    std::vector<vpColVector> pointcloud;
+
+    vpCameraParameters cam_color, cam_depth;
+    tracker.getCameraParameters(cam_color, cam_depth);
+
+    vpHomogeneousMatrix depth_M_color;
+    depth_M_color[0][3] = -0.05;
+    tracker.setCameraTransformationMatrix("Camera2", depth_M_color);
+
+    // load all the data in memory to not take into account I/O from disk
+    std::vector<vpImage<unsigned char>> images;
+    std::vector<vpImage<uint16_t>> depth_raws;
+    std::vector<std::vector<vpColVector>> pointclouds;
+    std::vector<vpHomogeneousMatrix> cMo_truth_all;
+    // forward
+    for (int i = 1; i <= 40; i++) {
+      if (read_data(input_directory, i, cam_depth, I, I_depth_raw, pointcloud, cMo_truth)) {
+        images.push_back(I);
+        depth_raws.push_back(I_depth_raw);
+        pointclouds.push_back(pointcloud);
+        cMo_truth_all.push_back(cMo_truth);
+      }
+    }
+    // backward
+    for (int i = 40; i >= 1; i--) {
+      if (read_data(input_directory, i, cam_depth, I, I_depth_raw, pointcloud, cMo_truth)) {
+        images.push_back(I);
+        depth_raws.push_back(I_depth_raw);
+        pointclouds.push_back(pointcloud);
+        cMo_truth_all.push_back(cMo_truth);
+      }
+    }
+
+    // Stereo MBT
+    {
+      std::vector<std::map<std::string, int>> mapOfTrackerTypes;
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+  #if defined(VISP_HAVE_OPENCV)
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::KLT_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+      mapOfTrackerTypes.push_back({{"Camera1", vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER}, {"Camera2", vpMbGenericTracker::DEPTH_DENSE_TRACKER}});
+  #endif
+
+      std::vector<std::string> benchmarkNames = {
+        "Edge MBT",
+        "Edge + Depth dense MBT",
+  #if defined(VISP_HAVE_OPENCV)
+        "KLT MBT",
+        "KLT + depth dense MBT",
+        "Edge + KLT + depth dense MBT"
+  #endif
+      };
+
+      std::vector<bool> monoculars = {
+        true,
+        false,
+  #if defined(VISP_HAVE_OPENCV)
+        true,
+        false,
+        false
+  #endif
+      };
+
+      for (size_t idx = 0; idx < mapOfTrackerTypes.size(); idx++) {
+        tracker.resetTracker();
+        tracker.setTrackerType(mapOfTrackerTypes[idx]);
+
+        tracker.loadConfigFile(configFileCam1, configFileCam2);
+        tracker.loadModel(input_directory + "/Models/chateau.cao", input_directory + "/Models/chateau.cao");
+        tracker.loadModel(input_directory + "/Models/cube.cao", false, T);
+        tracker.initFromPose(images.front(), cMo_truth_all.front());
+
+        std::map<std::string, unsigned int> mapOfWidths, mapOfHeights;
+        mapOfWidths["Camera2"] = monoculars[idx] ? 0 : I_depth_raw.getWidth();
+        mapOfHeights["Camera2"] = monoculars[idx] ? 0 : I_depth_raw.getHeight();
+
+        vpHomogeneousMatrix cMo;
+    #ifndef DEBUG_DISPLAY
+        BENCHMARK(benchmarkNames[idx].c_str())
+    #else
+        vpImage<unsigned char> I_depth;
+        vpImageConvert::createDepthHistogram(I_depth_raw, I_depth);
+
+        vpDisplayX d_color(I, 0, 0, "Color image");
+        vpDisplayX d_depth(I_depth, I.getWidth(), 0, "Depth image");
+        tracker.setDisplayFeatures(true);
+    #endif
+        {
+          tracker.initFromPose(images.front(), cMo_truth_all.front());
+
+          for (size_t i = 0; i < images.size(); i++) {
+            const vpImage<unsigned char>& I_current = images[i];
+            const std::vector<vpColVector>& pointcloud_current = pointclouds[i];
+
+      #ifdef DEBUG_DISPLAY
+            vpImageConvert::createDepthHistogram(depth_raws[i], I_depth);
+            I = I_current;
+            vpDisplay::display(I);
+            vpDisplay::display(I_depth);
+      #endif
+
+            std::map<std::string, const vpImage<unsigned char> *> mapOfImages;
+            mapOfImages["Camera1"] = &I_current;
+
+            std::map<std::string, const std::vector<vpColVector> *> mapOfPointclouds;
+            mapOfPointclouds["Camera2"] = &pointcloud_current;
+
+            tracker.track(mapOfImages, mapOfPointclouds, mapOfWidths, mapOfHeights);
+            cMo = tracker.getPose();
+
+      #ifdef DEBUG_DISPLAY
+            tracker.display(I, I_depth, cMo, depth_M_color*cMo, cam_color, cam_depth, vpColor::red, 3);
+            vpDisplay::displayFrame(I, cMo, cam_color, 0.05, vpColor::none, 3);
+            vpDisplay::displayFrame(I_depth, depth_M_color*cMo, cam_depth, 0.05, vpColor::none, 3);
+            vpDisplay::displayText(I, 20, 20, benchmarkNames[idx], vpColor::red);
+            vpDisplay::displayText(I, 40, 20, std::string("Nb features: " + std::to_string(tracker.getError().getRows())), vpColor::red);
+
+            vpDisplay::flush(I);
+            vpDisplay::flush(I_depth);
+            vpTime::wait(33);
+      #endif
+          }
+
+    #ifndef DEBUG_DISPLAY
+          return cMo;
+        };
+    #else
+        }
+    #endif
+
+        vpPoseVector pose_est(cMo);
+        vpPoseVector pose_truth(cMo_truth);
+        vpColVector t_err(3), tu_err(3);
+        for (unsigned int i = 0; i < 3; i++) {
+          t_err[i] = pose_est[i] - pose_truth[i];
+          tu_err[i] = pose_est[i+3] - pose_truth[i+3];
+        }
+
+        const double max_translation_error = 0.005;
+        const double max_rotation_error = 0.03;
+        CHECK(sqrt(t_err.sumSquare()) < max_translation_error);
+        CHECK(sqrt(tu_err.sumSquare()) < max_rotation_error);
+      }
+    }
+  } //if (runBenchmark)
+}
+
+int main(int argc, char *argv[])
+{
+  Catch::Session session; // There must be exactly one instance
+
+  // Build a new parser on top of Catch's
+  using namespace Catch::clara;
+  auto cli = session.cli()   // Get Catch's composite command line parser
+      | Opt(runBenchmark)    // bind variable to a new option, with a hint string
+      ["--benchmark"]        // the option names it will respond to
+      ("run benchmark comparing naive code with ViSP implementation");     // description string for the help output
+
+  // Now pass the new composite back to Catch so it uses that
+  session.cli(cli);
+
+  // Let Catch (using Clara) parse the command line
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+
+  // numFailed is clamped to 255 as some unices only use the lower 8 bits.
+  // This clamping has already been applied, so just return it here
+  // You can also do any post run clean-up here
+  return numFailed;
+}
+#else
+#include <iostream>
+
+int main()
+{
+  return 0;
+}
+#endif

--- a/script/PerfCompare.py
+++ b/script/PerfCompare.py
@@ -1,0 +1,118 @@
+from __future__ import print_function
+from __future__ import division
+
+import argparse
+from enum import Enum
+import xml.etree.ElementTree as ET
+from collections import OrderedDict
+
+def nanoToMilli(nano):
+    return nano / 1000
+
+class BenchmarkResult:
+    """BenchmarkResult class to hold perf numbers"""
+
+    def __init__(self, name, mean_value, mean_lower_bound, mean_upper_bound, \
+                 std_val, std_lower_bound, std_upper_bound):
+        self.name = name
+        self.mean_value = nanoToMilli(mean_value)
+        self.mean_lower_bound = nanoToMilli(mean_lower_bound)
+        self.mean_upper_bound = nanoToMilli(mean_upper_bound)
+        self.std_val = nanoToMilli(std_val)
+        self.std_lower_bound = nanoToMilli(std_lower_bound)
+        self.std_upper_bound = nanoToMilli(std_upper_bound)
+
+    def __str__(self):
+        return "BenchmarkResults %s\nmean value=%f, lowerBound=%f, upperBound=%f\nstd:%f, lowerBound=%f, upperBound=%f" \
+                % (self.name, self.mean_value, self.mean_lower_bound, self.mean_upper_bound, \
+                   self.std_val, self.std_lower_bound, self.std_upper_bound)
+
+class TestCase:
+    """TestCase class to hold the list of benchmark results"""
+
+    def __init__(self, name):
+        self.name = name
+        self.results = OrderedDict()
+
+    def __str__(self):
+        return "TestCase %s\nBenchmark result:\n%s" % (self.name, self.results)
+
+class Metric(Enum):
+    mean = 'mean'
+    lowMean = 'low_mean'
+    highMean = 'high_mean'
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--before", help="Path to XML perf log for before comparison.", required=True)
+parser.add_argument("--after", help="Path to XML perf log for after comparison.", required=True)
+parser.add_argument("--before-label", help="Label for before column.", default='Before')
+parser.add_argument("--after-label", help="Label for after column.", default='After')
+parser.add_argument("--metric", help="Benchmark metric (mean, low_mean, high_mean).", type=Metric, choices=list(Metric), default=Metric.mean)
+
+args = parser.parse_args()
+
+file_before = args.before
+file_after = args.after
+print('Path to XML perf log for before comparison:', file_before)
+print('Path to XML perf log for after comparison:', file_after)
+print()
+
+tree_before = ET.parse(file_before)
+tree_after = ET.parse(file_after)
+
+root_before = tree_before.getroot()
+root_after = tree_after.getroot()
+
+def loadResults(root):
+    results = OrderedDict()
+
+    for test_case in root.iter('TestCase'):
+        test_name = test_case.attrib['name']
+
+        current_test = TestCase(test_name)
+
+        for bench_res in test_case.iter('BenchmarkResults'):
+            bench_name = bench_res.attrib['name']
+
+            mean_node = bench_res.find('mean')
+            mean = float(mean_node.attrib['value'])
+            mean_lower = float(mean_node.attrib['lowerBound'])
+            mean_upper = float(mean_node.attrib['upperBound'])
+
+            std_node = bench_res.find('standardDeviation')
+            std = float(std_node.attrib['value'])
+            std_lower = float(std_node.attrib['lowerBound'])
+            std_upper = float(std_node.attrib['upperBound'])
+
+            current_test.results[bench_name] = BenchmarkResult(bench_name, mean, mean_lower, mean_upper, std, std_lower, std_upper)
+
+        results[test_name] = current_test
+
+    return results
+
+results_before = loadResults(root_before)
+results_after = loadResults(root_after)
+
+for r_before_name, r_before in results_before.items():
+    print('| {} | {} | {} | Speed-up |'.format(r_before_name, args.before_label, args.after_label))
+    print('| --- | --- | --- | --- |')
+    if r_before_name in results_after:
+        r_after = results_after[r_before_name]
+
+        for b_before_name, b_before in r_before.results.items():
+            if b_before_name in r_after.results:
+                b_after = r_after.results[b_before_name]
+
+                metric_before = b_before.mean_value
+                metric_after = b_after.mean_value
+
+                if args.metric == Metric.lowMean:
+                    metric_before = b_before.mean_lower_bound
+                    metric_after = b_after.mean_lower_bound
+                elif args.metric == Metric.highMean:
+                    metric_before = b_before.mean_upper_bound
+                    metric_after = b_after.mean_upper_bound
+
+                speed_up = metric_before / metric_after
+                print('| {} | {:.2f} | {:.2f} | {:.2f} |'.format(b_before_name, metric_before, metric_after, speed_up))
+        print()


### PR DESCRIPTION
Add `perfGenericTracker` to have a first benchmark file.
Add `PerfCompare.py` Python script.

It works like this:
```
./perfMatrixMultiplication --benchmark --reporter xml --out log_perfMatrixMultiplication_MKL.xml
./perfMatrixMultiplication --benchmark --reporter xml --out log_perfMatrixMultiplication_OpenBLAS.xml
python PerfCompare.py --before log_perfMatrixMultiplication_OpenBLAS.xml --after log_perfMatrixMultiplication_MKL.xml --before-label OpenBLAS --after-label MKL
```

The idea is to have first some benchmark with the `perf*` files and a script to compare between two ViSP revisions or platforms, and to ensure that there is no regression.
Output is markdown table, see below.

---

<details><summary>perfMatrixMultiplication OpenBLAS 0.2.20 vs MKL</summary>
<p>

| Benchmark matrix-matrix multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.08 | 0.13 | 0.62 |
| (3x3)x(3x3) - ViSP | 0.21 | 0.28 | 0.76 |
| (6x6)x(6x6) - Naive code | 0.21 | 0.32 | 0.66 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.26 | 1.02 |
| (8x8)x(8x8) - Naive code | 0.38 | 0.49 | 0.77 |
| (8x8)x(8x8) - ViSP | 0.30 | 0.32 | 0.96 |
| (10x10)x(10x10) - Naive code | 0.65 | 0.83 | 0.78 |
| (10x10)x(10x10) - ViSP | 0.42 | 0.46 | 0.92 |
| (20x20)x(20x20) - Naive code | 5.29 | 5.25 | 1.01 |
| (20x20)x(20x20) - ViSP | 1.10 | 0.78 | 1.42 |
| (6x200)x(200x6) - Naive code | 6.86 | 6.99 | 0.98 |
| (6x200)x(200x6) - ViSP | 1.79 | 0.63 | 2.84 |
| (200x6)x(6x200) - Naive code | 150.08 | 150.31 | 1.00 |
| (200x6)x(6x200) - ViSP | 41.03 | 25.21 | 1.63 |
| (207x119)x(119x207) - Naive code | 4722.32 | 4663.43 | 1.01 |
| (207x119)x(119x207) - ViSP | 84.29 | 199.37 | 0.42 |
| (83x201)x(201x83) - Naive code | 1296.67 | 1305.83 | 0.99 |
| (83x201)x(201x83) - ViSP | 37.23 | 62.04 | 0.60 |
| (600x400)x(400x600) - Naive code | 145025.97 | 143874.63 | 1.01 |
| (600x400)x(400x600) - ViSP | 1395.79 | 5089.98 | 0.27 |
| (400x600)x(600x400) - Naive code | 97906.05 | 98174.56 | 1.00 |
| (400x600)x(600x400) - ViSP | 912.74 | 3304.28 | 0.28 |

| Benchmark matrix-rotation matrix multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.11 | 0.29 | 0.38 |
| (3x3)x(3x3) - ViSP | 0.08 | 0.19 | 0.40 |

| Benchmark matrix-homogeneous matrix multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (4x4)x(4x4) - Naive code | 0.14 | 0.32 | 0.43 |
| (4x4)x(4x4) - ViSP | 0.10 | 0.23 | 0.45 |

| Benchmark matrix-vector multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x1) - Naive code | 0.07 | 0.18 | 0.38 |
| (3x3)x(3x1) - ViSP | 0.09 | 0.21 | 0.44 |
| (6x6)x(6x1) - Naive code | 0.09 | 0.20 | 0.44 |
| (6x6)x(6x1) - ViSP | 0.11 | 0.22 | 0.52 |
| (8x8)x(8x1) - Naive code | 0.10 | 0.22 | 0.48 |
| (8x8)x(8x1) - ViSP | 0.11 | 0.22 | 0.48 |
| (10x10)x(10x1) - Naive code | 0.12 | 0.24 | 0.51 |
| (10x10)x(10x1) - ViSP | 0.13 | 0.23 | 0.56 |
| (20x20)x(20x1) - Naive code | 0.30 | 0.54 | 0.54 |
| (20x20)x(20x1) - ViSP | 0.16 | 0.31 | 0.51 |
| (6x200)x(200x1) - Naive code | 0.79 | 1.24 | 0.64 |
| (6x200)x(200x1) - ViSP | 0.24 | 0.29 | 0.85 |
| (200x6)x(6x1) - Naive code | 1.10 | 1.37 | 0.80 |
| (200x6)x(6x1) - ViSP | 0.88 | 0.78 | 1.13 |
| (207x119)x(119x1) - Naive code | 14.77 | 19.45 | 0.76 |
| (207x119)x(119x1) - ViSP | 3.86 | 3.16 | 1.22 |
| (83x201)x(201x1) - Naive code | 9.94 | 13.95 | 0.71 |
| (83x201)x(201x1) - ViSP | 3.19 | 2.17 | 1.47 |
| (600x400)x(400x1) - Naive code | 211.39 | 204.74 | 1.03 |
| (600x400)x(400x1) - ViSP | 9.80 | 33.33 | 0.29 |
| (400x600)x(600x1) - Naive code | 154.12 | 192.78 | 0.80 |
| (400x600)x(600x1) - ViSP | 9.49 | 32.97 | 0.29 |

| Benchmark AtA | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.19 | 0.40 |
| (3x3) - ViSP | 0.21 | 0.27 | 0.78 |
| (6x6) - Naive code | 0.15 | 0.27 | 0.55 |
| (6x6) - ViSP | 0.27 | 0.30 | 0.90 |
| (8x8) - Naive code | 0.26 | 0.37 | 0.69 |
| (8x8) - ViSP | 0.31 | 0.31 | 0.99 |
| (10x10) - Naive code | 0.45 | 0.63 | 0.71 |
| (10x10) - ViSP | 0.43 | 0.45 | 0.96 |
| (20x20) - Naive code | 2.98 | 2.94 | 1.01 |
| (20x20) - ViSP | 1.13 | 1.04 | 1.09 |
| (6x200) - Naive code | 91.37 | 90.54 | 1.01 |
| (6x200) - ViSP | 40.61 | 25.21 | 1.61 |
| (200x6) - Naive code | 3.98 | 4.09 | 0.97 |
| (200x6) - ViSP | 1.96 | 0.73 | 2.69 |
| (207x119) - Naive code | 1380.70 | 1374.57 | 1.00 |
| (207x119) - ViSP | 54.12 | 120.66 | 0.45 |
| (83x201) - Naive code | 1444.74 | 1429.71 | 1.01 |
| (83x201) - ViSP | 61.09 | 133.76 | 0.46 |
| (600x400) - Naive code | 54764.11 | 52935.26 | 1.03 |
| (600x400) - ViSP | 912.44 | 3258.97 | 0.28 |
| (400x600) - Naive code | 72913.58 | 73568.12 | 0.99 |
| (400x600) - ViSP | 1322.87 | 4910.70 | 0.27 |

| Benchmark AAt | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.19 | 0.42 |
| (3x3) - ViSP | 0.21 | 0.28 | 0.73 |
| (6x6) - Naive code | 0.15 | 0.26 | 0.58 |
| (6x6) - ViSP | 0.26 | 0.31 | 0.85 |
| (8x8) - Naive code | 0.26 | 0.38 | 0.68 |
| (8x8) - ViSP | 0.30 | 0.33 | 0.92 |
| (10x10) - Naive code | 0.43 | 0.63 | 0.69 |
| (10x10) - ViSP | 0.41 | 0.47 | 0.86 |
| (20x20) - Naive code | 2.68 | 2.73 | 0.98 |
| (20x20) - ViSP | 1.15 | 0.85 | 1.35 |
| (6x200) - Naive code | 3.93 | 4.08 | 0.96 |
| (6x200) - ViSP | 1.67 | 1.00 | 1.67 |
| (200x6) - Naive code | 85.29 | 87.26 | 0.98 |
| (200x6) - ViSP | 40.27 | 24.69 | 1.63 |

| Benchmark matrix-velocity twist multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.41 | 0.56 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.26 | 1.01 |
| (20x6)x(6x6) - Naive code | 0.55 | 0.87 | 0.63 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.37 | 1.12 |
| (207x6)x(6x6) - Naive code | 5.11 | 5.47 | 0.93 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.24 | 2.04 |
| (600x6)x(6x6) - Naive code | 14.49 | 15.12 | 0.96 |
| (600x6)x(6x6) - ViSP | 6.71 | 3.13 | 2.14 |
| (1201x6)x(6x6) - Naive code | 28.74 | 29.74 | 0.97 |
| (1201x6)x(6x6) - ViSP | 13.21 | 5.80 | 2.28 |

| Benchmark matrix-force twist multiplication | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.41 | 0.57 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.26 | 1.03 |
| (20x6)x(6x6) - Naive code | 0.56 | 0.84 | 0.67 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.37 | 1.10 |
| (207x6)x(6x6) - Naive code | 5.10 | 5.46 | 0.94 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.24 | 2.04 |
| (600x6)x(6x6) - Naive code | 14.46 | 15.12 | 0.96 |
| (600x6)x(6x6) - ViSP | 6.83 | 3.09 | 2.21 |
| (1201x6)x(6x6) - Naive code | 29.11 | 29.73 | 0.98 |
| (1201x6)x(6x6) - ViSP | 13.31 | 5.81 | 2.29 |

</p>
</details>


<details><summary>perfMatrixMultiplication OpenBLAS 0.2.20 vs OpenBLAS @e7f0da92</summary>
<p>

| Benchmark matrix-matrix multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.08 | 0.09 | 0.94 |
| (3x3)x(3x3) - ViSP | 0.21 | 0.17 | 1.20 |
| (6x6)x(6x6) - Naive code | 0.21 | 0.21 | 0.99 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.22 | 1.20 |
| (8x8)x(8x8) - Naive code | 0.38 | 0.38 | 0.99 |
| (8x8)x(8x8) - ViSP | 0.30 | 0.24 | 1.28 |
| (10x10)x(10x10) - Naive code | 0.65 | 0.67 | 0.97 |
| (10x10)x(10x10) - ViSP | 0.42 | 0.34 | 1.24 |
| (20x20)x(20x20) - Naive code | 5.29 | 5.21 | 1.01 |
| (20x20)x(20x20) - ViSP | 1.10 | 0.91 | 1.21 |
| (6x200)x(200x6) - Naive code | 6.86 | 6.82 | 1.00 |
| (6x200)x(200x6) - ViSP | 1.79 | 1.73 | 1.04 |
| (200x6)x(6x200) - Naive code | 150.08 | 149.64 | 1.00 |
| (200x6)x(6x200) - ViSP | 41.03 | 33.09 | 1.24 |
| (207x119)x(119x207) - Naive code | 4722.32 | 4560.03 | 1.04 |
| (207x119)x(119x207) - ViSP | 84.29 | 77.77 | 1.08 |
| (83x201)x(201x83) - Naive code | 1296.67 | 1337.78 | 0.97 |
| (83x201)x(201x83) - ViSP | 37.23 | 28.68 | 1.30 |
| (600x400)x(400x600) - Naive code | 145025.97 | 142958.55 | 1.01 |
| (600x400)x(400x600) - ViSP | 1395.79 | 1340.60 | 1.04 |
| (400x600)x(600x400) - Naive code | 97906.05 | 98675.75 | 0.99 |
| (400x600)x(600x400) - ViSP | 912.74 | 832.24 | 1.10 |

| Benchmark matrix-rotation matrix multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x3) - Naive code | 0.11 | 0.11 | 0.99 |
| (3x3)x(3x3) - ViSP | 0.08 | 0.08 | 0.96 |

| Benchmark matrix-homogeneous matrix multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (4x4)x(4x4) - Naive code | 0.14 | 0.14 | 0.96 |
| (4x4)x(4x4) - ViSP | 0.10 | 0.11 | 0.94 |

| Benchmark matrix-vector multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3)x(3x1) - Naive code | 0.07 | 0.07 | 0.96 |
| (3x3)x(3x1) - ViSP | 0.09 | 0.09 | 1.02 |
| (6x6)x(6x1) - Naive code | 0.09 | 0.08 | 1.04 |
| (6x6)x(6x1) - ViSP | 0.11 | 0.12 | 0.98 |
| (8x8)x(8x1) - Naive code | 0.10 | 0.10 | 1.07 |
| (8x8)x(8x1) - ViSP | 0.11 | 0.11 | 0.96 |
| (10x10)x(10x1) - Naive code | 0.12 | 0.12 | 1.03 |
| (10x10)x(10x1) - ViSP | 0.13 | 0.13 | 1.02 |
| (20x20)x(20x1) - Naive code | 0.30 | 0.29 | 1.02 |
| (20x20)x(20x1) - ViSP | 0.16 | 0.16 | 1.01 |
| (6x200)x(200x1) - Naive code | 0.79 | 0.75 | 1.06 |
| (6x200)x(200x1) - ViSP | 0.24 | 0.25 | 0.99 |
| (200x6)x(6x1) - Naive code | 1.10 | 1.07 | 1.02 |
| (200x6)x(6x1) - ViSP | 0.88 | 0.87 | 1.01 |
| (207x119)x(119x1) - Naive code | 14.77 | 14.52 | 1.02 |
| (207x119)x(119x1) - ViSP | 3.86 | 2.25 | 1.72 |
| (83x201)x(201x1) - Naive code | 9.94 | 10.02 | 0.99 |
| (83x201)x(201x1) - ViSP | 3.19 | 1.61 | 1.99 |
| (600x400)x(400x1) - Naive code | 211.39 | 201.55 | 1.05 |
| (600x400)x(400x1) - ViSP | 9.80 | 7.41 | 1.32 |
| (400x600)x(600x1) - Naive code | 154.12 | 155.06 | 0.99 |
| (400x600)x(600x1) - ViSP | 9.49 | 7.43 | 1.28 |

| Benchmark AtA | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.07 | 1.01 |
| (3x3) - ViSP | 0.21 | 0.17 | 1.24 |
| (6x6) - Naive code | 0.15 | 0.15 | 1.01 |
| (6x6) - ViSP | 0.27 | 0.22 | 1.22 |
| (8x8) - Naive code | 0.26 | 0.26 | 0.99 |
| (8x8) - ViSP | 0.31 | 0.25 | 1.23 |
| (10x10) - Naive code | 0.45 | 0.45 | 1.00 |
| (10x10) - ViSP | 0.43 | 0.37 | 1.17 |
| (20x20) - Naive code | 2.98 | 2.92 | 1.02 |
| (20x20) - ViSP | 1.13 | 1.04 | 1.09 |
| (6x200) - Naive code | 91.37 | 93.58 | 0.98 |
| (6x200) - ViSP | 40.61 | 33.56 | 1.21 |
| (200x6) - Naive code | 3.98 | 3.98 | 1.00 |
| (200x6) - ViSP | 1.96 | 1.84 | 1.06 |
| (207x119) - Naive code | 1380.70 | 1389.71 | 0.99 |
| (207x119) - ViSP | 54.12 | 54.52 | 0.99 |
| (83x201) - Naive code | 1444.74 | 1448.31 | 1.00 |
| (83x201) - ViSP | 61.09 | 62.15 | 0.98 |
| (600x400) - Naive code | 54764.11 | 52523.58 | 1.04 |
| (600x400) - ViSP | 912.44 | 835.05 | 1.09 |
| (400x600) - Naive code | 72913.58 | 73687.02 | 0.99 |
| (400x600) - ViSP | 1322.87 | 1312.16 | 1.01 |

| Benchmark AAt | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (3x3) - Naive code | 0.08 | 0.08 | 1.01 |
| (3x3) - ViSP | 0.21 | 0.17 | 1.23 |
| (6x6) - Naive code | 0.15 | 0.15 | 1.01 |
| (6x6) - ViSP | 0.26 | 0.22 | 1.17 |
| (8x8) - Naive code | 0.26 | 0.27 | 0.99 |
| (8x8) - ViSP | 0.30 | 0.23 | 1.31 |
| (10x10) - Naive code | 0.43 | 0.44 | 0.98 |
| (10x10) - ViSP | 0.41 | 0.33 | 1.24 |
| (20x20) - Naive code | 2.68 | 2.73 | 0.98 |
| (20x20) - ViSP | 1.15 | 0.94 | 1.23 |
| (6x200) - Naive code | 3.93 | 4.04 | 0.97 |
| (6x200) - ViSP | 1.67 | 1.64 | 1.02 |
| (200x6) - Naive code | 85.29 | 87.45 | 0.98 |
| (200x6) - ViSP | 40.27 | 32.50 | 1.24 |

| Benchmark matrix-velocity twist multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.24 | 0.95 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.22 | 1.19 |
| (20x6)x(6x6) - Naive code | 0.55 | 0.58 | 0.95 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.32 | 1.29 |
| (207x6)x(6x6) - Naive code | 5.11 | 5.42 | 0.94 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.88 | 1.34 |
| (600x6)x(6x6) - Naive code | 14.49 | 15.36 | 0.94 |
| (600x6)x(6x6) - ViSP | 6.71 | 5.07 | 1.32 |
| (1201x6)x(6x6) - Naive code | 28.74 | 29.83 | 0.96 |
| (1201x6)x(6x6) - ViSP | 13.21 | 10.15 | 1.30 |

| Benchmark matrix-force twist multiplication | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| (6x6)x(6x6) - Naive code | 0.23 | 0.24 | 0.97 |
| (6x6)x(6x6) - ViSP | 0.27 | 0.22 | 1.22 |
| (20x6)x(6x6) - Naive code | 0.56 | 0.58 | 0.97 |
| (20x6)x(6x6) - ViSP | 0.41 | 0.33 | 1.24 |
| (207x6)x(6x6) - Naive code | 5.10 | 5.40 | 0.94 |
| (207x6)x(6x6) - ViSP | 2.52 | 1.87 | 1.35 |
| (600x6)x(6x6) - Naive code | 14.46 | 15.24 | 0.95 |
| (600x6)x(6x6) - ViSP | 6.83 | 5.09 | 1.34 |
| (1201x6)x(6x6) - Naive code | 29.11 | 30.09 | 0.97 |
| (1201x6)x(6x6) - ViSP | 13.31 | 10.30 | 1.29 |

</p>
</details>

---

<details><summary>perfGenericTracker OpenBLAS vs MKL</summary>
<p>

| Benchmark generic tracker | OpenBLAS | MKL | Speed-up |
| --- | --- | --- | --- |
| Edge MBT | 161677.49 | 166364.90 | 0.97 |
| Edge + Depth dense MBT | 333057.51 | 308968.60 | 1.08 |

</p>
</details>

<details><summary>perfGenericTracker OpenBLAS 0.2.20 vs OpenBLAS @e7f0da92</summary>
<p>

| Benchmark generic tracker | OpenBLAS 0.2.20 | OpenBLAS @e7f0da92 | Speed-up |
| --- | --- | --- | --- |
| Edge MBT | 161677.49 | 161156.84 | 1.00 |
| Edge + Depth dense MBT | 333057.51 | 332829.89 | 1.00 |

</p>
</details>