### PR TITLE
Re-orthogonalization of rotation part in vpHomogeneousMatrix if slightly not valid

### DIFF
--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -172,7 +172,7 @@ public:
   /*!
     Destructor.
   */
-  virtual ~vpHomogeneousMatrix(){};
+  virtual ~vpHomogeneousMatrix(){}
 
   void buildFrom(const vpTranslationVector &t, const vpRotationMatrix &R);
   void buildFrom(const vpTranslationVector &t, const vpThetaUVector &tu);
@@ -199,7 +199,7 @@ public:
   void inverse(vpHomogeneousMatrix &Mi) const;
 
   // Test if the rotational part of the matrix is a rotation matrix.
-  bool isAnHomogeneousMatrix() const;
+  bool isAnHomogeneousMatrix(double threshold=1e-6) const;
 
   void insert(const vpRotationMatrix &R);
   void insert(const vpThetaUVector &tu);
@@ -242,7 +242,7 @@ public:
     (void)ncols;
     (void)flagNullify;
     throw(vpException(vpException::fatalError, "Cannot resize an homogeneous matrix"));
-  };
+  }
 
   static vpHomogeneousMatrix mean(const std::vector<vpHomogeneousMatrix> &vec_M);
 
@@ -255,7 +255,7 @@ public:
      \deprecated Provided only for compat with previous releases.
      This function does nothing.
    */
-  vp_deprecated void init(){};
+  vp_deprecated void init(){}
   /*!
      \deprecated You should rather use eye().
    */

--- a/modules/core/include/visp3/core/vpRotationMatrix.h
+++ b/modules/core/include/visp3/core/vpRotationMatrix.h
@@ -141,7 +141,7 @@ public:
   /*!
     Destructor.
   */
-  virtual ~vpRotationMatrix(){};
+  virtual ~vpRotationMatrix(){}
 
   vpRotationMatrix buildFrom(const vpHomogeneousMatrix &M);
   vpRotationMatrix buildFrom(const vpThetaUVector &v);
@@ -160,7 +160,7 @@ public:
   vpRotationMatrix inverse() const;
   void inverse(vpRotationMatrix &R) const;
 
-  bool isARotationMatrix() const;
+  bool isARotationMatrix(double threshold=1e-6) const;
 
   // copy operator from vpRotationMatrix
   vpRotationMatrix &operator=(const vpRotationMatrix &R);
@@ -197,7 +197,7 @@ public:
     (void)ncols;
     (void)flagNullify;
     throw(vpException(vpException::fatalError, "Cannot resize a rotation matrix"));
-  };
+  }
 
   // transpose
   vpRotationMatrix t() const;
@@ -214,16 +214,13 @@ public:
      \deprecated Provided only for compat with previous releases.
      This function does nothing.
    */
-  vp_deprecated void init(){};
+  vp_deprecated void init(){}
   /*!
      \deprecated You should rather use eye().
    */
   vp_deprecated void setIdentity();
 //@}
 #endif
-
-private:
-  static const double threshold;
 
 protected:
   unsigned int m_index;

--- a/modules/core/src/math/transformation/vpRotationMatrix.cpp
+++ b/modules/core/src/math/transformation/vpRotationMatrix.cpp
@@ -54,7 +54,6 @@
 // Debug trace
 #include <math.h>
 #include <visp3/core/vpDebug.h>
-const double vpRotationMatrix::threshold = 1e-6;
 
 /*!
   Initialize the rotation matrix as identity.
@@ -236,7 +235,7 @@ R:
  */
 vpRotationMatrix& vpRotationMatrix::operator,(double val)
 {
-  m_index ++;;
+  m_index ++;
   if (m_index >= size()) {
     throw(vpException(vpException::dimensionError, "Cannot set rotation matrix out of bounds. It has only %d elements while you try to initialize with %d elements", size(), m_index+1));
   }
@@ -396,9 +395,8 @@ vpRotationMatrix &vpRotationMatrix::operator*=(double x)
 /*!
   Test if the rotation matrix is really a rotation matrix.
 */
-bool vpRotationMatrix::isARotationMatrix() const
+bool vpRotationMatrix::isARotationMatrix(double threshold) const
 {
-  unsigned int i, j;
   bool isRotation = true;
 
   if (getCols() != 3 || getRows() != 3) {
@@ -407,28 +405,32 @@ bool vpRotationMatrix::isARotationMatrix() const
 
   // test R^TR = Id ;
   vpRotationMatrix RtR = (*this).t() * (*this);
-  for (i = 0; i < 3; i++) {
-    for (j = 0; j < 3; j++) {
+  for (unsigned int i = 0; i < 3; i++) {
+    for (unsigned int j = 0; j < 3; j++) {
       if (i == j) {
-        if (fabs(RtR[i][j] - 1) > threshold)
+        if (fabs(RtR[i][j] - 1) > threshold) {
           isRotation = false;
+        }
       } else {
-        if (fabs(RtR[i][j]) > threshold)
+        if (fabs(RtR[i][j]) > threshold) {
           isRotation = false;
+        }
       }
     }
   }
   // test if it is a basis
   // test || Ci || = 1
-  for (i = 0; i < 3; i++) {
-    if ((sqrt(vpMath::sqr(RtR[0][i]) + vpMath::sqr(RtR[1][i]) + vpMath::sqr(RtR[2][i])) - 1) > threshold)
+  for (unsigned int i = 0; i < 3; i++) {
+    if ((sqrt(vpMath::sqr(RtR[0][i]) + vpMath::sqr(RtR[1][i]) + vpMath::sqr(RtR[2][i])) - 1) > threshold) {
       isRotation = false;
+    }
   }
 
   // test || Ri || = 1
-  for (i = 0; i < 3; i++) {
-    if ((sqrt(vpMath::sqr(RtR[i][0]) + vpMath::sqr(RtR[i][1]) + vpMath::sqr(RtR[i][2])) - 1) > threshold)
+  for (unsigned int i = 0; i < 3; i++) {
+    if ((sqrt(vpMath::sqr(RtR[i][0]) + vpMath::sqr(RtR[i][1]) + vpMath::sqr(RtR[i][2])) - 1) > threshold) {
       isRotation = false;
+    }
   }
 
   //  test if the basis is orthogonal
@@ -445,6 +447,7 @@ vpRotationMatrix::vpRotationMatrix() : vpArray2D<double>(3, 3), m_index(0) { eye
   rotation matrix.
 */
 vpRotationMatrix::vpRotationMatrix(const vpRotationMatrix &M) : vpArray2D<double>(3, 3), m_index(0) { (*this) = M; }
+
 /*!
   Construct a 3-by-3 rotation matrix from an homogeneous matrix.
 */
@@ -540,9 +543,8 @@ vpRotationMatrix vpRotationMatrix::t() const
 {
   vpRotationMatrix Rt;
 
-  unsigned int i, j;
-  for (i = 0; i < 3; i++)
-    for (j = 0; j < 3; j++)
+  for (unsigned int i = 0; i < 3; i++)
+    for (unsigned int j = 0; j < 3; j++)
       Rt[j][i] = (*this)[i][j];
 
   return Rt;
@@ -605,7 +607,6 @@ void vpRotationMatrix::printVector()
 */
 vpRotationMatrix vpRotationMatrix::buildFrom(const vpThetaUVector &v)
 {
-  unsigned int i, j;
   double theta, si, co, sinc, mcosc;
   vpRotationMatrix R;
 
@@ -625,8 +626,8 @@ vpRotationMatrix vpRotationMatrix::buildFrom(const vpThetaUVector &v)
   R[2][1] = sinc * v[0] + mcosc * v[2] * v[1];
   R[2][2] = co + mcosc * v[2] * v[2];
 
-  for (i = 0; i < 3; i++)
-    for (j = 0; j < 3; j++)
+  for (unsigned int i = 0; i < 3; i++)
+    for (unsigned int j = 0; j < 3; j++)
       (*this)[i][j] = R[i][j];
 
   return *this;

--- a/modules/core/test/math/testHomogeneousMatrix.cpp
+++ b/modules/core/test/math/testHomogeneousMatrix.cpp
@@ -1,0 +1,118 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2021 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test some vpHomogeneousMatrix functionalities.
+ *
+ *****************************************************************************/
+
+/*!
+  Test some vpHomogeneousMatrix functionalities.
+ */
+#include <visp3/core/vpConfig.h>
+
+#ifdef VISP_HAVE_CATCH2
+#include <visp3/core/vpHomogeneousMatrix.h>
+
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+TEST_CASE("vpHomogeneousMatrix re-orthogonalize rotation matrix", "[vpHomogeneousMatrix]") {
+  CHECK_NOTHROW([](){
+    vpHomogeneousMatrix M {
+      0.9835, -0.0581,  0.1716, 0.0072,
+      -0.0489, -0.9972, -0.0571, 0.0352,
+      0.1744,  0.0478, -0.9835, 0.9470
+    };
+  }());
+
+  CHECK_NOTHROW([](){
+    vpHomogeneousMatrix M {
+      0.9835, -0.0581,  0.1716, 0.0072,
+      -0.0937, -0.9738,  0.2072, 0.0481,
+      0.1551, -0.2199, -0.9631, 0.9583
+    };
+
+    std::cout << "Original data:" << std::endl;
+    std::cout << "0.9835 -0.0581  0.1716 0.0072" << std::endl;
+    std::cout << " -0.0937 -0.9738  0.2072 0.0481" << std::endl;
+    std::cout << "0.1551 -0.2199 -0.9631 0.9583" << std::endl;
+    std::cout << "0 0 0 1" << std::endl;
+    std::cout << "M after rotation re-orthogonalization:\n" << M << std::endl;
+  }());
+
+  CHECK_NOTHROW([](){
+    vpHomogeneousMatrix M1 {
+      0.9835, -0.0581,  0.1716, 0.0072,
+      -0.0937, -0.9738,  0.2072, 0.0481,
+      0.1551, -0.2199, -0.9631, 0.9583
+    };
+
+    // if M1 contains a proper rotation matrix
+    // following R init should not throw exception since re-orthogonalization
+    // is done only in vpHomogeneousMatrix, not in vpRotationMatrix
+    vpRotationMatrix R {
+      M1[0][0], M1[0][1], M1[0][2],
+      M1[1][0], M1[1][1], M1[1][2],
+      M1[2][0], M1[2][1], M1[2][2]
+    };
+  }());
+
+  CHECK_THROWS([](){
+    vpHomogeneousMatrix M {
+      0.983, -0.058,  0.171, 0.0072,
+      -0.093, -0.973,  0.207, 0.0481,
+      0.155, -0.219, -0.963, 0.9583
+    };
+  }());
+}
+
+int main(int argc, char *argv[])
+{
+  Catch::Session session; // There must be exactly one instance
+
+  // Let Catch (using Clara) parse the command line
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+
+  // numFailed is clamped to 255 as some unices only use the lower 8 bits.
+  // This clamping has already been applied, so just return it here
+  // You can also do any post run clean-up here
+  return numFailed;
+}
+#else
+#include <iostream>
+
+int main()
+{
+  return 0;
+}
+#endif


### PR DESCRIPTION
My use case:
- I am using Blender and poses decimal precision are printed using Blender/Python default terminal accuracy
- I am using C++11 `std::initializer_list` feature to easily initialize a `vpHomogeneousMatrix`:
```cpp
    vpHomogeneousMatrix M1 {
      0.9835, -0.0581,  0.1716, 0.0072,
      -0.0937, -0.9738,  0.2072, 0.0481,
      0.1551, -0.2199, -0.9631, 0.9583
    };
```
- before since the rotation part is not exactly orthogonal, it throws an exception (
- see:
https://github.com/lagadic/visp/blob/efb9421168f7c7770fad1a3ef14020cbcbdf2fbf/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp#L711-L717
https://github.com/lagadic/visp/blob/efb9421168f7c7770fad1a3ef14020cbcbdf2fbf/modules/core/src/math/transformation/vpRotationMatrix.cpp#L399-L436
- now, we perform re-orthogonalization of the rotation part
- so this changes slightly the input data

To be discussed if it is valid to slightly change the input data. Also, this is not updated in `vpRotationMatrix` but the same "issue" exists.