### PR TITLE
Various improvements in pseudo inverse

### DIFF
--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -299,8 +299,7 @@ public:
   after resize. If false, the initial values from the common part of the
   array (common part between old and new version of the array) are kept.
   Default value is true.
-  \param recopy_ : if true, will perform an explicit recopy of the old data
-  if needed and if flagNullify is set to false.
+  \param recopy_ : if true, will perform an explicit recopy of the old data.
   */
   void resize(unsigned int nrows, unsigned int ncols, bool flagNullify = true, bool recopy_ = true)
   {

--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -485,29 +485,42 @@ vpMatrix M(R);
   unsigned int pseudoInverse(vpMatrix &Ap, double svThreshold = 1e-6) const;
   unsigned int pseudoInverse(vpMatrix &Ap, vpColVector &sv, double svThreshold = 1e-6) const;
   unsigned int pseudoInverse(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt) const;
-  unsigned int pseudoInverse(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt,
-                             vpMatrix &kerAt) const;
+  unsigned int pseudoInverse(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
+  vpMatrix pseudoInverse(int rank_in) const;
+  int pseudoInverse(vpMatrix &Ap, int rank_in) const;
+  int pseudoInverse(vpMatrix &Ap, vpColVector &sv, int rank_in) const;
+  int pseudoInverse(vpMatrix &Ap, vpColVector &sv, int rank_in, vpMatrix &imA, vpMatrix &imAt) const;
+  int pseudoInverse(vpMatrix &Ap, vpColVector &sv, int rank_in, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
 
 #if defined(VISP_HAVE_LAPACK)
   vpMatrix pseudoInverseLapack(double svThreshold = 1e-6) const;
   unsigned int pseudoInverseLapack(vpMatrix &Ap, double svThreshold = 1e-6) const;
   unsigned int pseudoInverseLapack(vpMatrix &Ap, vpColVector &sv, double svThreshold = 1e-6) const;
-  unsigned int pseudoInverseLapack(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt,
-                                   vpMatrix &kerAt) const;
+  unsigned int pseudoInverseLapack(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
+  vpMatrix pseudoInverseLapack(int rank_in) const;
+  int pseudoInverseLapack(vpMatrix &Ap, int rank_in) const;
+  int pseudoInverseLapack(vpMatrix &Ap, vpColVector &sv, int rank_in) const;
+  int pseudoInverseLapack(vpMatrix &Ap, vpColVector &sv, int rank_in, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
 #endif
 #if defined(VISP_HAVE_EIGEN3)
   vpMatrix pseudoInverseEigen3(double svThreshold = 1e-6) const;
   unsigned int pseudoInverseEigen3(vpMatrix &Ap, double svThreshold = 1e-6) const;
   unsigned int pseudoInverseEigen3(vpMatrix &Ap, vpColVector &sv, double svThreshold = 1e-6) const;
-  unsigned int pseudoInverseEigen3(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt,
-                                   vpMatrix &kerAt) const;
+  unsigned int pseudoInverseEigen3(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
+  vpMatrix pseudoInverseEigen3(int rank_in) const;
+  int pseudoInverseEigen3(vpMatrix &Ap, int rank_in) const;
+  int pseudoInverseEigen3(vpMatrix &Ap, vpColVector &sv, int rank_in) const;
+  int pseudoInverseEigen3(vpMatrix &Ap, vpColVector &sv, int rank_in, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
 #endif
 #if (VISP_HAVE_OPENCV_VERSION >= 0x020101)
   vpMatrix pseudoInverseOpenCV(double svThreshold = 1e-6) const;
   unsigned int pseudoInverseOpenCV(vpMatrix &Ap, double svThreshold = 1e-6) const;
   unsigned int pseudoInverseOpenCV(vpMatrix &Ap, vpColVector &sv, double svThreshold = 1e-6) const;
-  unsigned int pseudoInverseOpenCV(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt,
-                                   vpMatrix &kerAt) const;
+  unsigned int pseudoInverseOpenCV(vpMatrix &Ap, vpColVector &sv, double svThreshold, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
+  vpMatrix pseudoInverseOpenCV(int rank_in) const;
+  int pseudoInverseOpenCV(vpMatrix &Ap, int rank_in) const;
+  int pseudoInverseOpenCV(vpMatrix &Ap, vpColVector &sv, int rank_in) const;
+  int pseudoInverseOpenCV(vpMatrix &Ap, vpColVector &sv, int rank_in, vpMatrix &imA, vpMatrix &imAt, vpMatrix &kerAt) const;
 #endif
   //@}
 


### PR DESCRIPTION
- remove duplicated `compute_pseudo_inverse()` in `vpMatrix`
- optimize pseudo inverse computation avoiding extra transpose when nrows < ncols
- introduce new `vpMatrix::pseudo_inverse()` functions with the rank as input parameter instead of a singular values threshold