### PR TITLE
Various improvements in vpHomography and vpMatrix 

### DIFF
--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -181,12 +181,12 @@ void compute_pseudo_inverse(const vpMatrix &U, const vpColVector &sv, const vpMa
   Ap.resize(ncols, nrows, true, false);
 
   // compute the highest singular value and the rank of h
-  double maxsv = fabs(sv[0]);
+  double maxsv = sv[0];
 
   rank_out = 0;
 
   for (unsigned int i = 0; i < ncols; i++) {
-    if (fabs(sv[i]) > maxsv * svThreshold) {
+    if (sv[i] > maxsv * svThreshold) {
       rank_out++;
     }
   }
@@ -6505,14 +6505,14 @@ unsigned int vpMatrix::kernel(vpMatrix &kerAt, double svThreshold) const
   // Compute the highest singular value and rank of the matrix
   double maxsv = 0;
   for (unsigned int i = 0; i < nbcol; i++) {
-    if (fabs(sv[i]) > maxsv) {
-      maxsv = fabs(sv[i]);
+    if (sv[i] > maxsv) {
+      maxsv = sv[i];
     }
   }
 
   unsigned int rank = 0;
   for (unsigned int i = 0; i < nbcol; i++) {
-    if (fabs(sv[i]) > maxsv * svThreshold) {
+    if (sv[i] > maxsv * svThreshold) {
       rank++;
     }
   }
@@ -6521,7 +6521,7 @@ unsigned int vpMatrix::kernel(vpMatrix &kerAt, double svThreshold) const
   if (rank != nbcol) {
     for (unsigned int j = 0, k = 0; j < nbcol; j++) {
       // if( v.col(j) in kernel and non zero )
-      if ((fabs(sv[j]) <= maxsv * svThreshold) &&
+      if ((sv[j] <= maxsv * svThreshold) &&
           (std::fabs(V.getCol(j).sumSquare()) > std::numeric_limits<double>::epsilon())) {
         for (unsigned int i = 0; i < V.getRows(); i++) {
           kerAt[k][i] = V[i][j];
@@ -6737,15 +6737,15 @@ double vpMatrix::cond(double svThreshold) const
   // Compute the highest singular value
   double maxsv = 0;
   for (unsigned int i = 0; i < nbcol; i++) {
-    if (fabs(sv[i]) > maxsv) {
-      maxsv = fabs(sv[i]);
+    if (sv[i] > maxsv) {
+      maxsv = sv[i];
     }
   }
 
   // Compute the rank of the matrix
   unsigned int rank = 0;
   for (unsigned int i = 0; i < nbcol; i++) {
-    if (fabs(sv[i]) > maxsv * svThreshold) {
+    if (sv[i] > maxsv * svThreshold) {
       rank++;
     }
   }
@@ -6753,8 +6753,8 @@ double vpMatrix::cond(double svThreshold) const
   // Compute the lowest singular value
   double minsv = maxsv;
   for (unsigned int i = 0; i < rank; i++) {
-    if (fabs(sv[i]) < minsv) {
-      minsv = fabs(sv[i]);
+    if (sv[i] < minsv) {
+      minsv = sv[i];
     }
   }
 

--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -229,14 +229,10 @@ void compute_pseudo_inverse(const vpMatrix &U, const vpColVector &sv, const vpMa
   if (kerAt) {
     kerAt->resize(ncols - rank, ncols);
     if (rank != ncols) {
-      for (unsigned int j = 0, k = 0; j < ncols; j++) {
-        // if( v.col(j) in kernel and non zero )
-        if ((fabs(sv[j]) <= maxsv * svThreshold) &&
-            (std::fabs(V.getCol(j).sumSquare()) > std::numeric_limits<double>::epsilon())) {
-          for (unsigned int i = 0; i < V.getRows(); i++) {
-            (*kerAt)[k][i] = V[i][j];
-          }
-          k++;
+      for (unsigned int k = 0; k < (ncols - rank); k++) {
+        unsigned j = k + rank;
+        for (unsigned int i = 0; i < V.getRows(); i++) {
+          (*kerAt)[k][i] = V[i][j];
         }
       }
     }

--- a/modules/vision/include/visp3/vision/vpHomography.h
+++ b/modules/vision/include/visp3/vision/vpHomography.h
@@ -220,13 +220,19 @@ public:
   void buildFrom(const vpPoseVector &arb, const vpPlane &bP);
   //! Construction from homogeneous matrix and a plane
   void buildFrom(const vpHomogeneousMatrix &aMb, const vpPlane &bP);
+
+  vpHomography collineation2homography(const vpCameraParameters &cam) const;
+
   vpMatrix convert() const;
 
   void computeDisplacement(vpRotationMatrix &aRb, vpTranslationVector &atb, vpColVector &n);
 
   void computeDisplacement(const vpColVector &nd, vpRotationMatrix &aRb, vpTranslationVector &atb, vpColVector &n);
 
+  double det() const;
   void eye();
+
+  vpHomography homography2collineation(const vpCameraParameters &cam) const;
 
   //! invert the homography
   vpHomography inverse(double sv_threshold = 1e-16, unsigned int *rank=NULL) const;

--- a/modules/vision/src/homography-estimation/vpHomographyMalis.cpp
+++ b/modules/vision/src/homography-estimation/vpHomographyMalis.cpp
@@ -234,18 +234,18 @@ void HLM2D(unsigned int nb_pts, vpMatrix &points_des, vpMatrix &points_cour, vpM
         pour effectuer un controle sur le rang de la matrice : pas plus
         de 2 valeurs singulieres quasi=0
   *****/
-  vals_inf = fabs(sv[0]);
+  vals_inf = sv[0];
   vect = 0;
   contZeros = 0;
-  if (fabs(sv[0]) < eps) {
+  if (sv[0] < eps) {
     contZeros = contZeros + 1;
   }
   for (unsigned int j = 1; j < 9; j++) {
-    if (fabs(sv[j]) < vals_inf) {
-      vals_inf = fabs(sv[j]);
+    if (sv[j] < vals_inf) {
+      vals_inf = sv[j];
       vect = j;
     }
-    if (fabs(sv[j]) < eps) {
+    if (sv[j] < eps) {
       contZeros = contZeros + 1;
     }
   }


### PR DESCRIPTION
- fix `vpMatrix::pseudoInverse(... , int rank_in, vpMatrix &kerAt)` where ` kerAt` was wrong when `rank_in` is given as input
- optimize `vpMatrix::pseudoInverse()` removing useless `fabs()` call on sigular values that are always positive or null
- create new `vpHomography::homography2collineation()` and `vpHomography::collineation2homography()` optimized functions to transform an homography form calibrated domain to pixel space and vice versa