### PR TITLE
Use g++ 9 and 10 instead of 11 that sounds not available

### DIFF
--- a/.github/workflows/ubuntu-dep-apt.yml
+++ b/.github/workflows/ubuntu-dep-apt.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        compiler: [9, 11]
+        compiler: [9, 10]
 
     steps:
     # https://github.com/marketplace/actions/cancel-workflow-action


### PR DESCRIPTION
Today g++-11 is no more available, while it was yesterday (see [here](https://github.com/lagadic/visp/runs/2727996799?check_suite_focus=true))

Today on Ubuntu 18.04 available compilers are:
```
Run dpkg --list | grep compiler
ii  clang-9                                                     1:9-2~ubuntu18.04.2                                                 amd64        C, C++ and Objective-C compiler
ii  g++                                                         4:7.4.0-1ubuntu2.3                                                  amd64        GNU C++ compiler
ii  g++-10                                                      10.3.0-1ubuntu1~18.04~1                                             amd64        GNU C++ compiler
ii  g++-7                                                       7.5.0-3ubuntu1~18.04                                                amd64        GNU C++ compiler
ii  g++-9                                                       9.3.0-11ubuntu0~18.04.1                                             amd64        GNU C++ compiler
ii  gcc                                                         4:7.4.0-1ubuntu2.3                                                  amd64        GNU C compiler
ii  gcc-10                                                      10.3.0-1ubuntu1~18.04~1                                             amd64        GNU C compiler
ii  gcc-7                                                       7.5.0-3ubuntu1~18.04                                                amd64        GNU C compiler
ii  gcc-9                                                       9.3.0-11ubuntu0~18.04.1                                             amd64        GNU C compiler
```

Today on Ubuntu 20.04 available compilers are:
```
Run dpkg --list | grep compiler
ii  clang-10                                                    1:10.0.0-4ubuntu1                                                   amd64        C, C++ and Objective-C compiler
ii  clang-11                                                    1:11.0.0-2~ubuntu20.04.1                                            amd64        C, C++ and Objective-C compiler
ii  clang-12                                                    1:12.0.1~++20210525082622+328a6ec95532-1~exp1~20210525063352.95     amd64        C, C++ and Objective-C compiler
ii  g++                                                         4:9.3.0-1ubuntu2                                                    amd64        GNU C++ compiler
ii  g++-10                                                      10.2.0-5ubuntu1~20.04                                               amd64        GNU C++ compiler
ii  g++-9                                                       9.3.0-17ubuntu1~20.04                                               amd64        GNU C++ compiler
ii  gcc                                                         4:9.3.0-1ubuntu2                                                    amd64        GNU C compiler
ii  gcc-10                                                      10.2.0-5ubuntu1~20.04                                               amd64        GNU C compiler
ii  gcc-9                                                       9.3.0-17ubuntu1~20.04                                               amd64        GNU C compiler 
```