### PR TITLE
Simplify code for BgraToRgba conversion in simdlib

### DIFF
--- a/3rdparty/simdlib/Simd/SimdAvx2BgraToRgba.cpp
+++ b/3rdparty/simdlib/Simd/SimdAvx2BgraToRgba.cpp
@@ -32,10 +32,10 @@ namespace Simd
     {
         template <bool align> SIMD_INLINE void BgraToRgba(const uint8_t * bgra, uint8_t * rgba)
         {
-            Store<align>((__m256i*)rgba + 0, BgraToRgba<false>(Load<align>((__m256i*)(bgra + 0))));
-            Store<align>((__m256i*)rgba + 1, BgraToRgba<false>(Load<false>((__m256i*)(bgra + 32))));
-            Store<align>((__m256i*)rgba + 2, BgraToRgba<false>(Load<false>((__m256i*)(bgra + 64))));
-            Store<align>((__m256i*)rgba + 3, BgraToRgba<true >(Load<align>((__m256i*)(bgra + 96))));
+            Store<align>((__m256i*)rgba + 0, BgraToRgba(Load<align>((__m256i*)(bgra + 0))));
+            Store<align>((__m256i*)rgba + 1, BgraToRgba(Load<align>((__m256i*)(bgra + 32))));
+            Store<align>((__m256i*)rgba + 2, BgraToRgba(Load<align>((__m256i*)(bgra + 64))));
+            Store<align>((__m256i*)rgba + 3, BgraToRgba(Load<align>((__m256i*)(bgra + 96))));
         }
 
         template <bool align> void BgraToRgba(const uint8_t * bgra, size_t width, size_t height, size_t bgraStride, uint8_t * rgba, size_t rgbaStride)

--- a/3rdparty/simdlib/Simd/SimdBaseBgraToRgba.cpp
+++ b/3rdparty/simdlib/Simd/SimdBaseBgraToRgba.cpp
@@ -28,31 +28,23 @@ namespace Simd
 {
     namespace Base
     {
-        void BgraToRgba(const uint8_t *bgra, size_t size, uint8_t *rgba, bool lastRow)
+        void BgraToRgba(const uint8_t *bgra, size_t size, uint8_t *rgba)
         {
-            for (size_t i = (lastRow ? 1 : 0); i < size; ++i, bgra += 4, rgba += 4)
+            for (size_t i = 0; i < size; ++i, bgra += 4, rgba += 4)
             {
                 *(int32_t*)rgba = (*(int32_t*)bgra);
                 std::swap(rgba[0], rgba[2]);
-            }
-            if (lastRow)
-            {
-                rgba[0] = bgra[2];
-                rgba[1] = bgra[1];
-                rgba[2] = bgra[0];
-                rgba[3] = bgra[3];
             }
         }
 
         void BgraToRgba(const uint8_t *bgra, size_t width, size_t height, size_t bgraStride, uint8_t *rgba, size_t rgbaStride)
         {
-            for (size_t row = 1; row < height; ++row)
+            for (size_t row = 0; row < height; ++row)
             {
-                BgraToRgba(bgra, width, rgba, false);
+                BgraToRgba(bgra, width, rgba);
                 bgra += bgraStride;
                 rgba += rgbaStride;
             }
-            BgraToRgba(bgra, width, rgba, true);
         }
     }
 }

--- a/3rdparty/simdlib/Simd/SimdConversion.h
+++ b/3rdparty/simdlib/Simd/SimdConversion.h
@@ -201,14 +201,7 @@ namespace Simd
             return _mm256_or_si256(_mm256_shuffle_epi8(_mm256_permute4x64_epi64(bgr, 0xE9), K8_BGRA_TO_RGB_SHUFFLE), alpha);
         }
 
-        template<bool tail> __m256i BgraToRgba(const __m256i & bgra);
-
-        template<> SIMD_INLINE __m256i BgraToRgba<false>(const __m256i & bgra)
-        {
-            return _mm256_shuffle_epi8(bgra, K8_BGRA_TO_RGBA_SHUFFLE);
-        }
-
-        template<> SIMD_INLINE __m256i BgraToRgba<true>(const __m256i & bgra)
+        SIMD_INLINE __m256i BgraToRgba(const __m256i & bgra)
         {
             return _mm256_shuffle_epi8(bgra, K8_BGRA_TO_RGBA_SHUFFLE);
         }

--- a/3rdparty/simdlib/Simd/SimdLib.cpp
+++ b/3rdparty/simdlib/Simd/SimdLib.cpp
@@ -238,7 +238,7 @@ SIMD_API void SimdBgrToRgba(const uint8_t *bgr, size_t width, size_t height, siz
 
 SIMD_API void SimdBgraToRgba(const uint8_t *bgra, size_t width, size_t height, size_t bgraStride, uint8_t *rgba, size_t rgbaStride)
 {
-#if defined(SIMD_AVX2_ENABLE) //&& !defined(SIMD_CLANG_AVX2_BGR_TO_BGRA_ERROR)
+#if defined(SIMD_AVX2_ENABLE)
     if(Avx2::Enable && width >= Avx2::A)
         Avx2::BgraToRgba(bgra, width, height, bgraStride, rgba, rgbaStride);
     else

--- a/3rdparty/simdlib/Simd/SimdLib.h
+++ b/3rdparty/simdlib/Simd/SimdLib.h
@@ -452,11 +452,11 @@ extern "C"
 
         \fn void SimdBgraToRgba(const uint8_t * bgra, size_t width, size_t height, size_t bgraStride, uint8_t * rgba, size_t rgbaStride);
 
-        \short Converts 24-bit BGRA image to 32-bit RGBA image.
+        \short Converts 32-bit BGRA image to 32-bit RGBA image.
 
         All images must have the same width and height.
 
-        \param [in] bgra - a pointer to pixels data of input 24-bit BGR image.
+        \param [in] bgra - a pointer to pixels data of input 32-bit BGRA image.
         \param [in] width - an image width.
         \param [in] height - an image height.
         \param [in] bgraStride - a row size of the bgra image.

--- a/3rdparty/simdlib/Simd/SimdNeonBgraToRgba.cpp
+++ b/3rdparty/simdlib/Simd/SimdNeonBgraToRgba.cpp
@@ -58,7 +58,6 @@ namespace Simd
             for (size_t row = 0; row < height; ++row)
             {
                 for (size_t col = 0, colRgba = 0; col < alignedWidth; col += A, colRgba += A4)
-                    // colBgra = colRgba
                     BgraToRgba<align>(bgra + colRgba, rgba + colRgba, _bgra);
                 if (width != alignedWidth)
                     BgraToRgba<false>(bgra + 4 * (width - A), rgba + 4 * (width - A), _bgra);

--- a/3rdparty/simdlib/Simd/SimdSsse3BgraToRGBa.cpp
+++ b/3rdparty/simdlib/Simd/SimdSsse3BgraToRGBa.cpp
@@ -32,8 +32,8 @@ namespace Simd
         template <bool align> SIMD_INLINE void BgraToRgba(const uint8_t * bgra, uint8_t * rgba, __m128i shuffle)
         {
             Store<align>((__m128i*)rgba + 0, _mm_shuffle_epi8(Load<align>((__m128i*)(bgra + 0)), shuffle));
-            Store<align>((__m128i*)rgba + 1, _mm_shuffle_epi8(Load<false>((__m128i*)(bgra + 16)), shuffle));
-            Store<align>((__m128i*)rgba + 2, _mm_shuffle_epi8(Load<false>((__m128i*)(bgra + 32)), shuffle));
+            Store<align>((__m128i*)rgba + 1, _mm_shuffle_epi8(Load<align>((__m128i*)(bgra + 16)), shuffle));
+            Store<align>((__m128i*)rgba + 2, _mm_shuffle_epi8(Load<align>((__m128i*)(bgra + 32)), shuffle));
             Store<align>((__m128i*)rgba + 3, _mm_shuffle_epi8(Load<align>((__m128i*)(bgra + 48)), shuffle));
         }
 


### PR DESCRIPTION
Related #862 

With AVX2, register size is 256 bits. And with RGBa data (offsets are 0, 32, 64, 96), either the whole bitmap is aligned (array address is multiple of 256 bits), either it is not. With RGB data the beginning of the bitmap can be aligned, but never the middle in the computation loop (offsets are 0, 24, 48, 64).
Same thing with SSE that has 128 bits register size.