### PR TITLE
Fix realsense t265

### DIFF
--- a/modules/sensor/include/visp3/sensor/vpRealSense2.h
+++ b/modules/sensor/include/visp3/sensor/vpRealSense2.h
@@ -359,6 +359,7 @@ public:
   vpHomogeneousMatrix getTransformation(const rs2_stream &from, const rs2_stream &to, int from_index = -1) const;
 
   void open(const rs2::config &cfg = rs2::config());
+  void open(const rs2::config &cfg, std::function<void(rs2::frame)> &callback);
 
   friend VISP_EXPORT std::ostream &operator<<(std::ostream &os, const vpRealSense2 &rs);
 


### PR DESCRIPTION
Overloading `open()` function to enable the use of callbacks. Callbacks will be used to access different data streams (images, pose, ...) at different rates.