### PR TITLE
Clear input pose vector in vpDetectorAprilTag at each new detection

### DIFF
--- a/modules/detection/src/tag/vpDetectorAprilTag.cpp
+++ b/modules/detection/src/tag/vpDetectorAprilTag.cpp
@@ -800,6 +800,10 @@ bool vpDetectorAprilTag::detect(const vpImage<unsigned char> &I, double tagSize,
   m_polygon.clear();
   m_nb_objects = 0;
 
+  cMo_vec.clear();
+  if (cMo_vec2) {
+    cMo_vec2->clear();
+  }
   bool detected = m_impl->detect(I, tagSize, cam, m_polygon, m_message, m_displayTag,
                                  m_displayTagColor, m_displayTagThickness,
                                  &cMo_vec, cMo_vec2, projErrors, projErrors2);


### PR DESCRIPTION
To avoid having to do this:

```cpp
  vpImage<unsigned char> I;
  vpImageIo::read(I, "target_1.png");
  std::vector<vpHomogeneousMatrix> cMo_vec;
  if (detector.detect(I, tagSize, cam, cMo_vec)) {
      //
  }

  cMo_vec.clear(); //need to clear the input vector
  vpImageIo::read(I, "target_2.png");
  if (detector.detect(I, tagSize, cam, cMo_vec)) {
      //
  }
```