### PR TITLE
Update accuracy thresholds for cdash-ci

### DIFF
--- a/modules/tracker/mbt/test/testGenericTracker.cpp
+++ b/modules/tracker/mbt/test/testGenericTracker.cpp
@@ -362,12 +362,12 @@ namespace
     //Take the highest thresholds between all CI machines
 #ifdef VISP_HAVE_COIN3D
     map_thresh[vpMbGenericTracker::EDGE_TRACKER]
-        = useScanline ? std::pair<double, double>(0.005, 3.9) : std::pair<double, double>(0.007, 3.2);
+        = useScanline ? std::pair<double, double>(0.005, 3.9) : std::pair<double, double>(0.007, 3.4);
 #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
     map_thresh[vpMbGenericTracker::KLT_TRACKER]
-        = useScanline ? std::pair<double, double>(0.006, 1.9) : std::pair<double, double>(0.005, 1.3);
+        = useScanline ? std::pair<double, double>(0.006, 1.9) : std::pair<double, double>(0.005, 1.5);
     map_thresh[vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER]
-        = useScanline ? std::pair<double, double>(0.005, 3.2) : std::pair<double, double>(0.006, 2.8);
+        = useScanline ? std::pair<double, double>(0.005, 3.4) : std::pair<double, double>(0.006, 3.0);
 #endif
     map_thresh[vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::DEPTH_DENSE_TRACKER]
         = useScanline ? std::pair<double, double>(0.003, 1.7) : std::pair<double, double>(0.002, 0.8);
@@ -384,7 +384,7 @@ namespace
     map_thresh[vpMbGenericTracker::KLT_TRACKER]
         = useScanline ? std::pair<double, double>(0.006, 1.7) : std::pair<double, double>(0.005, 1.4);
     map_thresh[vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER]
-        = useScanline ? std::pair<double, double>(0.004, 1.2) : std::pair<double, double>(0.004, 1.0);
+        = useScanline ? std::pair<double, double>(0.004, 1.2) : std::pair<double, double>(0.004, 1.2);
 #endif
     map_thresh[vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::DEPTH_DENSE_TRACKER]
         = useScanline ? std::pair<double, double>(0.002, 0.7) : std::pair<double, double>(0.001, 0.4);


### PR DESCRIPTION
1. `CentOS Linux-7.3.1611-Linux-amd64-g++4.8.5-Dyn-RelWithDebInfo-v4l2-X11-OpenCV2.4.5-lapack-gsl-jpeg-png-xml-pthread-OpenMP-apriltag-sse`:
  - `testGenericTracker-edge-KLT`
  > t_err: 0.000917505 ; tu_err: 1.18855
  > Pose estimated exceeds the threshold (t_thresh = 0.004 ; tu_thresh = 1)!

2. `CentOS Linux-7.3.1611-Linux-amd64-g++4.8.5-Dyn-RelWithDebInfo-v4l2-X11-OpenCV2.4.5-lapack-gsl-jpeg-png-xml-pthread-OpenMP-apriltag-Wov-Weq-Moment`:
  - `testGenericTracker-edge-KLT`
  > t_err: 0.000938192 ; tu_err: 1.09439
  > Pose estimated exceeds the threshold (t_thresh = 0.004 ; tu_thresh = 1)!

3. `Ubuntu-12.04-Linux-i386-g++4.6-Dyn-RelWithDebInfo-dc1394-v4l2-freenect-usb-X11-OpenCV2.3.1-lapack-gsl-jpeg-png-xml-pthread-OpenMP-dmtx-zbar-apriltag-Wov-Weq-Moment`:
  - `testGenericTracker-edge-KLT`
  > Pose estimated exceeds the threshold (t_thresh = 0.004 ; tu_thresh = 1)!
  > t_err: 0.000925685 ; tu_err: 1.1301

4. `Ubuntu-18.04-Linux-amd64-g++7-Dyn-RelWithDebInfo-dc1394-v4l2-pcl-usb-flycap-X11-OpenCV3.2.0-lapack-gsl-eigen3-Ogre-OIS-Coin-jpeg-png-xml-pthread-OpenMP-dmtx-zbar-apriltag-c11`:
  - ` testGenericTracker`
  > Pose estimated exceeds the threshold (t_thresh = 0.007 ; tu_thresh = 3.2)!
  > t_err: 0.00322111 ; tu_err: 3.3117
  - `testGenericTracker-edge-KLT-scanline`
  > Pose estimated exceeds the threshold (t_thresh = 0.005 ; tu_thresh = 3.2)!
  > t_err: 0.0025004 ; tu_err: 3.32097

5. `Ubuntu-12.04-Linux-i386-g++4.6-Dyn-RelWithDebInfo-dc1394-v4l2-freenect-usb-X11-OpenCV2.3.1-lapack-gsl-Ogre-OIS-Coin-jpeg-png-xml-pthread-OpenMP-dmtx-zbar-apriltag-sse`:
  - `testGenericTracker-edge-KLT`
  > Pose estimated exceeds the threshold (t_thresh = 0.006 ; tu_thresh = 2.8)!
  > t_err: 0.00362571 ; tu_err: 2.9567
  - `testGenericTracker-edge-KLT-scanline`
  > Pose estimated exceeds the threshold (t_thresh = 0.005 ; tu_thresh = 3.2)!
  > t_err: 0.00271383 ; tu_err: 3.24033
  - `testGenericTracker-KLT`
  > Pose estimated exceeds the threshold (t_thresh = 0.005 ; tu_thresh = 1.3)!
  > t_err: 0.00441524 ; tu_err: 1.41101