### PR TITLE
Lower PCL version requirement for computeCentroid() function

### DIFF
--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
@@ -497,7 +497,7 @@ bool vpMbtFaceDepthNormal::computeDesiredFeaturesPCL(const pcl::PointCloud<pcl::
     extract.setNegative(false);
     extract.filter(*point_cloud_face_extracted);
 
-#if PCL_VERSION_COMPARE(>=, 1, 8, 0)
+#if PCL_VERSION_COMPARE(>=, 1, 7, 2)
     pcl::PointXYZ centroid_point_pcl;
     if (pcl::computeCentroid(*point_cloud_face_extracted, centroid_point_pcl)) {
       pcl::PointXYZ face_normal;


### PR DESCRIPTION
Ubuntu 16.04 comes with:

```
libpcl-dev:
  Installé : 1.7.2-14build1
  Candidat : 1.7.2-14build1
 Table de version :
 *** 1.7.2-14build1 500
        500 http://fr.archive.ubuntu.com/ubuntu xenial/universe amd64 Packages
        100 /var/lib/dpkg/status
```

This function exists in `1.7.2`, [see](https://github.com/PointCloudLibrary/pcl/blob/pcl-1.7.2/common/include/pcl/common/centroid.h#L1114).

Related: https://github.com/lagadic/visp/commit/7dad2e990daf37f39ed4eacb05b42c715b82b498