### PR TITLE
Fix running tutorial with --disable_depth

### DIFF
--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd.cpp
@@ -90,7 +90,7 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<vpR
   // Transform pointcloud
   pointcloud->width = width;
   pointcloud->height = height;
-  pointcloud->reserve((size_t)width * height);
+  pointcloud->resize((size_t)width * height);
 
   // Only for Creative SR300
   const float depth_scale = 0.00100000005f;
@@ -117,7 +117,6 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<vpR
     }
   }
 
-  std::cout << "DEBUG: point cloud size: " << pointcloud->width << " " << pointcloud->height << std::endl;
   return true;
 }
 }
@@ -204,11 +203,10 @@ int main(int argc, char *argv[])
   std::vector<int> trackerTypes;
 #ifdef VISP_HAVE_OPENCV
   trackerTypes.push_back(vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER);
-  if (!disable_depth)
-    trackerTypes.push_back(vpMbGenericTracker::DEPTH_DENSE_TRACKER);
 #else
   trackerTypes.push_back(vpMbGenericTracker::EDGE_TRACKER);
 #endif
+  trackerTypes.push_back(vpMbGenericTracker::DEPTH_DENSE_TRACKER);
   vpMbGenericTracker tracker(trackerTypes);
   //! [Constructor]
   //! [Load config file]


### PR DESCRIPTION
With PCL 1.7, I have this:

```
std::vector<PointT, Eigen::aligned_allocator<PointT> > points;
```

```
inline void reserve (size_t n) { points.reserve (n); }
```

```
      /** \brief Resize the cloud
        * \param[in] n the new cloud size
        */
      inline void resize (size_t n) 
      { 
        points.resize (n);
        if (width * height != n)
        {
          width = static_cast<uint32_t> (n);
          height = 1;
        }
      }
```

```
      /** \brief Insert a new point in the cloud, at the end of the container.
        * \note This breaks the organized structure of the cloud by setting the height to 1!
        * \param[in] pt the point to insert
        */
      inline void 
      push_back (const PointT& pt)
      {
        points.push_back (pt);
        width = static_cast<uint32_t> (points.size ());
        height = 1;
      }
```

No idea why they have implemented `push_back` like this.

In any case, with `reserve` it is `push_back` that must be used with `std::vector`.