### PR TITLE
Various improvements in model-based tracker 

### DIFF
--- a/example/tracking/mbtEdgeKltTracking.cpp
+++ b/example/tracking/mbtEdgeKltTracking.cpp
@@ -592,13 +592,6 @@ int main(int argc, const char **argv)
     }
     reader.close();
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbEdgeKltTracker::loadModel() We clean only if Coin was used.
-    if (!cao3DModel)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/example/tracking/mbtEdgeTracking.cpp
+++ b/example/tracking/mbtEdgeTracking.cpp
@@ -568,13 +568,6 @@ int main(int argc, const char **argv)
     }
     reader.close();
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbEdgeTracker::loadModel() We clean only if Coin was used.
-    if (!cao3DModel)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/example/tracking/mbtGenericTracking.cpp
+++ b/example/tracking/mbtGenericTracking.cpp
@@ -641,13 +641,6 @@ int main(int argc, const char **argv)
     delete tracker;
     tracker = NULL;
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbGenericTracker::loadModel() We clean only if Coin was used.
-    if (!cao3DModel)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/example/tracking/mbtGenericTracking2.cpp
+++ b/example/tracking/mbtGenericTracking2.cpp
@@ -727,13 +727,6 @@ int main(int argc, const char **argv)
     delete tracker;
     tracker = NULL;
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbGenericTracker::loadModel() We clean only if Coin was used.
-    if (!cao3DModel)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/example/tracking/mbtGenericTrackingDepth.cpp
+++ b/example/tracking/mbtGenericTrackingDepth.cpp
@@ -759,6 +759,13 @@ int main(int argc, const char **argv)
           ss.str("");
           ss << "nb features: " << tracker->getError().getRows();
           vpDisplay::displayText(I_depth, 80, 20, ss.str(), vpColor::red);
+          {
+            std::stringstream ss;
+            ss << "Features: edges " << dynamic_cast<vpMbGenericTracker *>(tracker)->getNbFeaturesEdge()
+               << ", klt " << dynamic_cast<vpMbGenericTracker *>(tracker)->getNbFeaturesKlt()
+               << ", depth " << dynamic_cast<vpMbGenericTracker *>(tracker)->getNbFeaturesDepthDense();
+            vpDisplay::displayText(I, I.getHeight() - 30, 20, ss.str(), vpColor::red);
+          }
         }
       }
 

--- a/example/tracking/mbtGenericTrackingDepth.cpp
+++ b/example/tracking/mbtGenericTrackingDepth.cpp
@@ -816,13 +816,6 @@ int main(int argc, const char **argv)
     delete tracker;
     tracker = NULL;
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbGenericTracker::loadModel() We clean only if Coin was used.
-    if (use_vrml)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/example/tracking/mbtGenericTrackingDepthOnly.cpp
+++ b/example/tracking/mbtGenericTrackingDepthOnly.cpp
@@ -761,13 +761,6 @@ int main(int argc, const char **argv)
     delete tracker;
     tracker = NULL;
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbGenericTracker::loadModel() We clean only if Coin was used.
-    if (use_vrml)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/example/tracking/mbtKltTracking.cpp
+++ b/example/tracking/mbtKltTracking.cpp
@@ -539,13 +539,6 @@ int main(int argc, const char **argv)
 
     reader.close();
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model in
-    // vpMbKltTracker::loadModel() We clean only if Coin was used.
-    if (!cao3DModel)
-      SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -195,6 +195,25 @@ public:
   virtual void getMovingEdge(vpMe &me1, vpMe &me2) const;
   virtual void getMovingEdge(std::map<std::string, vpMe> &mapOfMovingEdges) const;
 
+  /*!
+   * Return the number of depth dense features taken into account in the virtual visual-servoing scheme.
+   */
+  virtual inline unsigned int getNbFeaturesDepthDense() const { return m_nb_feat_depthDense; }
+  /*!
+   * Return the number of depth normal features features taken into account in the virtual visual-servoing scheme.
+   */
+  virtual inline unsigned int getNbFeaturesDepthNormal() const { return m_nb_feat_depthNormal; }
+  /*!
+   * Return the number of moving-edges features taken into account in the virtual visual-servoing scheme.
+   *
+   * This function is similar to getNbPoints().
+   */
+  virtual inline unsigned int getNbFeaturesEdge() const { return m_nb_feat_edge; }
+  /*!
+   * Return the number of klt keypoints features taken into account in the virtual visual-servoing scheme.
+   */
+  virtual inline unsigned int getNbFeaturesKlt() const { return m_nb_feat_klt; }
+
   virtual unsigned int getNbPoints(unsigned int level = 0) const;
   virtual void getNbPoints(std::map<std::string, unsigned int> &mapOfNbPoints, unsigned int level = 0) const;
 
@@ -654,5 +673,15 @@ protected:
   vpColVector m_w;
   //! Weighted error
   vpColVector m_weightedError;
+
+  //! Number of moving-edges features
+  unsigned int m_nb_feat_edge;
+  //! Number of klt features
+  unsigned int m_nb_feat_klt;
+  //! Number of depth normal features
+  unsigned int m_nb_feat_depthNormal;
+  //! Number of depth dense features
+  unsigned int m_nb_feat_depthDense;
+
 };
 #endif

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbTracker.h
@@ -221,6 +221,8 @@ protected:
   const vpImage<bool> *m_mask;
   //! Grayscale image buffer, used when passing color images
   vpImage<unsigned char> m_I;
+  //! Flag that indicates that SoDB::init(); was called
+  bool m_sodb_init_called;
 
 public:
   vpMbTracker();

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -498,18 +498,18 @@ void vpMbGenericTracker::computeVVS(std::map<std::string, const vpImage<unsigned
        it != m_mapOfTrackers.end(); ++it) {
     TrackerWrapper *tracker = it->second;
     if (tracker->m_trackerType & EDGE_TRACKER) {
-      m_nb_feat_edge = tracker->m_error_edge.size();
+      m_nb_feat_edge += tracker->m_error_edge.size();
     }
 #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
     if (tracker->m_trackerType & KLT_TRACKER) {
-      m_nb_feat_klt = tracker->m_error_klt.size();
+      m_nb_feat_klt += tracker->m_error_klt.size();
     }
 #endif
     if (tracker->m_trackerType & DEPTH_NORMAL_TRACKER) {
-      m_nb_feat_depthNormal = tracker->m_error_depthNormal.size();
+      m_nb_feat_depthNormal += tracker->m_error_depthNormal.size();
     }
     if (tracker->m_trackerType & DEPTH_DENSE_TRACKER) {
-      m_nb_feat_depthDense = tracker->m_error_depthDense.size();
+      m_nb_feat_depthDense += tracker->m_error_depthDense.size();
     }
   }
 

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -2903,18 +2903,6 @@ void vpMbGenericTracker::loadConfigFile(const std::map<std::string, std::string>
   file (.wrl) or a CAO file (.cao). CAO format is described in the
   loadCAOModel() method.
 
-  \warning When this class is called to load a vrml model, remember that you
-  have to call Call SoDD::finish() before ending the program.
-  \code
-int main()
-{
-    ...
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-  SoDB::finish();
-#endif
-}
-  \endcode
-
   \throw vpException::ioError if the file cannot be open, or if its extension
 is not wrl or cao.
 
@@ -2942,27 +2930,15 @@ void vpMbGenericTracker::loadModel(const std::string &modelFile, bool verbose, c
   file (.wrl) or a CAO file (.cao). CAO format is described in the
   loadCAOModel() method.
 
-  \warning When this class is called to load a vrml model, remember that you
-  have to call Call SoDD::finish() before ending the program.
-  \code
-int main()
-{
-    ...
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-  SoDB::finish();
-#endif
-}
-  \endcode
-
   \throw vpException::ioError if the file cannot be open, or if its extension
-is not wrl or cao.
+  is not wrl or cao.
 
   \param modelFile1 : the file containing the 3D model description for the
-first camera. The extension of this file is either .wrl or .cao.
+  first camera. The extension of this file is either .wrl or .cao.
   \param modelFile2 : the file containing the the 3D model description for the second
-camera. The extension of this file is either .wrl or .cao.
+  camera. The extension of this file is either .wrl or .cao.
   \param verbose : verbose option to print additional information when loading CAO model files
-which include other CAO model files.
+  which include other CAO model files.
   \param T1 : optional transformation matrix (currently only for .cao) to transform
   3D points in \a modelFile1 expressed in the original object frame to the desired object frame.
   \param T2 : optional transformation matrix (currently only for .cao) to transform
@@ -2992,25 +2968,13 @@ void vpMbGenericTracker::loadModel(const std::string &modelFile1, const std::str
   file (.wrl) or a CAO file (.cao). CAO format is described in the
   loadCAOModel() method.
 
-  \warning When this class is called to load a vrml model, remember that you
-  have to call Call SoDD::finish() before ending the program.
-  \code
-int main()
-{
-    ...
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-  SoDB::finish();
-#endif
-}
-  \endcode
-
   \throw vpException::ioError if the file cannot be open, or if its extension
-is not wrl or cao.
+  is not wrl or cao.
 
   \param mapOfModelFiles : map of files containing the 3D model description.
   The extension of this file is either .wrl or .cao.
   \param verbose : verbose option to print additional information when loading
-CAO model files which include other CAO model files.
+  CAO model files which include other CAO model files.
   \param mapOfT : optional map of transformation matrices (currently only for .cao)
   to transform 3D points in \a mapOfModelFiles expressed in the original object frame to
   the desired object frame (if the models have the same object frame which should be the

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -42,7 +42,8 @@
 
 vpMbGenericTracker::vpMbGenericTracker()
   : m_error(), m_L(), m_mapOfCameraTransformationMatrix(), m_mapOfFeatureFactors(), m_mapOfTrackers(),
-    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError()
+    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError(),
+    m_nb_feat_edge(0), m_nb_feat_klt(0), m_nb_feat_depthNormal(0), m_nb_feat_depthDense(0)
 {
   m_mapOfTrackers["Camera"] = new TrackerWrapper(EDGE_TRACKER);
 
@@ -62,7 +63,8 @@ vpMbGenericTracker::vpMbGenericTracker()
 
 vpMbGenericTracker::vpMbGenericTracker(unsigned int nbCameras, int trackerType)
   : m_error(), m_L(), m_mapOfCameraTransformationMatrix(), m_mapOfFeatureFactors(), m_mapOfTrackers(),
-    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError()
+    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError(),
+    m_nb_feat_edge(0), m_nb_feat_klt(0), m_nb_feat_depthNormal(0), m_nb_feat_depthDense(0)
 {
   if (nbCameras == 0) {
     throw vpException(vpTrackingException::fatalError, "Cannot use no camera!");
@@ -98,7 +100,8 @@ vpMbGenericTracker::vpMbGenericTracker(unsigned int nbCameras, int trackerType)
 
 vpMbGenericTracker::vpMbGenericTracker(const std::vector<int> &trackerTypes)
   : m_error(), m_L(), m_mapOfCameraTransformationMatrix(), m_mapOfFeatureFactors(), m_mapOfTrackers(),
-    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError()
+    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError(),
+    m_nb_feat_edge(0), m_nb_feat_klt(0), m_nb_feat_depthNormal(0), m_nb_feat_depthDense(0)
 {
   if (trackerTypes.empty()) {
     throw vpException(vpException::badValue, "There is no camera!");
@@ -137,7 +140,8 @@ vpMbGenericTracker::vpMbGenericTracker(const std::vector<int> &trackerTypes)
 vpMbGenericTracker::vpMbGenericTracker(const std::vector<std::string> &cameraNames,
                                        const std::vector<int> &trackerTypes)
   : m_error(), m_L(), m_mapOfCameraTransformationMatrix(), m_mapOfFeatureFactors(), m_mapOfTrackers(),
-    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError()
+    m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError(),
+    m_nb_feat_edge(0), m_nb_feat_klt(0), m_nb_feat_depthNormal(0), m_nb_feat_depthDense(0)
 {
   if (cameraNames.size() != trackerTypes.size() || cameraNames.empty()) {
     throw vpException(vpTrackingException::badValue,
@@ -313,6 +317,11 @@ void vpMbGenericTracker::computeVVS(std::map<std::string, const vpImage<unsigned
   double factorDepth = m_mapOfFeatureFactors[DEPTH_NORMAL_TRACKER];
   double factorDepthDense = m_mapOfFeatureFactors[DEPTH_DENSE_TRACKER];
 
+  m_nb_feat_edge = 0;
+  m_nb_feat_klt = 0;
+  m_nb_feat_depthNormal = 0;
+  m_nb_feat_depthDense = 0;
+
   while (std::fabs(normRes_1 - normRes) > m_stopCriteriaEpsilon && (iter < m_maxIter)) {
     computeVVSInteractionMatrixAndResidu(mapOfImages, mapOfVelocityTwist);
 
@@ -482,6 +491,26 @@ void vpMbGenericTracker::computeVVS(std::map<std::string, const vpImage<unsigned
     }
 
     iter++;
+  }
+
+  // Update features number
+  for (std::map<std::string, TrackerWrapper *>::const_iterator it = m_mapOfTrackers.begin();
+       it != m_mapOfTrackers.end(); ++it) {
+    TrackerWrapper *tracker = it->second;
+    if (tracker->m_trackerType & EDGE_TRACKER) {
+      m_nb_feat_edge = tracker->m_error_edge.size();
+    }
+#if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
+    if (tracker->m_trackerType & KLT_TRACKER) {
+      m_nb_feat_klt = tracker->m_error_klt.size();
+    }
+#endif
+    if (tracker->m_trackerType & DEPTH_NORMAL_TRACKER) {
+      m_nb_feat_depthNormal = tracker->m_error_depthNormal.size();
+    }
+    if (tracker->m_trackerType & DEPTH_DENSE_TRACKER) {
+      m_nb_feat_depthDense = tracker->m_error_depthDense.size();
+    }
   }
 
   computeCovarianceMatrixVVS(isoJoIdentity_, W_true, cMo_prev, L_true, LVJ_true, m_error);
@@ -1507,6 +1536,8 @@ void vpMbGenericTracker::getMovingEdge(std::map<std::string, vpMe> &mapOfMovingE
 
   \note Multi-scale moving edge tracking is not possible, scale level=0 must
   be used.
+
+  \sa getNbFeaturesEdge()
 */
 unsigned int vpMbGenericTracker::getNbPoints(unsigned int level) const
 {
@@ -1801,9 +1832,9 @@ void vpMbGenericTracker::initCircle(const vpPoint & /*p1*/, const vpPoint & /*p2
   the image acquired by the second camera. This file should have .init
   extension.
   \param displayHelp : Optionnal display of an image that should
-  have the same generic name as the init file (ie teabox.ppm). This image may
+  have the same generic name as the init file (ie teabox.ppm, or teabox.png). This image may
   be used to show where to click. This functionality is only available if
-  visp_io module is used.
+  visp_io module is used. Supported image formats are .pgm, .ppm, .png, .jpeg.
   \param T1 : optional transformation matrix to transform 3D points in \a initFile1
   expressed in the original object frame to the desired object frame.
   \param T2 : optional transformation matrix to transform 3D points in \a initFile2
@@ -1870,9 +1901,9 @@ void vpMbGenericTracker::initClick(const vpImage<unsigned char> &I1, const vpIma
   the image acquired by the second camera. This file should have .init
   extension.
   \param displayHelp : Optionnal display of an image that should
-  have the same generic name as the init file (ie teabox.ppm). This image may
+  have the same generic name as the init file (ie teabox.ppm, or teabox.png). This image may
   be used to show where to click. This functionality is only available if
-  visp_io module is used.
+  visp_io module is used. Supported image formats are .pgm, .ppm, .png, .jpeg.
   \param T1 : optional transformation matrix to transform 3D points in \a initFile1
   expressed in the original object frame to the desired object frame.
   \param T2 : optional transformation matrix to transform 3D points in \a initFile2
@@ -1935,10 +1966,10 @@ void vpMbGenericTracker::initClick(const vpImage<vpRGBa> &I_color1, const vpImag
   \param mapOfImages : Map of grayscale images.
   \param mapOfInitFiles : Map of files containing the points where to click
   for each camera.
-  \param displayHelp : Optionnal display of an image that
-  should have the same generic name as the init file (ie teabox.ppm). This
-  image may be used to show where to click. This functionality is only
-  available if visp_io module is used.
+  \param displayHelp : Optionnal display of an image that should
+  have the same generic name as the init file (ie teabox.ppm, or teabox.png). This image may
+  be used to show where to click. This functionality is only available if
+  visp_io module is used. Supported image formats are .pgm, .ppm, .png, .jpeg.
   \param mapOfT : optional map of transformation matrices to transform
   3D points in \a mapOfInitFiles expressed in the original object frame to the
   desired object frame (if the init points are expressed in the same object frame
@@ -2037,10 +2068,10 @@ void vpMbGenericTracker::initClick(const std::map<std::string, const vpImage<uns
   \param mapOfColorImages : Map of color images.
   \param mapOfInitFiles : Map of files containing the points where to click
   for each camera.
-  \param displayHelp : Optionnal display of an image that
-  should have the same generic name as the init file (ie teabox.ppm). This
-  image may be used to show where to click. This functionality is only
-  available if visp_io module is used.
+  \param displayHelp : Optionnal display of an image that should
+  have the same generic name as the init file (ie teabox.ppm, or teabox.png). This image may
+  be used to show where to click. This functionality is only available if
+  visp_io module is used. Supported image formats are .pgm, .ppm, .png, .jpeg.
   \param mapOfT : optional map of transformation matrices to transform
   3D points in \a mapOfInitFiles expressed in the original object frame to the
   desired object frame (if the init points are expressed in the same object frame

--- a/modules/tracker/mbt/test/testGenericTracker.cpp
+++ b/modules/tracker/mbt/test/testGenericTracker.cpp
@@ -627,11 +627,6 @@ namespace
     if (!vec_err_tu.empty())
       std::cout << "Max thetau error: " << *std::max_element(vec_err_tu.begin(), vec_err_tu.end()) << std::endl;
 
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    // Cleanup memory allocated by Coin library used to load a vrml model. We clean only if Coin was used.
-    SoDB::finish();
-#endif
-
     return EXIT_SUCCESS;
   }
 }

--- a/tutorial/detection/object/tutorial-detection-object-mbt-deprecated.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt-deprecated.cpp
@@ -221,9 +221,6 @@ int main(int argc, char **argv)
     }
     if (!click_done)
       vpDisplay::getClick(I);
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
   }

--- a/tutorial/detection/object/tutorial-detection-object-mbt.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt.cpp
@@ -221,9 +221,6 @@ int main(int argc, char **argv)
     }
     if (!click_done)
       vpDisplay::getClick(I);
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
   }

--- a/tutorial/detection/object/tutorial-detection-object-mbt2-deprecated.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt2-deprecated.cpp
@@ -314,10 +314,6 @@ int main(int argc, char **argv)
 
     if (!click_done)
       vpDisplay::getClick(IMatching);
-
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
   }

--- a/tutorial/detection/object/tutorial-detection-object-mbt2.cpp
+++ b/tutorial/detection/object/tutorial-detection-object-mbt2.cpp
@@ -314,10 +314,6 @@ int main(int argc, char **argv)
 
     if (!click_done)
       vpDisplay::getClick(IMatching);
-
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
   } catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
   }

--- a/tutorial/tracking/model-based/generic-apriltag/tutorial-mb-generic-tracker-apriltag-rs2.cpp
+++ b/tutorial/tracking/model-based/generic-apriltag/tutorial-mb-generic-tracker-apriltag-rs2.cpp
@@ -104,6 +104,11 @@ state_t track(const vpImage<unsigned char> &I, vpMbGenericTracker &tracker,
   tracker.display(I, cMo, cam, vpColor::red, 2);
   vpDisplay::displayFrame(I, cMo, cam, 0.025, vpColor::none, 3);
   vpDisplay::displayText(I, 40, 20, "State: tracking in progress", vpColor::red);
+  {
+    std::stringstream ss;
+    ss << "Features: edges " << tracker.getNbFeaturesEdge() << ", klt " << tracker.getNbFeaturesKlt();
+    vpDisplay::displayText(I, 60, 20, ss.str(), vpColor::red);
+  }
 
   return state_tracking;
 }
@@ -413,6 +418,13 @@ int main(int argc, const char **argv)
         }
         else {
           state = track(I_gray, tracker, opt_projection_error_threshold, cMo);
+        }
+        {
+          std::stringstream ss;
+          ss << "Features: edges " << tracker.getNbFeaturesEdge()
+             << ", klt " << tracker.getNbFeaturesKlt()
+             << ", depth " << tracker.getNbFeaturesDepthDense();
+          vpDisplay::displayText(I_gray, I_gray.getHeight() - 30, 20, ss.str(), vpColor::red);
         }
       }
 

--- a/tutorial/tracking/model-based/generic-apriltag/tutorial-mb-generic-tracker-apriltag-webcam.cpp
+++ b/tutorial/tracking/model-based/generic-apriltag/tutorial-mb-generic-tracker-apriltag-webcam.cpp
@@ -104,6 +104,11 @@ state_t track(const vpImage<unsigned char> &I, vpMbGenericTracker &tracker,
   tracker.display(I, cMo, cam, vpColor::red, 2);
   vpDisplay::displayFrame(I, cMo, cam, 0.025, vpColor::none, 3);
   vpDisplay::displayText(I, 40, 20, "State: tracking in progress", vpColor::red);
+  {
+    std::stringstream ss;
+    ss << "Features: edges " << tracker.getNbFeaturesEdge() << ", klt " << tracker.getNbFeaturesKlt();
+    vpDisplay::displayText(I, 60, 20, ss.str(), vpColor::red);
+  }
 
   return state_tracking;
 }

--- a/tutorial/tracking/model-based/generic-rgbd-blender/tutorial-mb-generic-tracker-rgbd-blender.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd-blender/tutorial-mb-generic-tracker-rgbd-blender.cpp
@@ -216,8 +216,9 @@ int main(int argc, char *argv[])
           mapOfPointCloudWidths["Camera2"] = depth_width;
           mapOfPointCloudHeights["Camera2"] = depth_height;
           tracker.track(mapOfImages, mapOfPointClouds, mapOfPointCloudWidths, mapOfPointCloudHeights);
-        } else
+        } else {
           tracker.track(I);
+        }
       }
 
       vpHomogeneousMatrix cMo = tracker.getPose();
@@ -229,8 +230,9 @@ int main(int argc, char *argv[])
         tracker.display(I, I_depth, cMo, depthMcolor*cMo, cam_color, cam_depth, vpColor::red, 2);
         vpDisplay::displayFrame(I_depth, depthMcolor*cMo, cam_depth, 0.05, vpColor::none, 2);
       }
-      else
+      else {
         tracker.display(I, cMo, cam_color, vpColor::red, 2);
+      }
 
       vpDisplay::displayFrame(I, cMo, cam_color, 0.05, vpColor::none, 2);
       std::ostringstream oss;
@@ -238,9 +240,18 @@ int main(int argc, char *argv[])
       vpDisplay::displayText(I, 20, 20, oss.str(), vpColor::red);
 
       if (!display_ground_truth) {
-        oss.str("");
-        oss << "Nb features: " << tracker.getError().getRows();
-        vpDisplay::displayText(I, 40, 20, oss.str(), vpColor::red);
+        {
+          std::stringstream ss;
+          ss << "Nb features: " << tracker.getError().size();
+          vpDisplay::displayText(I, I.getHeight() - 50, 20, ss.str(), vpColor::red);
+        }
+        {
+          std::stringstream ss;
+          ss << "Features: edges " << tracker.getNbFeaturesEdge()
+             << ", klt " << tracker.getNbFeaturesKlt()
+             << ", depth " << tracker.getNbFeaturesDepthDense();
+          vpDisplay::displayText(I, I.getHeight() - 30, 20, ss.str(), vpColor::red);
+        }
       }
 
       vpDisplay::flush(I);
@@ -264,7 +275,7 @@ int main(int argc, char *argv[])
       frame_cpt++;
     }
 
-    vpDisplay::displayText(I, 20, 20, "Click to quit.", vpColor::red);
+    vpDisplay::displayText(I, 40, 20, "Click to quit.", vpColor::red);
     vpDisplay::flush(I);
     vpDisplay::getClick(I);
   } catch (std::exception& e) {

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense.cpp
@@ -420,14 +420,17 @@ int main(int argc, char *argv[])
           vpDisplay::displayFrame(I_depth, cMo, cam_depth, 0.05, vpColor::none, 3);
         }
 
-        if (use_edges || use_klt) {
+        {
           std::stringstream ss;
-          ss << "Nb features: " << tracker.getError().getRows();
-          vpDisplay::displayText(I_gray, 20, I_gray.getWidth() - 150, ss.str(), vpColor::red);
-        } else if (use_depth) {
+          ss << "Nb features: " << tracker.getError().size();
+          vpDisplay::displayText(I_gray, I_gray.getHeight() - 50, 20, ss.str(), vpColor::red);
+        }
+        {
           std::stringstream ss;
-          ss << "Nb features: " << tracker.getError().getRows();
-          vpDisplay::displayText(I_depth, 20, I_depth.getWidth() - 150, ss.str(), vpColor::red);
+          ss << "Features: edges " << tracker.getNbFeaturesEdge()
+             << ", klt " << tracker.getNbFeaturesKlt()
+             << ", depth " << tracker.getNbFeaturesDepthDense();
+          vpDisplay::displayText(I_gray, I_gray.getHeight() - 30, 20, ss.str(), vpColor::red);
         }
       }
 

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
@@ -111,7 +111,9 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<vpR
       float point[3];
       float pixel[2] = {(float)j, (float)i};
       rs_deproject_pixel_to_point(point, depth_intrinsic, pixel, scaled_depth);
-      pointcloud->push_back(pcl::PointXYZ(point[0], point[1], point[2]));
+      pointcloud->points[(size_t) (i*width + j)].x = point[0];
+      pointcloud->points[(size_t) (i*width + j)].y = point[1];
+      pointcloud->points[(size_t) (i*width + j)].z = point[2];
     }
   }
 

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
@@ -117,6 +117,7 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<vpR
     }
   }
 
+  std::cout << "DEBUG: point cloud size: " << pointcloud->width << " " << pointcloud->height << std::endl;
   return true;
 }
 }

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
@@ -77,7 +77,6 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<vpR
   unsigned int height = 0, width = 0;
   vpIoTools::readBinaryValueLE(file_depth, height);
   vpIoTools::readBinaryValueLE(file_depth, width);
-
   I_depth_raw.resize(height, width);
 
   uint16_t depth_value = 0;
@@ -126,7 +125,7 @@ int main(int argc, char *argv[])
   std::string config_color = "model/cube/cube.xml", config_depth = "model/cube/cube_depth.xml";
   std::string model_color = "model/cube/cube.cao", model_depth = "model/cube/cube.cao";
   std::string init_file = "model/cube/cube.init";
-  int frame_cpt = 0;
+  unsigned int frame_cpt = 0;
   bool disable_depth = false;
 
   for (int i = 1; i < argc; i++) {
@@ -153,6 +152,16 @@ int main(int argc, char *argv[])
     }
   }
 
+  std::cout << "Tracked features: " << std::endl;
+#ifdef VISP_HAVE_OPENCV
+  std::cout << "  Use edges   : 1" << std::endl;
+  std::cout << "  Use klt     : 1" << std::endl;
+  std::cout << "  Use depth   : " << ! disable_depth << std::endl;
+#else
+  std::cout << "  Use edges   : 1" << std::endl;
+  std::cout << "  Use klt     : 0" << std::endl;
+  std::cout << "  Use depth   : 0" << std::endl;
+#endif
   std::cout << "Config files: " << std::endl;
   std::cout << "  Input directory: " << "\"" << input_directory << "\"" << std::endl;
   std::cout << "  Config color: " << "\"" << config_color << "\"" << std::endl;
@@ -192,7 +201,8 @@ int main(int argc, char *argv[])
   std::vector<int> trackerTypes;
 #ifdef VISP_HAVE_OPENCV
   trackerTypes.push_back(vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER);
-  trackerTypes.push_back(vpMbGenericTracker::DEPTH_DENSE_TRACKER);
+  if (!disable_depth)
+    trackerTypes.push_back(vpMbGenericTracker::DEPTH_DENSE_TRACKER);
 #else
   trackerTypes.push_back(vpMbGenericTracker::EDGE_TRACKER);
 #endif
@@ -248,7 +258,7 @@ int main(int argc, char *argv[])
     bool quit = false;
     while (! quit) {
       double t = vpTime::measureTimeMs();
-      read_data(frame_cpt, input_directory, I_color, I_depth_raw, pointcloud);
+      quit = ! read_data(frame_cpt, input_directory, I_color, I_depth_raw, pointcloud);
       vpImageConvert::convert(I_color, I_gray);
       vpImageConvert::createDepthHistogram(I_depth_raw, I_depth);
 
@@ -284,6 +294,18 @@ int main(int argc, char *argv[])
       std::stringstream ss;
       ss << "Computation time: " << t << " ms";
       vpDisplay::displayText(I_gray, 20, 20, ss.str(), vpColor::red);
+      {
+        std::stringstream ss;
+        ss << "Nb features: " << tracker.getError().size();
+        vpDisplay::displayText(I_gray, I_gray.getHeight() - 50, 20, ss.str(), vpColor::red);
+      }
+      {
+        std::stringstream ss;
+        ss << "Features: edges " << tracker.getNbFeaturesEdge()
+           << ", klt " << tracker.getNbFeaturesKlt()
+           << ", depth " << tracker.getNbFeaturesDepthDense();
+        vpDisplay::displayText(I_gray, I_gray.getHeight() - 30, 20, ss.str(), vpColor::red);
+      }
 
       vpDisplay::flush(I_gray);
       vpDisplay::flush(I_depth);
@@ -301,6 +323,10 @@ int main(int argc, char *argv[])
 
   std::cout << "\nProcessing time, Mean: " << vpMath::getMean(times_vec) << " ms ; Median: " << vpMath::getMedian(times_vec)
             << " ; Std: " << vpMath::getStdev(times_vec) << " ms" << std::endl;
+
+  vpDisplay::displayText(I_gray, 60, 20, "Click to quit", vpColor::red);
+  vpDisplay::flush(I_gray);
+  vpDisplay::getClick(I_gray);
 
   return EXIT_SUCCESS;
 }

--- a/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-full.cpp
+++ b/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-full.cpp
@@ -190,6 +190,11 @@ int main(int argc, char **argv)
       //! [Display]
       vpDisplay::displayFrame(I, cMo, cam, 0.025, vpColor::none, 3);
       vpDisplay::displayText(I, 10, 10, "A click to exit...", vpColor::red);
+      {
+        std::stringstream ss;
+        ss << "Features: edges " << tracker.getNbFeaturesEdge() << ", klt " << tracker.getNbFeaturesKlt();
+        vpDisplay::displayText(I, 30, 10, ss.str(), vpColor::red);
+      }
       vpDisplay::flush(I);
 
       if (vpDisplay::getClick(I, false))

--- a/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-full.cpp
+++ b/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-full.cpp
@@ -201,10 +201,7 @@ int main(int argc, char **argv)
         break;
     }
     vpDisplay::getClick(I);
-//! [Cleanup]
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
+    //! [Cleanup]
     delete display;
     //! [Cleanup]
   } catch (const vpException &e) {

--- a/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-live.cpp
+++ b/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-live.cpp
@@ -440,6 +440,11 @@ int main(int argc, char **argv)
           ss << "Rotation tu: " << std::setprecision(4) << vpMath::deg(pose[3]) << " " << vpMath::deg(pose[4]) << " " << vpMath::deg(pose[5]) << " [deg]";
           vpDisplay::displayText(I, 100, 20, ss.str(), vpColor::green);
         }
+        {
+          std::stringstream ss;
+          ss << "Features: edges " << tracker.getNbFeaturesEdge() << ", klt " << tracker.getNbFeaturesKlt();
+          vpDisplay::displayText(I, 120, 20, ss.str(), vpColor::red);
+        }
       }
 
       if (learn_position) {

--- a/tutorial/tracking/model-based/old/edges/tutorial-mb-edge-tracker.cpp
+++ b/tutorial/tracking/model-based/old/edges/tutorial-mb-edge-tracker.cpp
@@ -139,11 +139,6 @@ int main(int argc, char **argv)
         break;
     }
     vpDisplay::getClick(I);
-//! [Cleanup]
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
-    //! [Cleanup]
   } catch (const vpException &e) {
     std::cout << "Catch a ViSP exception: " << e << std::endl;
   }

--- a/tutorial/tracking/model-based/old/generic/tutorial-mb-tracker-full.cpp
+++ b/tutorial/tracking/model-based/old/generic/tutorial-mb-tracker-full.cpp
@@ -196,10 +196,7 @@ int main(int argc, char **argv)
         break;
     }
     vpDisplay::getClick(I);
-//! [Cleanup]
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
+    //! [Cleanup]
     delete display;
     delete tracker;
     //! [Cleanup]

--- a/tutorial/tracking/model-based/old/hybrid/tutorial-mb-hybrid-tracker.cpp
+++ b/tutorial/tracking/model-based/old/hybrid/tutorial-mb-hybrid-tracker.cpp
@@ -114,10 +114,6 @@ int main(int argc, char **argv)
         break;
     }
     vpDisplay::getClick(I);
-
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
   } catch (const vpException &e) {
     std::cout << "Catch a ViSP exception: " << e << std::endl;
   }

--- a/tutorial/tracking/model-based/old/keypoint/tutorial-mb-klt-tracker.cpp
+++ b/tutorial/tracking/model-based/old/keypoint/tutorial-mb-klt-tracker.cpp
@@ -108,10 +108,6 @@ int main(int argc, char **argv)
         break;
     }
     vpDisplay::getClick(I);
-
-#if defined(VISP_HAVE_COIN3D) && (COIN_MAJOR_VERSION >= 2)
-    SoDB::finish();
-#endif
   } catch (const vpException &e) {
     std::cout << "Catch a ViSP exception: " << e << std::endl;
   }


### PR DESCRIPTION
- Remove `SoDB::finish()` explicit call in examples and tutorials that could bring issues like:
  ```
  tutorial-mb-generic-tracker: mutex.cpp:161: void cc_mutex_destruct(cc_mutex*): Assertion `mutex != NULL' failed.
  Aborted (core dumped)
  ```
- Fix issue in `tutorial-mb-generic-tracker-rgbd.cpp` in `read_data()` to be able to consider depth data as PCL pointcloud
- Introduce new functions to get the number of features by type (edge, klt, depth normal, depth dense). Almost all the examples and tutorial are now displaying this feedback info. Could be useful to understand what's happening in #834 