### PR TITLE
Move most of ViSP SIMD code to simdlib

### DIFF
--- a/3rdparty/simdlib/Simd/SimdAvx1.h
+++ b/3rdparty/simdlib/Simd/SimdAvx1.h
@@ -1,0 +1,39 @@
+/*
+* Simd Library (http://ermig1979.github.io/Simd).
+*
+* Copyright (c) 2011-2019 Yermalayeu Ihar,
+*               2019-2019 Facundo Galan.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#ifndef __SimdAvx1_h__
+#define __SimdAvx1_h__
+
+#include "Simd/SimdDefs.h"
+
+namespace Simd
+{
+#ifdef SIMD_AVX_ENABLE
+    namespace Avx
+    {
+        void SimdMatTranspose(const double * mat, size_t rows, size_t cols, double * dst);
+    }
+#endif// SIMD_AVX_ENABLE
+}
+#endif//__SimdAvx1_h__

--- a/3rdparty/simdlib/Simd/SimdAvx1CustomFunctions.cpp
+++ b/3rdparty/simdlib/Simd/SimdAvx1CustomFunctions.cpp
@@ -1,0 +1,109 @@
+/*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdStore.h"
+
+namespace Simd
+{
+#ifdef SIMD_AVX_ENABLE
+    namespace Avx
+    {
+        static void transpose4x4(const double* a, size_t rows, size_t cols, double * b, size_t i, size_t j)
+        {
+            __m256d a0 = _mm256_loadu_pd(&a[i*cols + j]);
+            __m256d a1 = _mm256_loadu_pd(&a[(i+1)*cols + j]);
+            __m256d a2 = _mm256_loadu_pd(&a[(i+2)*cols + j]);
+            __m256d a3 = _mm256_loadu_pd(&a[(i+3)*cols + j]);
+
+            __m256d T0 = _mm256_shuffle_pd(a0, a1, 15);
+            __m256d T1 = _mm256_shuffle_pd(a0, a1, 0);
+            __m256d T2 = _mm256_shuffle_pd(a2, a3, 15);
+            __m256d T3 = _mm256_shuffle_pd(a2, a3, 0);
+
+            a1 = _mm256_permute2f128_pd(T0, T2, 32);
+            a3 = _mm256_permute2f128_pd(T0, T2, 49);
+            a0 = _mm256_permute2f128_pd(T1, T3, 32);
+            a2 = _mm256_permute2f128_pd(T1, T3, 49);
+
+            _mm256_storeu_pd(&b[j*rows + i], a0);
+            _mm256_storeu_pd(&b[(j+1)*rows + i], a1);
+            _mm256_storeu_pd(&b[(j+2)*rows + i], a2);
+            _mm256_storeu_pd(&b[(j+3)*rows + i], a3);
+        }
+
+        void transpose16x16(const double * a, size_t rows, size_t cols, double * b, size_t i, size_t j)
+        {
+            transpose4x4(a, rows, cols, b, i, j);
+            transpose4x4(a, rows, cols, b, i, j + 4);
+            transpose4x4(a, rows, cols, b, i, j + 8);
+            transpose4x4(a, rows, cols, b, i, j + 12);
+
+            transpose4x4(a, rows, cols, b, i + 4, j);
+            transpose4x4(a, rows, cols, b, i + 4, j + 4);
+            transpose4x4(a, rows, cols, b, i + 4, j + 8);
+            transpose4x4(a, rows, cols, b, i + 4, j + 12);
+
+            transpose4x4(a, rows, cols, b, i + 8, j);
+            transpose4x4(a, rows, cols, b, i + 8, j + 4);
+            transpose4x4(a, rows, cols, b, i + 8, j + 8);
+            transpose4x4(a, rows, cols, b, i + 8, j + 12);
+
+            transpose4x4(a, rows, cols, b, i + 12, j);
+            transpose4x4(a, rows, cols, b, i + 12, j + 4);
+            transpose4x4(a, rows, cols, b, i + 12, j + 8);
+            transpose4x4(a, rows, cols, b, i + 12, j + 12);
+        }
+
+        void SimdMatTranspose(const double * mat, size_t rows, size_t cols, double * dst)
+        {
+            // Matrix transpose using tiling
+            const int nrows = static_cast<int>(rows);
+            const int ncols = static_cast<int>(cols);
+            const int tileSize = 16;
+
+            for (int i = 0; i < nrows;) {
+                for (; i <= nrows - tileSize; i += tileSize) {
+                    int j = 0;
+                    for (; j <= ncols - tileSize; j += tileSize) {
+                        transpose16x16(mat, rows, cols, dst, i, j);
+                    }
+
+                    for (int k = i; k < i + tileSize; k++) {
+                        for (int l = j; l < ncols; l++) {
+                            dst[l*rows + k] = mat[k*cols + l];
+                        }
+                    }
+                }
+
+                for (; i < nrows; i++) {
+                    for (int j = 0; j < ncols; j++) {
+                        dst[j*rows + i] = mat[i*cols + j];
+                    }
+                }
+            }
+
+            _mm256_zeroupper();
+        }
+    }
+#else
+    // Work arround to avoid warning: libvisp_simdlib.a(SimdAvx1CustomFunctions.cpp.o) has no symbols
+    void dummy_SimdAvx1CustomFunctions(){};
+#endif// SIMD_AVX_ENABLE
+}

--- a/3rdparty/simdlib/Simd/SimdBase.h
+++ b/3rdparty/simdlib/Simd/SimdBase.h
@@ -107,10 +107,35 @@ namespace Simd
         void StretchGray2x2(const uint8_t *src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t *dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
 
-        // ViSP custom SIMD code
+        /* ViSP custom SIMD code */
         void ImageErosion(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType);
 
         void ImageDilatation(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType);
+
+        double SimdVectorSum(const double * vec, size_t size);
+
+        double SimdVectorSumSquare(const double * vec, size_t size);
+
+        double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection);
+
+        void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst);
+
+        void SimdMatMulTwist(const double * mat, size_t rows, const double * twist, double * dst);
+
+        void SimdMatTranspose(const double * mat, size_t rows, size_t cols, double * dst);
+
+        void SimdImageDifference(const unsigned char * img1, const unsigned char * img2, size_t size, unsigned char * imgDiff);
+
+        void SimdNormalizedCorrelation(const double * img1, double mean1, const double * img2, double mean2, size_t size,
+                                       double& a2, double& b2, double& ab);
+
+        void SimdNormalizedCorrelation2(const double * img1, size_t width1, const double * img2,
+                                        size_t width2, size_t height2, size_t i0, size_t j0, double& ab);
+
+        void SimdRemap(const unsigned char * src, size_t channels, size_t width, size_t height, size_t offset,
+                       const int * mapU, const int * mapV, const float * mapDu, const float * mapDv, unsigned char * dst);
+
+        void SimdComputeJtR(const double * J, size_t rows, const double * R, double * dst);
     }
 }
 #endif//__SimdBase_h__

--- a/3rdparty/simdlib/Simd/SimdBaseCustomFunctions.cpp
+++ b/3rdparty/simdlib/Simd/SimdBaseCustomFunctions.cpp
@@ -115,5 +115,152 @@ namespace Simd
                 }
             }
         }
+
+        double SimdVectorSum(const double * vec, size_t size)
+        {
+            double sum = 0.0;
+            for (size_t i = 0; i < size; i++) {
+                sum += vec[i];
+            }
+            return  sum;
+        }
+
+        double SimdVectorSumSquare(const double * vec, size_t size)
+        {
+            double sum_square = 0.0;
+            for (size_t i = 0; i < size; i++) {
+                sum_square += vec[i] * vec[i];
+            }
+            return sum_square;
+        }
+
+        double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection)
+        {
+            double mean_value = SimdVectorSum(vec, size) / size;
+            double sum_squared_diff = 0.0;
+            for (size_t i = 0; i < size; i++) {
+                sum_squared_diff += (vec[i] - mean_value) * (vec[i] - mean_value);
+            }
+
+            double divisor = (double)size;
+            if (useBesselCorrection) {
+              divisor = divisor - 1;
+            }
+
+            return std::sqrt(sum_squared_diff / divisor);
+        }
+
+        void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst)
+        {
+          for (size_t i = 0; i < size; i++) {
+              dst[i] = src1[i] * src2[i];
+          }
+        }
+
+        void SimdMatMulTwist(const double * mat, size_t rows, const double * twist, double * dst)
+        {
+            for (size_t i = 0; i < rows; i++) {
+                for (size_t j = 0; j < 6; j++) {
+                    double s = 0;
+                    for (size_t k = 0; k < 6; k++) {
+                        s += mat[i*6 + k] * twist[k*6 + j];
+                    }
+                    dst[i*6 + j] = s;
+                }
+            }
+        }
+
+        void SimdMatTranspose(const double * mat, size_t rows, size_t cols, double * dst)
+        {
+            if (rows <= 16 || cols <= 16) {
+                for (size_t i = 0; i < rows; i++) {
+                    for (size_t j = 0; j < cols; j++) {
+                        dst[j*cols + i] = mat[i*cols + j];
+                    }
+                }
+            } else {
+                // https://stackoverflow.com/a/21548079
+                const size_t tileSize = 32;
+                for (size_t i = 0; i < rows; i += tileSize) {
+                    for (size_t j = 0; j < cols; j++) {
+                        for (size_t b = 0; b < tileSize && i + b < rows; b++) {
+                            dst[i*cols + i+b] = mat[(i+b)*cols + j];
+                        }
+                    }
+                }
+            }
+        }
+
+        void SimdImageDifference(const unsigned char * img1, const unsigned char * img2, size_t size, unsigned char * imgDiff)
+        {
+            for (size_t i = 0; i < size; i++) {
+                int diff = img1[i] - img2[i] + 128;
+                imgDiff[i] = static_cast<unsigned char>(std::max(std::min(diff, 255), 0));
+            }
+        }
+
+        void SimdNormalizedCorrelation(const double * img1, double mean1, const double * img2, double mean2, size_t size,
+                                       double& a2, double& b2, double& ab)
+        {
+            for (size_t cpt = 0; cpt < size; cpt++) {
+              ab += (img1[cpt] - mean1) * (img2[cpt] - mean2);
+              a2 += (img1[cpt] - mean1) * (img1[cpt] - mean1);
+              b2 += (img2[cpt] - mean2) * (img2[cpt] - mean2);
+            }
+        }
+
+        void SimdNormalizedCorrelation2(const double * img1, size_t width1, const double * img2,
+                                        size_t width2, size_t height2, size_t i0, size_t j0, double& ab)
+        {
+            for (size_t i = 0; i < height2; i++) {
+                for (size_t j = 0; j < width2; j++) {
+                    ab += img1[(i0 + i)*width1 + j0 + j] * img2[i*width2 + j];
+                }
+            }
+        }
+
+        static float lerp(float A, float B, float t)
+        {
+            return A * (1.0f - t) + B * t;
+        }
+
+        void SimdRemap(const unsigned char * src, size_t channels, size_t width, size_t height, size_t offset,
+                       const int * mapU, const int * mapV, const float * mapDu, const float * mapDv, unsigned char * dst)
+        {
+            for (size_t j = 0; j < width; j++) {
+                int u_round = mapU[offset + j];
+                int v_round = mapV[offset + j];
+
+                float du = mapDu[offset + j];
+                float dv = mapDv[offset + j];
+
+                if (0 <= u_round && 0 <= v_round && u_round < static_cast<int>(width) - 1
+                    && v_round < static_cast<int>(height) - 1) {
+                    for (size_t c = 0; c < channels; c++) {
+                        // process interpolation
+                        float col0 = lerp(src[(v_round*width + u_round)*channels + c], src[(v_round*width + u_round + 1)*channels + c], du);
+                        float col1 = lerp(src[((v_round + 1)*width + u_round)*channels + c], src[((v_round + 1)*width + u_round + 1)*channels + c], du);
+                        float value = lerp(col0, col1, dv);
+
+                        dst[(offset + j)*channels + c] = static_cast<unsigned char>(value);
+                    }
+                } else {
+                    for (size_t c = 0; c < channels; c++) {
+                        dst[(offset + j)*channels + c] = 0;
+                    }
+                }
+            }
+        }
+
+        void SimdComputeJtR(const double * J, size_t rows, const double * R, double * dst)
+        {
+            for (size_t i = 0; i < 6; i++) {
+                double ssum = 0;
+                for (size_t j = 0; j < rows; j++) {
+                    ssum += J[j*6 + i] * R[j];
+                }
+                dst[i] = ssum;
+            }
+        }
     }
 }

--- a/3rdparty/simdlib/Simd/SimdLib.cpp
+++ b/3rdparty/simdlib/Simd/SimdLib.cpp
@@ -66,6 +66,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReasonForCall, LPVOID lpReserved)
 #include "Simd/SimdSse1.h"
 #include "Simd/SimdSse2.h"
 #include "Simd/SimdSsse3.h"
+#include "Simd/SimdAvx1.h"
 #include "Simd/SimdAvx2.h"
 #include "Simd/SimdNeon.h"
 
@@ -741,7 +742,7 @@ SIMD_API void SimdStretchGray2x2(const uint8_t *src, size_t srcWidth, size_t src
         Base::StretchGray2x2(src, srcWidth, srcHeight, srcStride, dst, dstWidth, dstHeight, dstStride);
 }
 
-// ViSP custom SIMD code
+/* ViSP custom SIMD code */
 SIMD_API void SimdImageErosion(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType)
 {
 #ifdef SIMD_SSE2_ENABLE
@@ -760,4 +761,121 @@ SIMD_API void SimdImageDilatation(uint8_t * img, const uint8_t * buff, size_t wi
     else
 #endif
         Base::ImageDilatation(img, buff, width, height, connexityType);
+}
+
+SIMD_API double SimdVectorSum(const double * vec, size_t size)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+        return Sse2::SimdVectorSum(vec, size);
+    else
+#endif
+        return Base::SimdVectorSum(vec, size);
+}
+
+SIMD_API double SimdVectorSumSquare(const double * vec, size_t size)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+        return Sse2::SimdVectorSumSquare(vec, size);
+    else
+#endif
+        return Base::SimdVectorSumSquare(vec, size);
+}
+
+SIMD_API double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+        return Sse2::SimdVectorStdev(vec, size, useBesselCorrection);
+    else
+#endif
+        return Base::SimdVectorStdev(vec, size, useBesselCorrection);
+}
+
+SIMD_API void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+        Sse2::SimdVectorHadamard(src1, src2, size, dst);
+    else
+#endif
+        Base::SimdVectorHadamard(src1, src2, size, dst);
+}
+
+SIMD_API void SimdMatMulTwist(const double * mat, size_t rows, const double * twist, double * dst)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable)
+        Sse2::SimdMatMulTwist(mat, rows, twist, dst);
+    else
+#endif
+        Base::SimdMatMulTwist(mat, rows, twist, dst);
+}
+
+SIMD_API void SimdMatTranspose(const double * mat, size_t rows, size_t cols, double * dst)
+{
+#ifdef SIMD_AVX_ENABLE
+    if (Avx::Enable)
+        Avx::SimdMatTranspose(mat, rows, cols, dst);
+    else
+#endif
+        Base::SimdMatTranspose(mat, rows, cols, dst);
+}
+
+SIMD_API void SimdImageDifference(const unsigned char * img1, const unsigned char * img2, size_t size, unsigned char * imgDiff)
+{
+#ifdef SIMD_SSSE3_ENABLE
+    if (Ssse3::Enable && size >= Ssse3::A)
+        Ssse3::SimdImageDifference(img1,img2, size, imgDiff);
+    else
+#endif
+        Base::SimdImageDifference(img1, img2, size, imgDiff);
+}
+
+SIMD_API void SimdNormalizedCorrelation(const double * img1, double mean1, const double * img2, double mean2, size_t size,
+                                        double& a2, double& b2, double& ab, bool useOptimized)
+{
+    if (useOptimized) {
+#ifdef SIMD_SSE2_ENABLE
+        if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+            Sse2::SimdNormalizedCorrelation(img1, mean1, img2, mean2, size, a2, b2, ab);
+        else
+#endif
+            Base::SimdNormalizedCorrelation(img1, mean1, img2, mean2, size, a2, b2, ab);
+    } else {
+        Base::SimdNormalizedCorrelation(img1, mean1, img2, mean2, size, a2, b2, ab);
+    }
+}
+
+SIMD_API void SimdNormalizedCorrelation2(const double * img1, size_t width1, const double * img2,
+                                         size_t width2, size_t height2, size_t i0, size_t j0, double& ab)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable && width2*sizeof(double) >= Sse2::A)
+        Sse2::SimdNormalizedCorrelation2(img1, width1, img2, width2, height2, i0, j0, ab);
+    else
+#endif
+        Base::SimdNormalizedCorrelation2(img1, width1, img2, width2, height2, i0, j0, ab);
+}
+
+SIMD_API void SimdRemap(const unsigned char * src, size_t channels, size_t width, size_t height, size_t offset,
+                        const int * mapU, const int * mapV, const float * mapDu, const float * mapDv, unsigned char * dst)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable && channels >= 4)
+        Sse2::SimdRemap(src, channels, width, height, offset, mapU, mapV, mapDu, mapDv, dst);
+    else
+#endif
+        Base::SimdRemap(src, channels, width, height, offset, mapU, mapV, mapDu, mapDv, dst);
+}
+
+SIMD_API void SimdComputeJtR(const double * J, size_t rows, const double * R, double * dst)
+{
+#ifdef SIMD_SSE2_ENABLE
+    if (Sse2::Enable)
+        Sse2::SimdComputeJtR(J, rows, R, dst);
+    else
+#endif
+        Base::SimdComputeJtR(J, rows, R, dst);
 }

--- a/3rdparty/simdlib/Simd/SimdLib.cpp
+++ b/3rdparty/simdlib/Simd/SimdLib.cpp
@@ -766,7 +766,8 @@ SIMD_API void SimdImageDilatation(uint8_t * img, const uint8_t * buff, size_t wi
 SIMD_API double SimdVectorSum(const double * vec, size_t size)
 {
 #ifdef SIMD_SSE2_ENABLE
-    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+    const int unrollLoopSize = 2;
+    if (Sse2::Enable && size*sizeof(double) >= unrollLoopSize*Sse2::A)
         return Sse2::SimdVectorSum(vec, size);
     else
 #endif
@@ -776,7 +777,8 @@ SIMD_API double SimdVectorSum(const double * vec, size_t size)
 SIMD_API double SimdVectorSumSquare(const double * vec, size_t size)
 {
 #ifdef SIMD_SSE2_ENABLE
-    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+    const int unrollLoopSize = 2;
+    if (Sse2::Enable && size*sizeof(double) >= unrollLoopSize*Sse2::A)
         return Sse2::SimdVectorSumSquare(vec, size);
     else
 #endif
@@ -786,7 +788,8 @@ SIMD_API double SimdVectorSumSquare(const double * vec, size_t size)
 SIMD_API double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection)
 {
 #ifdef SIMD_SSE2_ENABLE
-    if (Sse2::Enable && size*sizeof(double) >= Sse2::A)
+    const int unrollLoopSize = 2;
+    if (Sse2::Enable && size*sizeof(double) >= unrollLoopSize*Sse2::A)
         return Sse2::SimdVectorStdev(vec, size, useBesselCorrection);
     else
 #endif

--- a/3rdparty/simdlib/Simd/SimdLib.h
+++ b/3rdparty/simdlib/Simd/SimdLib.h
@@ -460,7 +460,7 @@ extern "C"
         \param [in] width - an image width.
         \param [in] height - an image height.
         \param [in] bgraStride - a row size of the bgra image.
-        \param [out] rgba - a pointer to pixels data of output 32-bit BGRA image.
+        \param [out] rgba - a pointer to pixels data of output 32-bit RGBA image.
         \param [in] rgbaStride - a row size of the rgba image.
         \param [in] alpha - a value of alpha channel.
     */
@@ -1120,10 +1120,48 @@ extern "C"
     SIMD_API void SimdStretchGray2x2(const uint8_t * src, size_t srcWidth, size_t srcHeight, size_t srcStride,
         uint8_t * dst, size_t dstWidth, size_t dstHeight, size_t dstStride);
 
-    // ViSP custom SIMD code
+    /* ViSP custom SIMD code */
+    // vpImageMorphology::erosion()
     SIMD_API void SimdImageErosion(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType);
 
+    // vpImageMorphology::dilatation
     SIMD_API void SimdImageDilatation(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType);
+
+    // vpColVector::sum()
+    SIMD_API double SimdVectorSum(const double * vec, size_t size);
+
+    // vpColVector::sumSquare()
+    SIMD_API double SimdVectorSumSquare(const double * vec, size_t size);
+
+    // vpColVector::stdev()
+    SIMD_API double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection);
+
+    // vpColVector::hadamard(const vpColVector &v)
+    SIMD_API void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst);
+
+    // vpMatrix::operator*(const vpVelocityTwistMatrix &V)
+    SIMD_API void SimdMatMulTwist(const double * mat, size_t rows, const double * twist, double * dst);
+
+    // vpMatrix::transpose(vpMatrix &At)
+    SIMD_API void SimdMatTranspose(const double * mat, size_t rows, size_t cols, double * dst);
+
+    // vpImageTools::imageDifference
+    SIMD_API void SimdImageDifference(const unsigned char * img1, const unsigned char * img2, size_t size, unsigned char * imgDiff);
+
+    // vpImageTools::normalizedCorrelation
+    SIMD_API void SimdNormalizedCorrelation(const double * img1, double mean1, const double * img2, double mean2, size_t size,
+                                            double& a2, double& b2, double& ab, bool useOptimized);
+
+    // vpImageTools::normalizedCorrelation
+    SIMD_API void SimdNormalizedCorrelation2(const double * img1, size_t width1, const double * img2,
+                                             size_t width2, size_t height2, size_t i0, size_t j0, double& ab);
+
+    // vpImageTools::remap()
+    SIMD_API void SimdRemap(const unsigned char * src, size_t channels, size_t width, size_t height, size_t offset,
+                            const int * mapU, const int * mapV, const float * mapDu, const float * mapDv, unsigned char * dst);
+
+    // vpMbTracker::computeJTR(const vpMatrix &interaction, const vpColVector &error, vpColVector &JTR)
+    SIMD_API void SimdComputeJtR(const double * J, size_t rows, const double * R, double * dst);
 
 #ifdef __cplusplus
 }

--- a/3rdparty/simdlib/Simd/SimdSse2.h
+++ b/3rdparty/simdlib/Simd/SimdSse2.h
@@ -75,6 +75,27 @@ namespace Simd
         void ImageErosion(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType);
 
         void ImageDilatation(uint8_t * img, const uint8_t * buff, size_t width, size_t height, SimdImageConnexityType connexityType);
+
+        double SimdVectorSum(const double * vec, size_t size);
+
+        double SimdVectorSumSquare(const double * vec, size_t size);
+
+        double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection);
+
+        void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst);
+
+        void SimdMatMulTwist(const double * mat, size_t rows, const double * twist, double * dst);
+
+        void SimdNormalizedCorrelation(const double * img1, double mean1, const double * img2, double mean2, size_t size,
+                                       double& a2, double& b2, double& ab);
+
+        void SimdNormalizedCorrelation2(const double * img1, size_t width1, const double * img2,
+                                        size_t width2, size_t height2, size_t i0, size_t j0, double& ab);
+
+        void SimdRemap(const unsigned char * src, size_t channels, size_t width, size_t height, size_t offset,
+                       const int * mapU, const int * mapV, const float * mapDu, const float * mapDv, unsigned char * dst);
+
+        void SimdComputeJtR(const double * J, size_t rows, const double * R, double * dst);
     }
 #endif// SIMD_SSE2_ENABLE
 }

--- a/3rdparty/simdlib/Simd/SimdSse2CustomFunctions.cpp
+++ b/3rdparty/simdlib/Simd/SimdSse2CustomFunctions.cpp
@@ -185,8 +185,8 @@ namespace Simd
         {
             __m128d v_sum1 = _mm_setzero_pd(), v_sum2 = _mm_setzero_pd();
 
-            size_t i = 0;
-            for (; i <= size - 4; i += 4) {
+            int i = 0;
+            for (; i <= static_cast<int>(size) - 4; i += 4) {
                 v_sum1 = _mm_add_pd(_mm_loadu_pd(vec + i), v_sum1);
                 v_sum2 = _mm_add_pd(_mm_loadu_pd(vec + i + 2), v_sum2);
             }
@@ -207,12 +207,12 @@ namespace Simd
         double SimdVectorSumSquare(const double * vec, size_t size)
         {
             double sum_square = 0.0;
-            size_t i = 0;
+            int i = 0;
 
             __m128d v_mul1, v_mul2;
             __m128d v_sum = _mm_setzero_pd();
 
-            for (; i <= size - 4; i += 4) {
+            for (; i <= static_cast<int>(size) - 4; i += 4) {
                 v_mul1 = _mm_mul_pd(_mm_loadu_pd(vec + i), _mm_loadu_pd(vec + i));
                 v_mul2 = _mm_mul_pd(_mm_loadu_pd(vec + i + 2), _mm_loadu_pd(vec + i + 2));
 
@@ -236,12 +236,12 @@ namespace Simd
         {
             double mean_value = SimdVectorSum(vec, size) / size;
             double sum_squared_diff = 0.0;
-            size_t i = 0;
+            int i = 0;
 
             __m128d v_sub, v_mul, v_sum = _mm_setzero_pd();
             __m128d v_mean = _mm_set1_pd(mean_value);
 
-            for (; i <= size - 4; i += 4) {
+            for (; i <= static_cast<int>(size) - 4; i += 4) {
                 v_sub = _mm_sub_pd(_mm_loadu_pd(vec + i), v_mean);
                 v_mul = _mm_mul_pd(v_sub, v_sub);
                 v_sum = _mm_add_pd(v_mul, v_sum);
@@ -270,8 +270,8 @@ namespace Simd
 
         void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst)
         {
-            size_t i = 0;
-            for (; i <= size - 2; i += 2) {
+            int i = 0;
+            for (; i <= static_cast<int>(size) - 2; i += 2) {
                 __m128d vout = _mm_mul_pd(_mm_loadu_pd(src1 + i), _mm_loadu_pd(src2 + i));
                 _mm_storeu_pd(dst + i, vout);
             }

--- a/3rdparty/simdlib/Simd/SimdSse2CustomFunctions.cpp
+++ b/3rdparty/simdlib/Simd/SimdSse2CustomFunctions.cpp
@@ -185,8 +185,8 @@ namespace Simd
         {
             __m128d v_sum1 = _mm_setzero_pd(), v_sum2 = _mm_setzero_pd();
 
-            int i = 0;
-            for (; i <= static_cast<int>(size) - 4; i += 4) {
+            size_t i = 0;
+            for (; i <= size - 4; i += 4) {
                 v_sum1 = _mm_add_pd(_mm_loadu_pd(vec + i), v_sum1);
                 v_sum2 = _mm_add_pd(_mm_loadu_pd(vec + i + 2), v_sum2);
             }
@@ -207,12 +207,12 @@ namespace Simd
         double SimdVectorSumSquare(const double * vec, size_t size)
         {
             double sum_square = 0.0;
-            int i = 0;
+            size_t i = 0;
 
             __m128d v_mul1, v_mul2;
             __m128d v_sum = _mm_setzero_pd();
 
-            for (; i <= static_cast<int>(size) - 4; i += 4) {
+            for (; i <= size - 4; i += 4) {
                 v_mul1 = _mm_mul_pd(_mm_loadu_pd(vec + i), _mm_loadu_pd(vec + i));
                 v_mul2 = _mm_mul_pd(_mm_loadu_pd(vec + i + 2), _mm_loadu_pd(vec + i + 2));
 
@@ -236,12 +236,12 @@ namespace Simd
         {
             double mean_value = SimdVectorSum(vec, size) / size;
             double sum_squared_diff = 0.0;
-            int i = 0;
+            size_t i = 0;
 
             __m128d v_sub, v_mul, v_sum = _mm_setzero_pd();
             __m128d v_mean = _mm_set1_pd(mean_value);
 
-            for (; i <= static_cast<int>(size) - 4; i += 4) {
+            for (; i <= size - 4; i += 4) {
                 v_sub = _mm_sub_pd(_mm_loadu_pd(vec + i), v_mean);
                 v_mul = _mm_mul_pd(v_sub, v_sub);
                 v_sum = _mm_add_pd(v_mul, v_sum);
@@ -270,8 +270,8 @@ namespace Simd
 
         void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst)
         {
-            int i = 0;
-            for (; i <= static_cast<int>(size) - 2; i += 2) {
+            size_t i = 0;
+            for (; i <= size - 2; i += 2) {
                 __m128d vout = _mm_mul_pd(_mm_loadu_pd(src1 + i), _mm_loadu_pd(src2 + i));
                 _mm_storeu_pd(dst + i, vout);
             }
@@ -426,16 +426,16 @@ namespace Simd
             __m128d v_JTR_4_5 = _mm_setzero_pd();
 
             for (size_t i = 0; i < rows; i++) {
-              const __m128d v_error = _mm_set1_pd(R[i]);
+                const __m128d v_error = _mm_set1_pd(R[i]);
 
-              __m128d v_interaction = _mm_loadu_pd(&J[i*6]);
-              v_JTR_0_1 = _mm_add_pd(v_JTR_0_1, _mm_mul_pd(v_interaction, v_error));
+                __m128d v_interaction = _mm_loadu_pd(&J[i*6]);
+                v_JTR_0_1 = _mm_add_pd(v_JTR_0_1, _mm_mul_pd(v_interaction, v_error));
 
-              v_interaction = _mm_loadu_pd(&J[i*6 + 2]);
-              v_JTR_2_3 = _mm_add_pd(v_JTR_2_3, _mm_mul_pd(v_interaction, v_error));
+                v_interaction = _mm_loadu_pd(&J[i*6 + 2]);
+                v_JTR_2_3 = _mm_add_pd(v_JTR_2_3, _mm_mul_pd(v_interaction, v_error));
 
-              v_interaction = _mm_loadu_pd(&J[i*6 + 4]);
-              v_JTR_4_5 = _mm_add_pd(v_JTR_4_5, _mm_mul_pd(v_interaction, v_error));
+                v_interaction = _mm_loadu_pd(&J[i*6 + 4]);
+                v_JTR_4_5 = _mm_add_pd(v_JTR_4_5, _mm_mul_pd(v_interaction, v_error));
             }
 
             _mm_storeu_pd(dst, v_JTR_0_1);

--- a/3rdparty/simdlib/Simd/SimdSse2CustomFunctions.cpp
+++ b/3rdparty/simdlib/Simd/SimdSse2CustomFunctions.cpp
@@ -180,6 +180,268 @@ namespace Simd
                 }
             }
         }
+
+        double SimdVectorSum(const double * vec, size_t size)
+        {
+            __m128d v_sum1 = _mm_setzero_pd(), v_sum2 = _mm_setzero_pd();
+
+            size_t i = 0;
+            for (; i <= size - 4; i += 4) {
+                v_sum1 = _mm_add_pd(_mm_loadu_pd(vec + i), v_sum1);
+                v_sum2 = _mm_add_pd(_mm_loadu_pd(vec + i + 2), v_sum2);
+            }
+
+            __m128d v_sum = _mm_add_pd(v_sum1, v_sum2);
+            double res[2];
+            _mm_storeu_pd(res, v_sum);
+            double sum = res[0] + res[1];
+
+            // tail processing
+            for (; i < size; i++) {
+                sum += vec[i];
+            }
+
+            return sum;
+        }
+
+        double SimdVectorSumSquare(const double * vec, size_t size)
+        {
+            double sum_square = 0.0;
+            size_t i = 0;
+
+            __m128d v_mul1, v_mul2;
+            __m128d v_sum = _mm_setzero_pd();
+
+            for (; i <= size - 4; i += 4) {
+                v_mul1 = _mm_mul_pd(_mm_loadu_pd(vec + i), _mm_loadu_pd(vec + i));
+                v_mul2 = _mm_mul_pd(_mm_loadu_pd(vec + i + 2), _mm_loadu_pd(vec + i + 2));
+
+                v_sum = _mm_add_pd(v_mul1, v_sum);
+                v_sum = _mm_add_pd(v_mul2, v_sum);
+            }
+
+            double res[2];
+            _mm_storeu_pd(res, v_sum);
+
+            sum_square = res[0] + res[1];
+
+            for (; i < size; i++) {
+                sum_square += vec[i] * vec[i];
+            }
+
+            return sum_square;
+        }
+
+        double SimdVectorStdev(const double * vec, size_t size, bool useBesselCorrection)
+        {
+            double mean_value = SimdVectorSum(vec, size) / size;
+            double sum_squared_diff = 0.0;
+            size_t i = 0;
+
+            __m128d v_sub, v_mul, v_sum = _mm_setzero_pd();
+            __m128d v_mean = _mm_set1_pd(mean_value);
+
+            for (; i <= size - 4; i += 4) {
+                v_sub = _mm_sub_pd(_mm_loadu_pd(vec + i), v_mean);
+                v_mul = _mm_mul_pd(v_sub, v_sub);
+                v_sum = _mm_add_pd(v_mul, v_sum);
+
+                v_sub = _mm_sub_pd(_mm_loadu_pd(vec + i + 2), v_mean);
+                v_mul = _mm_mul_pd(v_sub, v_sub);
+                v_sum = _mm_add_pd(v_mul, v_sum);
+            }
+
+            double res[2];
+            _mm_storeu_pd(res, v_sum);
+
+            sum_squared_diff = res[0] + res[1];
+
+            for (; i < size; i++) {
+                sum_squared_diff += (vec[i] - mean_value) * (vec[i] - mean_value);
+            }
+
+            double divisor = (double)size;
+            if (useBesselCorrection) {
+                divisor = divisor - 1;
+            }
+
+            return std::sqrt(sum_squared_diff / divisor);
+        }
+
+        void SimdVectorHadamard(const double * src1, const double * src2, size_t size, double * dst)
+        {
+            size_t i = 0;
+            for (; i <= size - 2; i += 2) {
+                __m128d vout = _mm_mul_pd(_mm_loadu_pd(src1 + i), _mm_loadu_pd(src2 + i));
+                _mm_storeu_pd(dst + i, vout);
+            }
+
+            for (; i < size; i++) {
+                dst[i] = src1[i] * src2[i];
+            }
+        }
+
+        void SimdMatMulTwist(const double * mat, size_t rows, const double * twist, double * dst)
+        {
+            // Transpose twist matrix
+            double transpose[36];
+            for (size_t i = 0; i < 6; i++) {
+                for (size_t j = 0; j < 6; j++) {
+                    transpose[i*6 + j] = twist[j*6 + i];
+                }
+            }
+
+            for (size_t i = 0; i < rows; i++) {
+                for (size_t j = 0; j < 6; j++) {
+                    __m128d v_mul = _mm_setzero_pd();
+                    for (size_t k = 0; k < 6; k += 2) {
+                        v_mul = _mm_add_pd(v_mul, _mm_mul_pd(_mm_loadu_pd(&mat[i*6 + k]), _mm_loadu_pd(&transpose[j*6 + k])));
+                    }
+
+                    double v_tmp[2];
+                    _mm_storeu_pd(v_tmp, v_mul);
+                    dst[i*6 + j] = v_tmp[0] + v_tmp[1];
+                }
+            }
+        }
+
+        void SimdNormalizedCorrelation(const double * img1, double mean1, const double * img2, double mean2, size_t size,
+                                       double& a2, double& b2, double& ab)
+        {
+            const __m128d v_mean_a = _mm_set1_pd(mean1);
+            const __m128d v_mean_b = _mm_set1_pd(mean2);
+            __m128d v_ab = _mm_setzero_pd();
+            __m128d v_a2 = _mm_setzero_pd();
+            __m128d v_b2 = _mm_setzero_pd();
+
+            size_t cpt = 0;
+            for (; cpt <= size - 2; cpt += 2, img1 += 2, img2 += 2) {
+                const __m128d v1 = _mm_loadu_pd(img1);
+                const __m128d v2 = _mm_loadu_pd(img2);
+                const __m128d norm_a = _mm_sub_pd(v1, v_mean_a);
+                const __m128d norm_b = _mm_sub_pd(v2, v_mean_b);
+                v_ab = _mm_add_pd(v_ab, _mm_mul_pd(norm_a, norm_b));
+                v_a2 = _mm_add_pd(v_a2, _mm_mul_pd(norm_a, norm_a));
+                v_b2 = _mm_add_pd(v_b2, _mm_mul_pd(norm_b, norm_b));
+            }
+
+            double v_res_ab[2], v_res_a2[2], v_res_b2[2];
+            _mm_storeu_pd(v_res_ab, v_ab);
+            _mm_storeu_pd(v_res_a2, v_a2);
+            _mm_storeu_pd(v_res_b2, v_b2);
+
+            ab = v_res_ab[0] + v_res_ab[1];
+            a2 = v_res_a2[0] + v_res_a2[1];
+            b2 = v_res_b2[0] + v_res_b2[1];
+
+            for (; cpt < size; cpt++) {
+                ab += (img1[cpt] - mean1) * (img2[cpt] - mean2);
+                a2 += (img1[cpt] - mean1) * (img1[cpt] - mean1);
+                b2 += (img2[cpt] - mean2) * (img2[cpt] - mean2);
+            }
+        }
+
+        void SimdNormalizedCorrelation2(const double * img1_, size_t width1, const double * img2,
+                                        size_t width2, size_t height2, size_t i0, size_t j0, double& ab)
+        {
+            const double *img1 = img1_;
+            __m128d v_ab = _mm_setzero_pd();
+
+            for (size_t i = 0; i < height2; i++) {
+                size_t j = 0;
+                img1 = &img1_[(i0 + i) * width1 + j0];
+
+                for (; j <= width2 - 2; j += 2, img1 += 2, img2 += 2) {
+                    const __m128d v1 = _mm_loadu_pd(img1);
+                    const __m128d v2 = _mm_loadu_pd(img2);
+                    v_ab = _mm_add_pd(v_ab, _mm_mul_pd(v1, v2));
+                }
+
+                for (; j < width2; j++) {
+                    ab += img1[(i0 + i)*width1 + j0 + j] * img2[i*width2 + j];
+                }
+            }
+
+            double v_res_ab[2];
+            _mm_storeu_pd(v_res_ab, v_ab);
+
+            ab += v_res_ab[0] + v_res_ab[1];
+        }
+
+        void SimdRemap(const unsigned char * src, size_t channels, size_t width, size_t height, size_t offset,
+                       const int * mapU, const int * mapV, const float * mapDu, const float * mapDv, unsigned char * dst)
+        {
+            for (size_t j = 0; j < width; j++) {
+                int u_round = mapU[offset + j];
+                int v_round = mapV[offset + j];
+
+                const __m128 vdu = _mm_set1_ps(mapDu[offset + j]);
+                const __m128 vdv = _mm_set1_ps(mapDv[offset + j]);
+
+                if (0 <= u_round && 0 <= v_round && u_round < static_cast<int>(width) - 1
+                    && v_round < static_cast<int>(height) - 1) {
+#define VLERP(va, vb, vt) _mm_add_ps(va, _mm_mul_ps(_mm_sub_ps(vb, va), vt))
+
+                    // process interpolation
+                    const __m128 vdata1 =
+                        _mm_set_ps(static_cast<float>(src[(v_round*width + u_round)*channels + 3]), static_cast<float>(src[(v_round*width + u_round)*channels + 2]),
+                                   static_cast<float>(src[(v_round*width + u_round)*channels + 1]), static_cast<float>(src[(v_round*width + u_round)*channels] + 0));
+
+                    const __m128 vdata2 =
+                        _mm_set_ps(static_cast<float>(src[(v_round*width + u_round + 1)*channels + 3]), static_cast<float>(src[(v_round*width + u_round + 1)*channels + 2]),
+                                   static_cast<float>(src[(v_round*width + u_round + 1)*channels + 1]), static_cast<float>(src[(v_round*width + u_round + 1)*channels + 0]));
+
+                    const __m128 vdata3 =
+                        _mm_set_ps(static_cast<float>(src[((v_round + 1)*width + u_round)*channels + 3]), static_cast<float>(src[((v_round + 1)*width + u_round)*channels + 2]),
+                                   static_cast<float>(src[((v_round + 1)*width + u_round)*channels + 1]), static_cast<float>(src[((v_round + 1)*width + u_round)*channels + 0]));
+
+                    const __m128 vdata4 = _mm_set_ps(
+                        static_cast<float>(src[((v_round + 1)*width + u_round + 1)*channels + 3]), static_cast<float>(src[((v_round + 1)*width + u_round + 1)*channels + 2]),
+                        static_cast<float>(src[((v_round + 1)*width + u_round + 1)*channels + 1]), static_cast<float>(src[((v_round + 1)*width + u_round + 1)*channels + 0]));
+
+                    const __m128 vcol0 = VLERP(vdata1, vdata2, vdu);
+                    const __m128 vcol1 = VLERP(vdata3, vdata4, vdu);
+                    const __m128 vvalue = VLERP(vcol0, vcol1, vdv);
+
+  #undef VLERP
+
+                    float values[4];
+                    _mm_storeu_ps(values, vvalue);
+                    dst[(offset + j)*channels + 0] = static_cast<unsigned char>(values[0]);
+                    dst[(offset + j)*channels + 1] = static_cast<unsigned char>(values[1]);
+                    dst[(offset + j)*channels + 2] = static_cast<unsigned char>(values[2]);
+                    dst[(offset + j)*channels + 3] = static_cast<unsigned char>(values[3]);
+                } else {
+                    for (size_t c = 0; c < channels; c++) {
+                        dst[(offset + j)*channels + c] = 0;
+                    }
+                }
+            }
+        }
+
+        void SimdComputeJtR(const double * J, size_t rows, const double * R, double * dst)
+        {
+            __m128d v_JTR_0_1 = _mm_setzero_pd();
+            __m128d v_JTR_2_3 = _mm_setzero_pd();
+            __m128d v_JTR_4_5 = _mm_setzero_pd();
+
+            for (size_t i = 0; i < rows; i++) {
+              const __m128d v_error = _mm_set1_pd(R[i]);
+
+              __m128d v_interaction = _mm_loadu_pd(&J[i*6]);
+              v_JTR_0_1 = _mm_add_pd(v_JTR_0_1, _mm_mul_pd(v_interaction, v_error));
+
+              v_interaction = _mm_loadu_pd(&J[i*6 + 2]);
+              v_JTR_2_3 = _mm_add_pd(v_JTR_2_3, _mm_mul_pd(v_interaction, v_error));
+
+              v_interaction = _mm_loadu_pd(&J[i*6 + 4]);
+              v_JTR_4_5 = _mm_add_pd(v_JTR_4_5, _mm_mul_pd(v_interaction, v_error));
+            }
+
+            _mm_storeu_pd(dst, v_JTR_0_1);
+            _mm_storeu_pd(dst + 2, v_JTR_2_3);
+            _mm_storeu_pd(dst + 4, v_JTR_4_5);
+        }
     }
 #else
     // Work arround to avoid warning: libvisp_simdlib.a(SimdSse2CustomFunctions.cpp.o) has no symbols

--- a/3rdparty/simdlib/Simd/SimdSsse3.h
+++ b/3rdparty/simdlib/Simd/SimdSsse3.h
@@ -68,6 +68,9 @@ namespace Simd
 
         void ResizeBilinear(const uint8_t *src, size_t srcWidth, size_t srcHeight, size_t srcStride,
             uint8_t *dst, size_t dstWidth, size_t dstHeight, size_t dstStride, size_t channelCount);
+
+        // ViSP custom SIMD code
+        void SimdImageDifference(const unsigned char * img1, const unsigned char * img2, size_t size, unsigned char * imgDiff);
     }
 #endif// SIMD_SSSE3_ENABLE
 }

--- a/3rdparty/simdlib/Simd/SimdSsse3CustomFunctions.cpp
+++ b/3rdparty/simdlib/Simd/SimdSsse3CustomFunctions.cpp
@@ -1,0 +1,69 @@
+/*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
+#include "Simd/SimdMemory.h"
+#include "Simd/SimdBase.h"
+#include "Simd/SimdStore.h"
+
+namespace Simd
+{
+#ifdef SIMD_SSSE3_ENABLE
+    namespace Ssse3
+    {
+        void SimdImageDifference(const unsigned char * img1, const unsigned char * img2, size_t size, unsigned char * imgDiff)
+        {
+            const __m128i mask1 = _mm_set_epi8(-1, 14, -1, 12, -1, 10, -1, 8, -1, 6, -1, 4, -1, 2, -1, 0);
+            const __m128i mask2 = _mm_set_epi8(-1, 15, -1, 13, -1, 11, -1, 9, -1, 7, -1, 5, -1, 3, -1, 1);
+            const __m128i mask_out2 = _mm_set_epi8(14, -1, 12, -1, 10, -1, 8, -1, 6, -1, 4, -1, 2, -1, 0, -1);
+
+            size_t i = 0;
+            for (; i <= size-16; i+= 16) {
+                const __m128i vdata1 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(img1 + i));
+                const __m128i vdata2 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(img2 + i));
+
+                __m128i vdata1_reorg = _mm_shuffle_epi8(vdata1, mask1);
+                __m128i vdata2_reorg = _mm_shuffle_epi8(vdata2, mask1);
+
+                const __m128i vshift = _mm_set1_epi16(128);
+                __m128i vdata_diff = _mm_add_epi16(_mm_sub_epi16(vdata1_reorg, vdata2_reorg), vshift);
+
+                const __m128i v255 = _mm_set1_epi16(255);
+                const __m128i vzero = _mm_setzero_si128();
+                const __m128i vdata_diff_min_max1 = _mm_max_epi16(_mm_min_epi16(vdata_diff, v255), vzero);
+
+                vdata1_reorg = _mm_shuffle_epi8(vdata1, mask2);
+                vdata2_reorg = _mm_shuffle_epi8(vdata2, mask2);
+
+                vdata_diff = _mm_add_epi16(_mm_sub_epi16(vdata1_reorg, vdata2_reorg), vshift);
+                const __m128i vdata_diff_min_max2 = _mm_max_epi16(_mm_min_epi16(vdata_diff, v255), vzero);
+
+                _mm_storeu_si128(reinterpret_cast<__m128i *>(imgDiff + i), _mm_or_si128(_mm_shuffle_epi8(vdata_diff_min_max1, mask1),
+                                                                                        _mm_shuffle_epi8(vdata_diff_min_max2, mask_out2)));
+            }
+
+            if (i < size) {
+                Base::SimdImageDifference(img1 + i, img2 + i, size - i, imgDiff + i);
+            }
+        }
+    }
+#else
+    // Work arround to avoid warning: libvisp_simdlib.a(SimdSsse3CustomFunctions.cpp.o) has no symbols
+    void dummy_SimdSsse3CustomFunctions(){};
+#endif// SIMD_SSSE3_ENABLE
+}

--- a/modules/core/test/image/testImageDifference.cpp
+++ b/modules/core/test/image/testImageDifference.cpp
@@ -118,14 +118,13 @@ int main()
       vpImageTools::imageDifference(I1, I2, Idiff_sse);
       t_sse += vpTime::measureTimeMs() - t;
 
-      bool same_result = Idiff_regular == Idiff_sse;
-      std::cout << "(Idiff_regular == Idiff_sse)? " << same_result << std::endl;
-      if (!same_result) {
+      if (Idiff_regular != Idiff_sse) {
         std::cerr << "Problem with vpImageTools::imageDifference()" << std::endl;
         return EXIT_FAILURE;
       }
     }
 
+    std::cout << "(Idiff_regular == Idiff_sse)" << std::endl;
     std::cout << "t_regular: " << t_regular << " ms ; mean t_regular: " << t_regular/256 << " ms" << std::endl;
     std::cout << "t_sse: " << t_sse << " ms ; mean t_sse: " << t_sse/256 << " ms" << std::endl;
     std::cout << "speed-up: " << t_regular / t_sse << " X" << std::endl;
@@ -150,14 +149,13 @@ int main()
       vpImageTools::imageDifference(I1_color, I2_color, Idiff_sse_color);
       t_sse += vpTime::measureTimeMs() - t;
 
-      bool same_result = Idiff_regular_color == Idiff_sse_color;
-      std::cout << "(Idiff_regular_color == Idiff_sse_color)? " << same_result << std::endl;
-      if (!same_result) {
+      if (Idiff_regular_color != Idiff_sse_color) {
         std::cerr << "Problem with vpImageTools::imageDifference()" << std::endl;
         return EXIT_FAILURE;
       }
     }
 
+    std::cout << "(Idiff_regular_color == Idiff_sse_color)" << std::endl;
     std::cout << "t_regular: " << t_regular << " ms ; mean t_regular: " << t_regular/256 << " ms" << std::endl;
     std::cout << "t_sse: " << t_sse << " ms ; mean t_sse: " << t_sse/256 << " ms" << std::endl;
     std::cout << "speed-up: " << t_regular / t_sse << " X" << std::endl;

--- a/modules/core/test/image/testUndistortImage.cpp
+++ b/modules/core/test/image/testUndistortImage.cpp
@@ -247,9 +247,9 @@ int main(int argc, const char **argv)
       exit(-1);
     }
 
-//
-// Here starts really the test
-//
+    //
+    // Here starts really the test
+    //
     vpImage<vpRGBa> I, I_; // Input image
     vpImage<unsigned char> I_gray;
     vpImage<vpRGBa> U; // undistorted output image
@@ -373,6 +373,35 @@ int main(int argc, const char **argv)
     filename = vpIoTools::path(vpIoTools::createFilePath(opath, "grid36-01_undistorted_remap.pgm"));
     std::cout << "Write undistorted image with remap: " << filename << std::endl;
     vpImageIo::write(U_remap_gray, filename);
+
+    // Compute images difference
+    vpImage<vpRGBa> U_diff_abs;
+    vpImageTools::imageDifferenceAbsolute(U, U_remap, U_diff_abs);
+    double mean_diff = 0.0;
+    for (unsigned int i = 0; i < U_diff_abs.getHeight(); i++) {
+      for (unsigned int j = 0; j < U_diff_abs.getWidth(); j++) {
+        mean_diff += U_diff_abs[i][j].R;
+        mean_diff += U_diff_abs[i][j].G;
+        mean_diff += U_diff_abs[i][j].B;
+        mean_diff += U_diff_abs[i][j].A;
+      }
+    }
+    double remap_mean_error = mean_diff / (4*U_diff_abs.getSize());
+    std::cout << "U_diff_abs mean value: " << remap_mean_error << std::endl;
+    const double remap_error_threshold = 0.5;
+    if (remap_mean_error > remap_error_threshold) {
+      std::cerr << "Issue with vpImageTools::remap() with vpRGBa image" << std::endl;
+      return 1;
+    }
+
+    vpImage<unsigned char> U_diff_gray_abs;
+    vpImageTools::imageDifferenceAbsolute(U_gray, U_remap_gray, U_diff_gray_abs);
+    double remap_mean_error_gray = U_diff_gray_abs.getSum() / U_diff_gray_abs.getSize();
+    std::cout << "U_diff_gray_abs mean value: " << remap_mean_error_gray << std::endl;
+    if (remap_mean_error_gray > remap_error_threshold) {
+      std::cerr << "Issue with vpImageTools::remap() with unsigned char image" << std::endl;
+      return 1;
+    }
 
     // Write the undistorted difference images on the disk
     vpImage<vpRGBa> U_diff;

--- a/modules/core/test/math/perfColVectorOperations.cpp
+++ b/modules/core/test/math/perfColVectorOperations.cpp
@@ -1,0 +1,383 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Benchmark column vector operations.
+ *
+ *****************************************************************************/
+
+#include <visp3/core/vpConfig.h>
+
+#ifdef VISP_HAVE_CATCH2
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+#include <visp3/core/vpColVector.h>
+
+namespace
+{
+static bool g_runBenchmark = false;
+static const std::vector<unsigned int> g_sizes = {23, 127, 233, 419, 1153, 2749};
+
+double getRandomValues(double min, double max)
+{
+  return (max - min) * ((double)rand() / (double)RAND_MAX) + min;
+}
+
+vpColVector generateRandomVector(unsigned int rows, double min=-100, double max=100)
+{
+  vpColVector v(rows);
+
+  for (unsigned int i = 0; i < v.getRows(); i++) {
+    v[i] = getRandomValues(min, max);
+  }
+
+  return v;
+}
+
+double stddev(const std::vector<double>& vec)
+{
+  double sum = std::accumulate(vec.begin(), vec.end(), 0.0);
+  double mean = sum / vec.size();
+
+  std::vector<double> diff(vec.size());
+  std::transform(vec.begin(), vec.end(), diff.begin(), [mean](double x) { return x - mean; });
+  double sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
+  return std::sqrt(sq_sum / vec.size());
+}
+
+double computeRegularSum(const vpColVector &v)
+{
+  double sum = 0.0;
+
+  for (unsigned int i = 0; i < v.getRows(); i++) {
+    sum += v[i];
+  }
+
+  return sum;
+}
+
+double computeRegularSumSquare(const vpColVector &v)
+{
+  double sum_square = 0.0;
+
+  for (unsigned int i = 0; i < v.getRows(); i++) {
+    sum_square += v[i] * v[i];
+  }
+
+  return sum_square;
+}
+
+double computeRegularStdev(const vpColVector &v)
+{
+  double mean_value = computeRegularSum(v) / v.getRows();
+  double sum_squared_diff = 0.0;
+
+  for (unsigned int i = 0; i < v.size(); i++) {
+    sum_squared_diff += (v[i] - mean_value) * (v[i] - mean_value);
+  }
+
+  double divisor = (double)v.size();
+
+  return std::sqrt(sum_squared_diff / divisor);
+}
+
+std::vector<double> computeHadamard(const std::vector<double>& v1, const std::vector<double>& v2)
+{
+  std::vector<double> result;
+  std::transform(v1.begin(), v1.end(), v2.begin(),
+                 std::back_inserter(result), std::multiplies<double>());
+  return result;
+}
+
+bool almostEqual(const vpColVector& v1, const vpColVector& v2, double tol=1e-9)
+{
+  if (v1.getRows() != v2.getRows()) {
+    return false;
+  }
+
+  for (unsigned int i = 0; i < v1.getRows(); i++) {
+    if (!vpMath::equal(v1[i], v2[i], tol)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+} // namespace
+
+TEST_CASE("Benchmark vpColVector::sum()", "[benchmark]") {
+  // Sanity checks
+  {
+    const double val = 11;
+    vpColVector v(1, val);
+    CHECK(v.sum() == Approx(val).epsilon(std::numeric_limits<double>::epsilon()));
+  }
+  {
+    const unsigned int size = 11;
+    std::vector<double> vec(size);
+    vpColVector v(size);
+    for (size_t i = 0; i < 11; i++) {
+      vec[i] = 2*i;
+      v[static_cast<unsigned int>(i)] = vec[i];
+    }
+    CHECK(v.sum() == Approx(std::accumulate(vec.begin(), vec.end(), 0.0)).epsilon(std::numeric_limits<double>::epsilon()));
+  }
+
+  if (g_runBenchmark) {
+    for (auto size : g_sizes) {
+      vpColVector v = generateRandomVector(size);
+      std::vector<double> vec = v.toStdVector();
+
+      std::ostringstream oss;
+      oss << "Benchmark vpColVector::sum() with size: " << size << " (ViSP)";
+      double vp_sum = 0;
+      BENCHMARK(oss.str().c_str()) {
+        vp_sum = v.sum();
+        return vp_sum;
+      };
+
+      oss.str("");
+      oss << "Benchmark std::accumulate() with size: " << size << " (C++)";
+      double std_sum = 0;
+      BENCHMARK(oss.str().c_str()) {
+        std_sum = std::accumulate(vec.begin(), vec.end(), 0.0);
+        return std_sum;
+      };
+      CHECK(vp_sum == Approx(std_sum));
+
+      oss.str("");
+      oss << "Benchmark naive sum() with size: " << size;
+      double naive_sum = 0;
+      BENCHMARK(oss.str().c_str()) {
+        naive_sum = computeRegularSum(v);
+        return naive_sum;
+      };
+      CHECK(naive_sum == Approx(std_sum));
+    }
+  }
+}
+
+TEST_CASE("Benchmark vpColVector::sumSquare()", "[benchmark]") {
+  // Sanity checks
+  {
+    const double val = 11;
+    vpColVector v(1, val);
+    CHECK(v.sumSquare() == Approx(val*val).epsilon(std::numeric_limits<double>::epsilon()));
+  }
+  {
+    const unsigned int size = 11;
+    std::vector<double> vec(size);
+    vpColVector v(size);
+    for (size_t i = 0; i < 11; i++) {
+      vec[i] = 2*i;
+      v[static_cast<unsigned int>(i)] = vec[i];
+    }
+    CHECK(v.sumSquare() == Approx(std::inner_product(vec.begin(), vec.end(), vec.begin(), 0.0)).epsilon(std::numeric_limits<double>::epsilon()));
+  }
+
+  if (g_runBenchmark) {
+    for (auto size : g_sizes) {
+      vpColVector v = generateRandomVector(size);
+      std::vector<double> vec = v.toStdVector();
+
+      std::ostringstream oss;
+      oss << "Benchmark vpColVector::sumSquare() with size: " << size << " (ViSP)";
+      double vp_sq_sum = 0;
+      BENCHMARK(oss.str().c_str()) {
+        vp_sq_sum = v.sumSquare();
+        return vp_sq_sum;
+      };
+
+      oss.str("");
+      oss << "Benchmark std::inner_product with size: " << size << " (C++)";
+      double std_sq_sum = 0;
+      BENCHMARK(oss.str().c_str()) {
+        std_sq_sum = std::inner_product(vec.begin(), vec.end(), vec.begin(), 0.0);
+        return std_sq_sum;
+      };
+      CHECK(vp_sq_sum == Approx(std_sq_sum));
+
+      oss.str("");
+      oss << "Benchmark naive sumSquare() with size: " << size;
+      double naive_sq_sum = 0;
+      BENCHMARK(oss.str().c_str()) {
+        naive_sq_sum = computeRegularSumSquare(v);
+        return naive_sq_sum;
+      };
+      CHECK(naive_sq_sum == Approx(std_sq_sum));
+    }
+  }
+}
+
+TEST_CASE("Benchmark vpColVector::stdev()", "[benchmark]") {
+  // Sanity checks
+  {
+    vpColVector v(2);
+    v[0] = 11;
+    v[1] = 16;
+    std::vector<double> vec = v.toStdVector();
+    CHECK(vpColVector::stdev(v) == Approx(stddev(vec)).epsilon(std::numeric_limits<double>::epsilon()));
+  }
+  {
+    const unsigned int size = 11;
+    std::vector<double> vec(size);
+    vpColVector v(size);
+    for (size_t i = 0; i < 11; i++) {
+      vec[i] = 2*i;
+      v[static_cast<unsigned int>(i)] = vec[i];
+    }
+    CHECK(vpColVector::stdev(v) == Approx(stddev(vec)).epsilon(std::numeric_limits<double>::epsilon()));
+  }
+
+  if (g_runBenchmark) {
+    for (auto size : g_sizes) {
+      vpColVector v = generateRandomVector(size);
+      std::vector<double> vec = v.toStdVector();
+
+      std::ostringstream oss;
+      oss << "Benchmark vpColVector::stdev() with size: " << size << " (ViSP)";
+      double vp_stddev = 0;
+      BENCHMARK(oss.str().c_str()) {
+        vp_stddev = vpColVector::stdev(v);
+        return vp_stddev;
+      };
+
+      oss.str("");
+      oss << "Benchmark C++ stddev impl with size: " << size << " (C++)";
+      double std_stddev = 0;
+      BENCHMARK(oss.str().c_str()) {
+        std_stddev = stddev(vec);
+        return std_stddev;
+      };
+      CHECK(vp_stddev == Approx(std_stddev));
+
+      oss.str("");
+      oss << "Benchmark naive stdev() with size: " << size;
+      double naive_stddev = 0;
+      BENCHMARK(oss.str().c_str()) {
+        naive_stddev = computeRegularStdev(v);
+        return naive_stddev;
+      };
+      CHECK(naive_stddev == Approx(std_stddev));
+    }
+  }
+}
+
+TEST_CASE("Benchmark vpColVector::hadamard()", "[benchmark]") {
+  // Sanity checks
+  {
+    vpColVector v1(2), v2(2);
+    v1[0] = 11;
+    v1[1] = 16;
+    v2[0] = 8;
+    v2[1] = 23;
+    vpColVector res1 = v1.hadamard(v2);
+    vpColVector res2(computeHadamard(v1.toStdVector(), v2.toStdVector()));
+    CHECK(almostEqual(res1, res2));
+  }
+  {
+    const unsigned int size = 11;
+    std::vector<double> vec1(size), vec2(size);
+    for (size_t i = 0; i < 11; i++) {
+      vec1[i] = 2*i;
+      vec2[i] = 3*i + 5;
+    }
+    vpColVector v1(vec1), v2(vec2);
+    vpColVector res1 = v1.hadamard(v2);
+    vpColVector res2(computeHadamard(v1.toStdVector(), v2.toStdVector()));
+    CHECK(almostEqual(res1, res2));
+  }
+
+  if (g_runBenchmark) {
+    for (auto size : g_sizes) {
+      vpColVector v1 = generateRandomVector(size);
+      vpColVector v2 = generateRandomVector(size);
+      std::vector<double> vec1 = v1.toStdVector();
+      std::vector<double> vec2 = v2.toStdVector();
+
+      std::ostringstream oss;
+      oss << "Benchmark vpColVector::hadamard() with size: " << size << " (ViSP)";
+      vpColVector vp_res;
+      BENCHMARK(oss.str().c_str()) {
+        vp_res = v1.hadamard(v2);
+        return vp_res;
+      };
+
+      oss.str("");
+      oss << "Benchmark C++ element wise multiplication with size: " << size << " (C++)";
+      std::vector<double> std_res;
+      BENCHMARK(oss.str().c_str()) {
+        std_res = computeHadamard(vec1, vec2);
+        return std_res;
+      };
+      CHECK(almostEqual(vp_res, vpColVector(std_res)));
+    }
+  }
+}
+
+int main(int argc, char *argv[])
+{
+  // Set random seed explicitly to avoid confusion
+  // See: https://en.cppreference.com/w/cpp/numeric/random/srand
+  // If rand() is used before any calls to srand(), rand() behaves as if it was seeded with srand(1).
+  srand(1);
+
+  Catch::Session session; // There must be exactly one instance
+
+  // Build a new parser on top of Catch's
+  using namespace Catch::clara;
+  auto cli = session.cli()   // Get Catch's composite command line parser
+      | Opt(g_runBenchmark)  // bind variable to a new option, with a hint string
+      ["--benchmark"]        // the option names it will respond to
+      ("run benchmark?");    // description string for the help output
+
+  // Now pass the new composite back to Catch so it uses that
+  session.cli(cli);
+
+  // Let Catch (using Clara) parse the command line
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+
+  // numFailed is clamped to 255 as some unices only use the lower 8 bits.
+  // This clamping has already been applied, so just return it here
+  // You can also do any post run clean-up here
+  return numFailed;
+}
+#else
+#include <iostream>
+
+int main()
+{
+  return 0;
+}
+#endif

--- a/modules/core/test/math/perfMatrixMultiplication.cpp
+++ b/modules/core/test/math/perfMatrixMultiplication.cpp
@@ -859,6 +859,11 @@ TEST_CASE("Benchmark matrix-force twist multiplication", "[benchmark]") {
 
 int main(int argc, char *argv[])
 {
+  // Set random seed explicitly to avoid confusion
+  // See: https://en.cppreference.com/w/cpp/numeric/random/srand
+  // If rand() is used before any calls to srand(), rand() behaves as if it was seeded with srand(1).
+  srand(1);
+
   Catch::Session session; // There must be exactly one instance
   unsigned int lapackMinSize = vpMatrix::getLapackMatrixMinSize();
 

--- a/modules/core/test/math/testColVector.cpp
+++ b/modules/core/test/math/testColVector.cpp
@@ -70,42 +70,6 @@ bool test(const std::string &s, const vpColVector &v, const std::vector<double> 
   return true;
 }
 
-double computeRegularSum(const vpColVector &v)
-{
-  double sum = 0.0;
-
-  for (unsigned int i = 0; i < v.getRows(); i++) {
-    sum += v[i];
-  }
-
-  return sum;
-}
-
-double computeRegularSumSquare(const vpColVector &v)
-{
-  double sum_square = 0.0;
-
-  for (unsigned int i = 0; i < v.getRows(); i++) {
-    sum_square += v[i] * v[i];
-  }
-
-  return sum_square;
-}
-
-double computeRegularStdev(const vpColVector &v)
-{
-  double mean_value = computeRegularSum(v) / v.getRows();
-  double sum_squared_diff = 0.0;
-
-  for (unsigned int i = 0; i < v.size(); i++) {
-    sum_squared_diff += (v[i] - mean_value) * (v[i] - mean_value);
-  }
-
-  double divisor = (double)v.size();
-
-  return std::sqrt(sum_squared_diff / divisor);
-}
-
 double getRandomValues(double min, double max)
 {
   return (max - min) * ((double)rand() / (double)RAND_MAX) + min;
@@ -352,91 +316,6 @@ int main()
     }
     std::cout << "r: [" << r << "]^T" << std::endl;
     r.print(std::cout, 8, "r");
-  }
-
-  // Test sum, sumSquare, stdev
-  {
-    srand(0);
-    vpGaussRand noise(10.0, 0.0);
-
-    int nbIterations = 1000;
-    unsigned int size = 117;
-
-    vpColVector v(size);
-    for (unsigned int cpt = 0; cpt < v.getRows(); cpt++) {
-      v[cpt] = rand() % 1000 + noise();
-    }
-
-    std::cout << "\nv.getRows()=" << v.getRows() << std::endl;
-
-    double regular_sum = 0.0;
-    double t_regular = vpTime::measureTimeMs();
-    for (int iteration = 0; iteration < nbIterations; iteration++) {
-      regular_sum += computeRegularSum(v);
-    }
-    t_regular = vpTime::measureTimeMs() - t_regular;
-
-    double sse_sum = 0.0;
-    double t_sse = vpTime::measureTimeMs();
-    for (int iteration = 0; iteration < nbIterations; iteration++) {
-      sse_sum += v.sum();
-    }
-    t_sse = vpTime::measureTimeMs() - t_sse;
-
-    std::cout << "\nregular_sum=" << regular_sum << " ; sse_sum=" << sse_sum << std::endl;
-    std::cout << "t_regular=" << t_regular << " ms ; t_sse=" << t_sse << " ms" << std::endl;
-    std::cout << "Speed-up: " << (t_regular / t_sse) << "X" << std::endl;
-
-    if (!vpMath::equal(regular_sum, sse_sum, std::numeric_limits<double>::epsilon())) {
-      std::cerr << "Problem when computing v.sum()!" << std::endl;
-      return EXIT_FAILURE;
-    }
-
-    double regular_sumSquare = 0.0;
-    t_regular = vpTime::measureTimeMs();
-    for (int iteration = 0; iteration < nbIterations; iteration++) {
-      regular_sumSquare += computeRegularSumSquare(v);
-    }
-    t_regular = vpTime::measureTimeMs() - t_regular;
-
-    double sse_sumSquare = 0.0;
-    t_sse = vpTime::measureTimeMs();
-    for (int iteration = 0; iteration < nbIterations; iteration++) {
-      sse_sumSquare += v.sumSquare();
-    }
-    t_sse = vpTime::measureTimeMs() - t_sse;
-
-    std::cout << "\nregular_sumSquare=" << regular_sumSquare << " ; sse_sumSquare=" << sse_sumSquare << std::endl;
-    std::cout << "t_regular=" << t_regular << " ms ; t_sse=" << t_sse << " ms" << std::endl;
-    std::cout << "Speed-up: " << (t_regular / t_sse) << "X" << std::endl;
-
-    if (!vpMath::equal(regular_sumSquare, sse_sumSquare, std::numeric_limits<double>::epsilon())) {
-      std::cerr << "Problem when computing v.sumSquare()!" << std::endl;
-      return EXIT_FAILURE;
-    }
-
-    double regular_stdev = 0.0;
-    t_regular = vpTime::measureTimeMs();
-    for (int iteration = 0; iteration < nbIterations; iteration++) {
-      regular_stdev += computeRegularStdev(v);
-    }
-    t_regular = vpTime::measureTimeMs() - t_regular;
-
-    double sse_stdev = 0.0;
-    t_sse = vpTime::measureTimeMs();
-    for (int iteration = 0; iteration < nbIterations; iteration++) {
-      sse_stdev += vpColVector::stdev(v, false);
-    }
-    t_sse = vpTime::measureTimeMs() - t_sse;
-
-    std::cout << "\nregular_stdev=" << regular_stdev << " ; sse_stdev=" << sse_stdev << std::endl;
-    std::cout << "t_regular=" << t_regular << " ms ; t_sse=" << t_sse << " ms" << std::endl;
-    std::cout << "Speed-up: " << (t_regular / t_sse) << "X" << std::endl;
-
-    if (!vpMath::equal(regular_stdev, sse_stdev, std::numeric_limits<double>::epsilon())) {
-      std::cerr << "Problem when computing vpColVector::stdev()!" << std::endl;
-      return EXIT_FAILURE;
-    }
   }
 
   {

--- a/modules/core/test/math/testMatrix.cpp
+++ b/modules/core/test/math/testMatrix.cpp
@@ -107,7 +107,15 @@ vpMatrix generateRandomMatrix(unsigned int rows, unsigned int cols, double min, 
 
   return M;
 }
+
+std::vector<double> computeHadamard(const std::vector<double>& v1, const std::vector<double>& v2)
+{
+  std::vector<double> result;
+  std::transform(v1.begin(), v1.end(), v2.begin(),
+                 std::back_inserter(result), std::multiplies<double>());
+  return result;
 }
+} // namespace
 
 int main(int argc, char *argv[])
 {
@@ -667,10 +675,19 @@ int main(int argc, char *argv[])
         M2.data[i] = i + 2;
       }
 
+      // Reference
+      std::vector<double> references = computeHadamard(std::vector<double>(M1.data, M1.data + M1.size()),
+                                                       std::vector<double>(M2.data, M2.data + M2.size()));
+
       std::cout << "M1:\n" << M1 << std::endl;
       std::cout << "\nM2:\n" << M2 << std::endl;
       M2 = M1.hadamard(M2);
       std::cout << "\nRes:\n" << M2 << std::endl;
+
+      if (!test("M2", M2, references)) {
+        std::cerr << "Error with Hadamard product" << std::endl;
+        return EXIT_FAILURE;
+      }
     }
 
     {

--- a/modules/tracker/mbt/CMakeLists.txt
+++ b/modules/tracker/mbt/CMakeLists.txt
@@ -297,7 +297,11 @@ if(WITH_CATCH2)
   include_directories(${CATCH2_INCLUDE_DIRS})
 endif()
 
-vp_add_module(mbt visp_vision visp_core visp_me visp_visual_features OPTIONAL visp_ar visp_klt visp_gui PRIVATE_OPTIONAL ${CLIPPER_LIBRARIES} ${PUGIXML_LIBRARIES} WRAP java)
+# simdlib is always enabled since it contains fallback code to plain C++ code
+# Simd lib is private
+include_directories(${SIMDLIB_INCLUDE_DIRS})
+
+vp_add_module(mbt visp_vision visp_core visp_me visp_visual_features OPTIONAL visp_ar visp_klt visp_gui PRIVATE_OPTIONAL ${CLIPPER_LIBRARIES} ${PUGIXML_LIBRARIES} ${SIMDLIB_LIBRARIES} WRAP java)
 vp_glob_module_sources()
 
 if(USE_OGRE)

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtTukeyEstimator.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtTukeyEstimator.h
@@ -271,7 +271,7 @@ inline void vpMbtTukeyEstimator<double>::MEstimator_impl_ssse3(const std::vector
 
 template <>
 inline void vpMbtTukeyEstimator<float>::MEstimator(const std::vector<float> &residues, std::vector<float> &weights,
-                                            const float NoiseThreshold)
+                                                   const float NoiseThreshold)
 {
   bool checkSSSE3 = vpCPUFeatures::checkSSSE3();
 #if !VISP_HAVE_SSSE3
@@ -286,7 +286,7 @@ inline void vpMbtTukeyEstimator<float>::MEstimator(const std::vector<float> &res
 
 template <>
 inline void vpMbtTukeyEstimator<double>::MEstimator(const std::vector<double> &residues, std::vector<double> &weights,
-                                             const double NoiseThreshold)
+                                                    const double NoiseThreshold)
 {
   bool checkSSSE3 = vpCPUFeatures::checkSSSE3();
 #if !VISP_HAVE_SSSE3


### PR DESCRIPTION
The reasons are the following:

- cleaner to have cpp files compiled with only appropriate flags in simdlib (e.g. SSE2 with only `-msse2`, this is not the case if for instance `-march=native` flag is passed for the ViSP code)
- easier to add optimizations for another architectures or for more advanced SIMD instructions set in simdlib
- theoretically, all advanced optimizations would be available in the binary library built from apt:
  - in simdlib, if the compiler supports the generation of AVX2 code, AVX2 code path is available with a runtime check if the CPU supports these instructions set
  - in regular ViSP code, the more advanced flags can only be `-msse2` (or `-mssse3` maybe) on `x86-64` on apt to be compatible with all `x86-64` targets

Remains:
- `vpMbtTukeyEstimator.h`
- `vpMbtFaceDepthDense.cpp`
- `vpMbtFaceDepthNormal.cpp`