### PR TITLE
Fix for packaging 3.4.0 for Debian, Homebrew, ROS Kinetic

### DIFF
--- a/3rdparty/simdlib/CMakeLists.txt
+++ b/3rdparty/simdlib/CMakeLists.txt
@@ -19,13 +19,6 @@ file(GLOB_RECURSE SIMD_BASE_HDR ${CMAKE_CURRENT_SOURCE_DIR}/Simd/*.h ${CMAKE_CUR
 # but here we use vars set in VISPDetectPlatform.cmake
 if(X86 OR X86_64)
 
-    # Is it needed?
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "i686")
-        set(COMMON_CXX_FLAGS "${COMMON_CXX_FLAGS} -m32")
-    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-        set(COMMON_CXX_FLAGS "${COMMON_CXX_FLAGS} -m64")
-    endif()
-
     # Flags check
     set(SSE_FLAG    "")
     set(SSE2_FLAG   "")

--- a/3rdparty/simdlib/Simd/SimdEnable.h
+++ b/3rdparty/simdlib/Simd/SimdEnable.h
@@ -44,8 +44,8 @@
 #include <TargetConditionals.h>             // To detect OSX or IOS using TARGET_OS_IPHONE or TARGET_OS_IOS macro
 #endif
 
-// The following includes <sys/auxv.h> and <asm/hwcap.h> are not available for iOS.
-#if (TARGET_OS_IOS == 0) // not iOS
+// The following includes <sys/auxv.h> and <asm/hwcap.h> are not available for macOS, iOS.
+#if !defined(__APPLE__) // not macOS, iOS
 #if defined(SIMD_PPC_ENABLE) || defined(SIMD_PPC64_ENABLE) || defined(SIMD_ARM_ENABLE) || defined(SIMD_ARM64_ENABLE)
 #include <unistd.h>
 #include <fcntl.h>
@@ -124,7 +124,7 @@ namespace Simd
     }
 #endif//defined(SIMD_X86_ENABLE) || defined(SIMD_X64_ENABLE)
 
-#if (TARGET_OS_IOS == 0) // not iOS
+#if !defined(__APPLE__) // not macOS, iOS
 #if defined(__GNUC__) && (defined(SIMD_PPC_ENABLE) || defined(SIMD_PPC64_ENABLE) || defined(SIMD_ARM_ENABLE) || defined(SIMD_ARM64_ENABLE))
     namespace CpuInfo
     {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ endif()
 # VISP version number.  An even minor number corresponds to releases.
 set(VISP_VERSION_MAJOR "3")
 set(VISP_VERSION_MINOR "4")
-set(VISP_VERSION_PATCH "0")
+set(VISP_VERSION_PATCH "1")
 set(VISP_VERSION "${VISP_VERSION_MAJOR}.${VISP_VERSION_MINOR}.${VISP_VERSION_PATCH}")
 # Package revision number
 set(VISP_REVISION "1")

--- a/cmake/VISPExtraTargets.cmake
+++ b/cmake/VISPExtraTargets.cmake
@@ -60,6 +60,7 @@ if(DOXYGEN_FOUND)
     COMMAND "${DOXYGEN_EXECUTABLE}" "${VISP_DOC_DIR}/config-doxygen"
     DEPENDS "${VISP_DOC_DIR}/config-doxygen"
   )
+  add_dependencies(visp_doc man developer_scripts)
   if(ENABLE_SOLUTION_FOLDERS)
     set_target_properties(visp_doc PROPERTIES FOLDER "extra")
     set_target_properties(html-doc PROPERTIES FOLDER "extra")

--- a/modules/detection/test/testAprilTag.cpp
+++ b/modules/detection/test/testAprilTag.cpp
@@ -735,11 +735,10 @@ TEST_CASE("Apriltag getTagsPoints3D test", "[apriltag_get_tags_points3D_test]") 
     // Note that using epsilon = std::numeric_limits<double>::epsilon() makes this test
     // failing on Ubuntu 18.04 when none of the Lapack 3rd party libraries, nor the built-in are used.
     // Admissible espilon value is 1e-14. Using 1e-15 makes the test failing.
-#ifdef VISP_HAVE_LAPACK
-    double epsilon = std::numeric_limits<double>::epsilon();
-#else
+    // Again on Debian i386 where Lapack is enable, using std::numeric_limits<double>::epsilon()
+    // makes this test failing.
     double epsilon = 1e-12;
-#endif
+
     for (unsigned int row = 0; row < cMo.getRows(); row++) {
       for (unsigned int col = 0; col < cMo.getCols(); col++) {
         CHECK(vpMath::equal(cMo[row][col], cMo_manual[row][col], epsilon));

--- a/modules/tracker/mbt/test/testGenericTracker.cpp
+++ b/modules/tracker/mbt/test/testGenericTracker.cpp
@@ -365,7 +365,7 @@ namespace
         = useScanline ? std::pair<double, double>(0.005, 3.9) : std::pair<double, double>(0.007, 3.7);
 #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
     map_thresh[vpMbGenericTracker::KLT_TRACKER]
-        = useScanline ? std::pair<double, double>(0.007, 1.9) : std::pair<double, double>(0.005, 1.8);
+        = useScanline ? std::pair<double, double>(0.007, 1.9) : std::pair<double, double>(0.007, 1.8);
     map_thresh[vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER]
         = useScanline ? std::pair<double, double>(0.005, 3.5) : std::pair<double, double>(0.006, 3.4);
 #endif


### PR DESCRIPTION
- Fix for Debian i386 architecture, see [build log](https://buildd.debian.org/status/fetch.php?pkg=visp&arch=i386&ver=3.4.0-1&stamp=1614944140&file=log)