### PR TITLE
Allow setting ip + port to communicate with Virtuose

### DIFF
--- a/modules/robot/include/visp3/robot/vpVirtuose.h
+++ b/modules/robot/include/visp3/robot/vpVirtuose.h
@@ -177,9 +177,8 @@ public:
   void setForce(const vpColVector &force);
   void setForceFactor(const float &forceFactor);
   void setIndexingMode(const VirtIndexingType &type);
-  /*! Set haptic device ip address and port. Default value is
-   * "localhost#5000".*/
-  inline void setIpAddress(const std::string &ip) { m_ip = ip; }
+  void setIpAddressAndPort(const std::string &ip, int port);
+
   void setObservationFrame(const vpPoseVector &position);
   void setPeriodicFunction(VirtPeriodicFunction CallBackVirt);
   void setPosition(vpPoseVector &position);
@@ -198,9 +197,26 @@ public:
   void startPeriodicFunction();
   void stopPeriodicFunction();
 
+#ifdef VISP_BUILD_DEPRECATED_FUNCTIONS
+  /*!
+    @name Deprecated functions
+  */
+  //@{
+  /*!
+   * \deprecated You should rather use setIpAddressAndPort() that is more explicit.
+   *
+   * Set haptic device ip address and port. Default value is
+   * "localhost#5000".
+   *
+   * \sa setIpAddressAndPort()
+   */
+  vp_deprecated inline void setIpAddress(const std::string &ip_port) { m_ip_port = ip_port; }
+  //@}
+#endif
+
 protected:
   VirtContext m_virtContext;
-  std::string m_ip;
+  std::string m_ip_port;
   bool m_verbose;
   int m_apiMajorVersion;
   int m_apiMinorVersion;

--- a/modules/robot/src/haptic-device/virtuose/vpVirtuose.cpp
+++ b/modules/robot/src/haptic-device/virtuose/vpVirtuose.cpp
@@ -52,7 +52,7 @@
  * Authorize indexing on all movements by default.
  */
 vpVirtuose::vpVirtuose()
-  : m_virtContext(NULL), m_ip("localhost#53210"), m_verbose(false), m_apiMajorVersion(0), m_apiMinorVersion(0),
+  : m_virtContext(NULL), m_ip_port("localhost#5000"), m_verbose(false), m_apiMajorVersion(0), m_apiMinorVersion(0),
     m_ctrlMajorVersion(0), m_ctrlMinorVersion(0), m_typeCommand(COMMAND_TYPE_IMPEDANCE), m_indexType(INDEXING_ALL),
     m_is_init(false), m_period(0.001f), m_njoints(6)
 {
@@ -61,7 +61,7 @@ vpVirtuose::vpVirtuose()
 }
 
 /*!
- * Default destructor that delete the VirtContext object.
+ * Delete the VirtContext object.
  */
 void vpVirtuose::close()
 {
@@ -77,6 +77,19 @@ void vpVirtuose::close()
 vpVirtuose::~vpVirtuose()
 {
   close();
+}
+
+/*!
+ * Set haptic device ip address and communication port.
+ * \param[in] ip: Host IP address. Default value set in constructor is "localhost".
+ * \param[in] port: Host communication port. Default value set in constructor is 5000.
+ */
+void vpVirtuose::setIpAddressAndPort(const std::string &ip, int port)
+{
+  std::stringstream ss;
+  ss << ip << "#" << port;
+
+  m_ip_port = ss.str();
 }
 
 /*!
@@ -531,11 +544,12 @@ vpColVector vpVirtuose::getVelocity() const
 void vpVirtuose::init()
 {
   if (!m_is_init) {
-    m_virtContext = virtOpen(m_ip.c_str());
+    m_virtContext = virtOpen(m_ip_port.c_str());
 
     if (m_virtContext == NULL) {
       int err = virtGetErrorCode(m_virtContext);
-      throw(vpException(vpException::fatalError, "Cannot open haptic device: %s", virtGetErrorMessage(err)));
+      throw(vpException(vpException::fatalError, "Cannot open communication with haptic device using %s: %s. Check ip and port values",
+                        m_ip_port.c_str(), virtGetErrorMessage(err)));
     }
 
     if (virtGetControlerVersion(m_virtContext, &m_ctrlMajorVersion, &m_ctrlMinorVersion)) {

--- a/modules/robot/test/virtuose/testVirtuose.cpp
+++ b/modules/robot/test/virtuose/testVirtuose.cpp
@@ -44,11 +44,39 @@
 
 #include <visp3/robot/vpVirtuose.h>
 
-int main()
+int main(int argc, char **argv)
 {
 #if defined(VISP_HAVE_VIRTUOSE)
+  std::string opt_ip = "localhost";
+  int opt_port = 5000;
+  for (int i = 0; i < argc; i++) {
+    if (std::string(argv[i]) == "--ip")
+      opt_ip = std::string(argv[i + 1]);
+    else if (std::string(argv[i]) == "--port")
+      opt_port = std::atoi(argv[i + 1]);
+    else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
+      std::cout << "\nUsage: " << argv[0]
+                << " [--ip <localhost>] [--port <port>]"
+                   " [--help] [-h]\n"
+                << std::endl
+                << "Description: " << std::endl
+                << " --ip <localhost>" << std::endl
+                << "\tHost IP address. Default value: \"localhost\"." << std::endl
+                << std::endl
+                << " --port <port>" << std::endl
+                << "\tCommunication port. Default value: 5000." << std::endl
+                << "\tSuggested values: " << std::endl
+                << "\t- 5000 to communicate with the Virtuose." << std::endl
+                << "\t- 53210 to communicate with the Virtuose equipped with the Glove." << std::endl
+                << std::endl;
+      return 0;
+    }
+  }
+
   try {
     vpVirtuose virtuose;
+    std::cout << "Try to connect to " << opt_ip << " port " << opt_port << std::endl;
+    virtuose.setIpAddressAndPort(opt_ip, opt_port);
     virtuose.init();
 
     bool emergStop = virtuose.getEmergencyStop();

--- a/modules/robot/test/virtuose/testVirtuoseHapticBox.cpp
+++ b/modules/robot/test/virtuose/testVirtuoseHapticBox.cpp
@@ -238,11 +238,38 @@ void CallBackVirtuose(VirtContext VC, void *ptr)
   return;
 }
 
-int main()
+int main(int argc, char **argv)
 {
+  std::string opt_ip = "localhost";
+  int opt_port = 5000;
+  for (int i = 0; i < argc; i++) {
+    if (std::string(argv[i]) == "--ip")
+      opt_ip = std::string(argv[i + 1]);
+    else if (std::string(argv[i]) == "--port")
+      opt_port = std::atoi(argv[i + 1]);
+    else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
+      std::cout << "\nUsage: " << argv[0]
+                << " [--ip <localhost>] [--port <port>]"
+                   " [--help] [-h]\n"
+                << std::endl
+                << "Description: " << std::endl
+                << " --ip <localhost>" << std::endl
+                << "\tHost IP address. Default value: \"localhost\"." << std::endl
+                << std::endl
+                << " --port <port>" << std::endl
+                << "\tCommunication port. Default value: 5000." << std::endl
+                << "\tSuggested values: " << std::endl
+                << "\t- 5000 to communicate with the Virtuose." << std::endl
+                << "\t- 53210 to communicate with the Virtuose equipped with the Glove." << std::endl
+                << std::endl;
+      return 0;
+    }
+  }
+
   try {
     vpVirtuose virtuose;
-    virtuose.setIpAddress("localhost#53210");
+    std::cout << "Try to connect to " << opt_ip << " port " << opt_port << std::endl;
+    virtuose.setIpAddressAndPort(opt_ip, opt_port);
     virtuose.setVerbose(true);
     virtuose.setPowerOn();
     virtuose.setPeriodicFunction(CallBackVirtuose);

--- a/modules/robot/test/virtuose/testVirtuoseJointLimits.cpp
+++ b/modules/robot/test/virtuose/testVirtuoseJointLimits.cpp
@@ -94,13 +94,40 @@ void CallBackVirtuose(VirtContext VC, void *ptr)
   return;
 }
 
-int main()
+int main(int argc, char **argv)
 {
+  std::string opt_ip = "localhost";
+  int opt_port = 5000;
+  for (int i = 0; i < argc; i++) {
+    if (std::string(argv[i]) == "--ip")
+      opt_ip = std::string(argv[i + 1]);
+    else if (std::string(argv[i]) == "--port")
+      opt_port = std::atoi(argv[i + 1]);
+    else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
+      std::cout << "\nUsage: " << argv[0]
+                << " [--ip <localhost>] [--port <port>]"
+                   " [--help] [-h]\n"
+                << std::endl
+                << "Description: " << std::endl
+                << " --ip <localhost>" << std::endl
+                << "\tHost IP address. Default value: \"localhost\"." << std::endl
+                << std::endl
+                << " --port <port>" << std::endl
+                << "\tCommunication port. Default value: 5000." << std::endl
+                << "\tSuggested values: " << std::endl
+                << "\t- 5000 to communicate with the Virtuose." << std::endl
+                << "\t- 53210 to communicate with the Virtuose equipped with the Glove." << std::endl
+                << std::endl;
+      return 0;
+    }
+  }
+
   try {
     float period = 0.001f;
     vpVirtuose virtuose;
     virtuose.setTimeStep(period);
-    virtuose.setIpAddress("localhost#53210");
+    std::cout << "Try to connect to " << opt_ip << " port " << opt_port << std::endl;
+    virtuose.setIpAddressAndPort(opt_ip, opt_port);
     virtuose.setVerbose(true);
     virtuose.setPowerOn();
 

--- a/modules/robot/test/virtuose/testVirtuoseWithGlove.cpp
+++ b/modules/robot/test/virtuose/testVirtuoseWithGlove.cpp
@@ -61,6 +61,7 @@
 int main()
 {
   int port = 53210;
+  std::string ip = "localhost";
 
   std::vector<vpVirtuose> virtuose(4); // 0: virtuose, 1: thumb, 2: index, 3: middle
   std::vector<vpHomogeneousMatrix> wMd(4);
@@ -70,11 +71,8 @@ int main()
 
   // Open device
   for (size_t device=0; device < virtuose.size(); device ++) {
-    std::stringstream ss; ss << port + device;
-    std::string ip = "localhost#" + ss.str();
-    std::cout << "Connect to: " << ip << std::endl;
-
-    virtuose[device].setIpAddress(ip);
+    std::cout << "Try to connect to " << ip << " port " << (port  + device) << std::endl;
+    virtuose[device].setIpAddressAndPort(ip, port + device);
     virtuose[device].init();
   }
 


### PR DESCRIPTION
- introduce command line options in Virtuose tests
- introduce a new function `vpVirtuose::setIpAddressAndPort()`
- make `vpVirtuose::setIpAddress()` deprecated
To use the Virtuose alone, use port 5000.
To use the Virtuose + Glove, use port 53210.