### PR TITLE
Add display of geometric features in color images

### DIFF
--- a/modules/core/include/visp3/core/vpCircle.h
+++ b/modules/core/include/visp3/core/vpCircle.h
@@ -61,8 +61,8 @@
 
   A 3D circle has the followings parameters:
   - **in the object frame**: the parameters oA, oB, oC corresponding to the 3D plane with equation
-  oA*(x-oX)+oB*(y-oY)+oC*(z-oZ)=0 passing through the 3D sphere center and the
-  3D coordinates oX, oY, oZ of the center and radius R of the 3D sphere. These
+  oA*(X-oX)+oB*(Y-oY)+oC*(Z-oZ)=0 where (X,Y,Z) are the coordinates of a 3D point belonging to the plane passing through
+  the 3D sphere center (oX,oY,oZ) and the 3D coordinates oX, oY, oZ of the center and radius R of the 3D sphere. These
   parameters registered in vpForwardProjection::oP internal 7-dim vector are set using the constructors
   vpCircle(double oA, double oB, double oC, double oX, double oY, double oZ, double R),
   vpCircle(const vpColVector &oP) or the fonctions
@@ -96,12 +96,16 @@ public:
   vpCircle(double oA, double oB, double oC, double oX, double oY, double oZ, double R);
   virtual ~vpCircle();
 
-  void changeFrame(const vpHomogeneousMatrix &cMo, vpColVector &cP) const;
+  void changeFrame(const vpHomogeneousMatrix &noMo, vpColVector &noP) const;
   void changeFrame(const vpHomogeneousMatrix &cMo);
 
   void display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
                unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
+               unsigned int thickness = 1);
   void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+               const vpColor &color = vpColor::green, unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                const vpColor &color = vpColor::green, unsigned int thickness = 1);
   vpCircle *duplicate() const;
 

--- a/modules/core/include/visp3/core/vpCylinder.h
+++ b/modules/core/include/visp3/core/vpCylinder.h
@@ -119,7 +119,11 @@ public:
 
   void display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
                unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
+               unsigned int thickness = 1);
   void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+               const vpColor &color = vpColor::green, unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                const vpColor &color = vpColor::green, unsigned int thickness = 1);
 
   vpCylinder *duplicate() const;

--- a/modules/core/include/visp3/core/vpLine.h
+++ b/modules/core/include/visp3/core/vpLine.h
@@ -113,7 +113,11 @@ public:
 
   void display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
                unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
+               unsigned int thickness = 1);
   void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+               const vpColor &color = vpColor::green, unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                const vpColor &color = vpColor::green, unsigned int thickness = 1);
 
   vpLine *duplicate() const;

--- a/modules/core/include/visp3/core/vpPoint.h
+++ b/modules/core/include/visp3/core/vpPoint.h
@@ -59,8 +59,8 @@ class vpHomogeneousMatrix;
 
   A 3D point has the followings parameters:
   - **in the object frame**: the normalized 3D coordinates oX, oY, oZ, oW of the point. These
-  parameters registered in vpForwardProjection::oP internal 4-dim vector are set using the constructors vpPoint(double oX, double oY, double oZ),
-  vpPoint(const vpColVector &oP) and vpPoint(const std::vector<double> &oP) or the fonctions
+  parameters registered in vpForwardProjection::oP internal 4-dim vector are set using the constructors vpPoint(double
+ oX, double oY, double oZ), vpPoint(const vpColVector &oP) and vpPoint(const std::vector<double> &oP) or the fonctions
   setWorldCoordinates(double oX, double oY, double oZ),
   setWorldCoordinates(const vpColVector &oP) and setWorldCoordinates(const std::vector<double> &oP).
  To get theses parameters use get_oP().
@@ -72,10 +72,10 @@ class vpHomogeneousMatrix;
   To get theses parameters use get_cP().
 
   - **in the image plane**: the 2D normalized coordinates (x, y, 1) corresponding
-  to the perspective projection of the point. These parameters are registered in vpTracker::p internal 3-dim vector and computed using projection() and
-  projection(const vpColVector &cP, vpColVector &p) const. They could be retrieved using get_x() and get_y().
-  They correspond to 2D normalized point parameters with values expressed in meters.
-  To get theses parameters use get_p().
+  to the perspective projection of the point. These parameters are registered in vpTracker::p internal 3-dim vector and
+ computed using projection() and projection(const vpColVector &cP, vpColVector &p) const. They could be retrieved using
+ get_x() and get_y(). They correspond to 2D normalized point parameters with values expressed in meters. To get theses
+ parameters use get_p().
 
 */
 class VISP_EXPORT vpPoint : public vpForwardProjection
@@ -96,6 +96,8 @@ public:
   void changeFrame(const vpHomogeneousMatrix &cMo);
 
   void display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
+               unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
                unsigned int thickness = 1);
   void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                const vpColor &color = vpColor::green, unsigned int thickness = 1);

--- a/modules/core/include/visp3/core/vpSphere.h
+++ b/modules/core/include/visp3/core/vpSphere.h
@@ -59,10 +59,9 @@
 
   A sphere has the followings parameters:
   - **in the object frame**: the 3D coordinates oX, oY, oZ of the center and radius R. These
-  parameters registered in vpForwardProjection::oP internal 4-dim vector are set using the constructors vpSphere(double oX, double oY, double oZ, double R),
-  vpSphere(const vpColVector &oP) or the fonctions setWorldCoordinates(double oX, double oY, double oZ, double R)
-  and setWorldCoordinates(const vpColVector &oP).
-  To get theses parameters use get_oP().
+  parameters registered in vpForwardProjection::oP internal 4-dim vector are set using the constructors vpSphere(double
+  oX, double oY, double oZ, double R), vpSphere(const vpColVector &oP) or the fonctions setWorldCoordinates(double oX,
+  double oY, double oZ, double R) and setWorldCoordinates(const vpColVector &oP). To get theses parameters use get_oP().
 
   - **in the camera frame**: the coordinates cX, cY, cZ of the center and radius R. These
   parameters registered in vpTracker::cP internal 4-dim vector are computed using
@@ -93,7 +92,11 @@ public:
 
   void display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
                unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color = vpColor::green,
+               unsigned int thickness = 1);
   void display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+               const vpColor &color = vpColor::green, unsigned int thickness = 1);
+  void display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                const vpColor &color = vpColor::green, unsigned int thickness = 1);
 
   vpSphere *duplicate() const;

--- a/modules/core/src/tracking/forward-projection/vpCircle.cpp
+++ b/modules/core/src/tracking/forward-projection/vpCircle.cpp
@@ -52,7 +52,7 @@ void vpCircle::init()
   Set the parameters of the 3D circle in the object frame.
 
   \param oP_ : This 7-dim vector defines the parameters oP[0], oP[1], oP[2] corresponding
-  to parameters oA, oB, oC of the plane with equation oA*(x-oX)+oB*(y-oY)+oC*(z-oZ)=0
+  to parameters oA, oB, oC of the plane with equation oA*(X-oX)+oB*(Y-oY)+oC*(Z-oZ)=0
   passing through the 3D sphere center.  oP[3], oP[4], oP[5] correspond to oX, oY, oZ the
   coordinates of the center of the sphere. oP[6] corresponds to the radius of
   the sphere.
@@ -62,7 +62,7 @@ void vpCircle::setWorldCoordinates(const vpColVector &oP_) { this->oP = oP_; }
 /*!
   Set the 3D circle coordinates in the object frame.
 
-  \param oA, oB, oC : Parameters of the plane with equation oA*(x-oX)+oB*(y-oY)+oC*(z-oZ)=0
+  \param oA, oB, oC : Parameters of the plane with equation oA*(X-oX)+oB*(Y-oY)+oC*(Z-oZ)=0
   passing through the 3D sphere center.
   \param oX : Coordinate of the center of the sphere along X-axis in the object frame.
   \param oY : Coordinate of the center of the sphere along Y-axis in the object frame.
@@ -89,7 +89,7 @@ vpCircle::vpCircle() { init(); }
   Construct the circle from the intersection of a plane and a sphere.
 
   \param oP_ : This 7-dim vector defines the parameters oP[0], oP[1], oP[2] corresponding
-  to parameters oA, oB, oC of the plane with equation oA*(x-oX)+oB*(y-oY)+oC*(z-oZ)=0
+  to parameters oA, oB, oC of the plane with equation oA*(X-oX)+oB*(Y-oY)+oC*(Z-oZ)=0
   passing through the 3D sphere center.  oP[3], oP[4], oP[5] correspond to oX, oY, oZ the
   coordinates of the center of the sphere. oP[6] corresponds to the radius of
   the sphere.
@@ -106,7 +106,7 @@ vpCircle::vpCircle(const vpColVector &oP_)
   Construct the 3D circle from the intersection of a plane and a sphere with
   coordinates expressed in the object frame.
 
-  \param oA, oB, oC : Parameters of the plane with equation oA*(x-oX)+oB*(y-oY)+oC*(z-oZ)=0
+  \param oA, oB, oC : Parameters of the plane with equation oA*(X-oX)+oB*(Y-oY)+oC*(Z-oZ)=0
   passing through the 3D sphere center.
   \param oX : Coordinate of the center of the sphere along X-axis in the object frame.
   \param oY : Coordinate of the center of the sphere along Y-axis in the object frame.
@@ -238,34 +238,37 @@ void vpCircle::projection(const vpColVector &cP_, vpColVector &p_) const
 /*!
   From the 3D coordinates of the circle in the object frame oP that are set using for
   example vpCircle(double oA, double oB, double oC, double oX, double oY, double oZ, double R)
-  or setWorldCoordinates(), compute the 3D coordinates of the circle in the camera frame cP = cMo * oP.
+  or setWorldCoordinates(), compute the 3D coordinates of the circle in a new object frame noP = noMo * oP.
+  Internal parameters of the circle remain unchanged.
 
-  \param cMo : Transformation from camera to object frame.
-  \param cP_ : 3D normalized coordinates of the circle in the camera frame cP = (cA, cB, cC, cX, cY, cZ, R).
-*/void vpCircle::changeFrame(const vpHomogeneousMatrix &cMo, vpColVector &cP_) const
+  \param noMo : Transformation from camera to object frame.
+  \param noP : 3D normalized coordinates of the circle in the a new ojbect frame noP = (noA, noB, noC, noX, noY, noZ,
+  R).
+*/
+void vpCircle::changeFrame(const vpHomogeneousMatrix &noMo, vpColVector &noP) const
 {
-  cP_.resize(7, false);
+  noP.resize(7, false);
 
   double A, B, C;
-  A = cMo[0][0] * oP[0] + cMo[0][1] * oP[1] + cMo[0][2] * oP[2];
-  B = cMo[1][0] * oP[0] + cMo[1][1] * oP[1] + cMo[1][2] * oP[2];
-  C = cMo[2][0] * oP[0] + cMo[2][1] * oP[1] + cMo[2][2] * oP[2];
+  A = noMo[0][0] * oP[0] + noMo[0][1] * oP[1] + noMo[0][2] * oP[2];
+  B = noMo[1][0] * oP[0] + noMo[1][1] * oP[1] + noMo[1][2] * oP[2];
+  C = noMo[2][0] * oP[0] + noMo[2][1] * oP[1] + noMo[2][2] * oP[2];
 
   double X0, Y0, Z0;
-  X0 = cMo[0][3] + cMo[0][0] * oP[3] + cMo[0][1] * oP[4] + cMo[0][2] * oP[5];
-  Y0 = cMo[1][3] + cMo[1][0] * oP[3] + cMo[1][1] * oP[4] + cMo[1][2] * oP[5];
-  Z0 = cMo[2][3] + cMo[2][0] * oP[3] + cMo[2][1] * oP[4] + cMo[2][2] * oP[5];
+  X0 = noMo[0][3] + noMo[0][0] * oP[3] + noMo[0][1] * oP[4] + noMo[0][2] * oP[5];
+  Y0 = noMo[1][3] + noMo[1][0] * oP[3] + noMo[1][1] * oP[4] + noMo[1][2] * oP[5];
+  Z0 = noMo[2][3] + noMo[2][0] * oP[3] + noMo[2][1] * oP[4] + noMo[2][2] * oP[5];
   double R = oP[6];
 
-  cP_[0] = A;
-  cP_[1] = B;
-  cP_[2] = C;
+  noP[0] = A;
+  noP[1] = B;
+  noP[2] = C;
 
-  cP_[3] = X0;
-  cP_[4] = Y0;
-  cP_[5] = Z0;
+  noP[3] = X0;
+  noP[4] = Y0;
+  noP[5] = Z0;
 
-  cP_[6] = R;
+  noP[6] = R;
 }
 
 /*!
@@ -299,7 +302,8 @@ void vpCircle::changeFrame(const vpHomogeneousMatrix &cMo)
 }
 
 /*!
- * Display the projection of a 3D circle in image \e I.
+ * Display the projection of a 3D circle in image \e I using internal coordinates in the image plane (x,y,n20,n11,n02)
+ * available in `p` vector. These coordinates may be updated using projection().
  *
  * \param I : Image used as background.
  * \param cam : Camera parameters.
@@ -307,6 +311,21 @@ void vpCircle::changeFrame(const vpHomogeneousMatrix &cMo)
  * \param thickness : Thickness used to draw the circle.
  */
 void vpCircle::display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color,
+                       unsigned int thickness)
+{
+  vpFeatureDisplay::displayEllipse(p[0], p[1], p[2], p[3], p[4], cam, I, color, thickness);
+}
+
+/*!
+ * Display the projection of a 3D circle in image \e I using internal coordinates in the image plane (x,y,n20,n11,n02)
+ * available in `p` vector. These coordinates may be updated using projection().
+ *
+ * \param I : Image used as background.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the circle.
+ * \param thickness : Thickness used to draw the circle.
+ */
+void vpCircle::display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color,
                        unsigned int thickness)
 {
   vpFeatureDisplay::displayEllipse(p[0], p[1], p[2], p[3], p[4], cam, I, color, thickness);
@@ -331,7 +350,28 @@ void vpCircle::display(const vpImage<unsigned char> &I, const vpHomogeneousMatri
   projection(_cP, _p);
   vpFeatureDisplay::displayEllipse(_p[0], _p[1], _p[2], _p[3], _p[4], cam, I, color, thickness);
 }
-//! for memory issue (used by the vpServo class only)
+
+/*!
+ * Display the projection of a sphere in image \e I.
+ * This method is non destructive wrt. cP and p internal circle parameters.
+ *
+ * \param I : Image used as background.
+ * \param cMo : Homogeneous transformation from camera frame to object frame.
+ * The circle is considered as viewed from this camera position.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the sphere.
+ * \param thickness : Thickness used to draw the circle.
+ */
+void vpCircle::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                       const vpColor &color, unsigned int thickness)
+{
+  vpColVector _cP, _p;
+  changeFrame(cMo, _cP);
+  projection(_cP, _p);
+  vpFeatureDisplay::displayEllipse(_p[0], _p[1], _p[2], _p[3], _p[4], cam, I, color, thickness);
+}
+
+//! For memory issue (used by the vpServo class only)
 vpCircle *vpCircle::duplicate() const
 {
   vpCircle *feature = new vpCircle(*this);

--- a/modules/core/src/tracking/forward-projection/vpCylinder.cpp
+++ b/modules/core/src/tracking/forward-projection/vpCylinder.cpp
@@ -381,6 +381,28 @@ void vpCylinder::display(const vpImage<unsigned char> &I, const vpHomogeneousMat
 
 /*!
  * Display the projection of a 3D cylinder in image \e I as two lines corresponding to the limbs.
+ * This method is non destructive wrt. cP and p internal 3D point parameters.
+ *
+ * \param I : Image used as background.
+ * \param cMo : Homogeneous transformation from camera frame to object frame.
+ * The point is considered as viewed from this camera position.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the sphere.
+ * \param thickness : Thickness used to draw the sphere.
+ */
+
+void vpCylinder::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                         const vpColor &color, unsigned int thickness)
+{
+
+  vpColVector _cP(7), _p(4);
+  changeFrame(cMo, _cP);
+  projection(_cP, _p);
+  vpFeatureDisplay::displayCylinder(_p[0], _p[1], _p[2], _p[3], cam, I, color, thickness);
+}
+
+/*!
+ * Display the projection of a 3D cylinder in image \e I as two lines corresponding to the limbs.
  *
  * \param I : Image used as background.
  * \param cam : Camera parameters.
@@ -388,6 +410,20 @@ void vpCylinder::display(const vpImage<unsigned char> &I, const vpHomogeneousMat
  * \param thickness : Thickness used to draw the point.
  */
 void vpCylinder::display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color,
+                         unsigned int thickness)
+{
+  vpFeatureDisplay::displayCylinder(p[0], p[1], p[2], p[3], cam, I, color, thickness);
+}
+
+/*!
+ * Display the projection of a 3D cylinder in image \e I as two lines corresponding to the limbs.
+ *
+ * \param I : Image used as background.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the point.
+ * \param thickness : Thickness used to draw the point.
+ */
+void vpCylinder::display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color,
                          unsigned int thickness)
 {
   vpFeatureDisplay::displayCylinder(p[0], p[1], p[2], p[3], cam, I, color, thickness);

--- a/modules/core/src/tracking/forward-projection/vpLine.cpp
+++ b/modules/core/src/tracking/forward-projection/vpLine.cpp
@@ -190,10 +190,7 @@ void vpLine::setWorldCoordinates(const vpColVector &oP1, const vpColVector &oP2)
   line.projection();
   \endcode
 */
-void vpLine::projection()
-{
-  projection(cP, p);
-}
+void vpLine::projection() { projection(cP, p); }
 
 /*!
 
@@ -473,6 +470,27 @@ void vpLine::display(const vpImage<unsigned char> &I, const vpCameraParameters &
 
 /*!
 
+  Displays the line in the image \e I thanks to the 2D parameters of
+  the line \e p in the image plane (vpTracker::p) and the camera
+  parameters which enable to convert the parameters from meter to pixel.
+
+  \param I : The image where the line must be displayed.
+
+  \param cam : The camera parameters to enable the conversion from
+                meter to pixel.
+
+  \param color : The desired color to display the line in the image.
+
+  \param thickness : Thickness of the feature representation.
+                          */
+void vpLine::display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color,
+                     unsigned int thickness)
+{
+  vpFeatureDisplay::displayLine(p[0], p[1], cam, I, color, thickness);
+}
+
+/*!
+
   Displays the line in the image \e I thanks to the parameters in the
   object frame (vpForwardProjection::oP), the homogeneous matrix
   relative to the pose between the camera frame and the object frame
@@ -501,8 +519,42 @@ void vpLine::display(const vpImage<unsigned char> &I, const vpHomogeneousMatrix 
   try {
     projection(_cP, _p);
     vpFeatureDisplay::displayLine(_p[0], _p[1], cam, I, color, thickness);
+  } catch (...) {
+    // Skip potential exception: due to a degenerate case: the image of the straight line is a point!
   }
-  catch(...) {
+}
+
+/*!
+
+  Displays the line in the image \e I thanks to the parameters in the
+  object frame (vpForwardProjection::oP), the homogeneous matrix
+  relative to the pose between the camera frame and the object frame
+  and the camera parameters which enable to convert the features from
+  meter to pixel.
+
+  This method is non destructive wrt. cP and p internal line parameters.
+
+  \param I : The image where the line must be displayed in overlay.
+
+  \param cMo : The homogeneous matrix corresponding to the pose
+                between the camera frame and the object frame.
+
+  \param cam : The camera parameters to enable the conversion from
+                meter to pixel.
+
+  \param color : The desired color to display the line in the image.
+
+  \param thickness : Thickness of the feature representation.
+                          */
+void vpLine::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                     const vpColor &color, unsigned int thickness)
+{
+  vpColVector _cP, _p;
+  changeFrame(cMo, _cP);
+  try {
+    projection(_cP, _p);
+    vpFeatureDisplay::displayLine(_p[0], _p[1], cam, I, color, thickness);
+  } catch (...) {
     // Skip potential exception: due to a degenerate case: the image of the straight line is a point!
   }
 }

--- a/modules/core/src/tracking/forward-projection/vpPoint.cpp
+++ b/modules/core/src/tracking/forward-projection/vpPoint.cpp
@@ -433,6 +433,20 @@ void vpPoint::display(const vpImage<unsigned char> &I, const vpCameraParameters 
   vpFeatureDisplay::displayPoint(p[0], p[1], cam, I, color, thickness);
 }
 
+/*!
+ * Display the projection of a 3D point in image \e I.
+ *
+ * \param I : Image used as background.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the point.
+ * \param thickness : Thickness used to draw the point.
+ */
+void vpPoint::display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color,
+                      unsigned int thickness)
+{
+  vpFeatureDisplay::displayPoint(p[0], p[1], cam, I, color, thickness);
+}
+
 // Get coordinates
 //! Get the point cX coordinate in the camera frame.
 double vpPoint::get_X() const { return cP[0]; }

--- a/modules/core/src/tracking/forward-projection/vpSphere.cpp
+++ b/modules/core/src/tracking/forward-projection/vpSphere.cpp
@@ -258,6 +258,26 @@ void vpSphere::display(const vpImage<unsigned char> &I, const vpHomogeneousMatri
 
 /*!
  * Display the projection of a 3D sphere in image \e I.
+ * This method is non destructive wrt. cP and p internal sphere parameters.
+ *
+ * \param I : Image used as background.
+ * \param cMo : Homogeneous transformation from camera frame to object frame.
+ * The sphere is considered as viewed from this camera position.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the sphere.
+ * \param thickness : Thickness used to draw the sphere.
+ */
+void vpSphere::display(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
+                       const vpColor &color, unsigned int thickness)
+{
+  vpColVector _cP, _p;
+  changeFrame(cMo, _cP);
+  projection(_cP, _p);
+  vpFeatureDisplay::displayEllipse(_p[0], _p[1], _p[2], _p[3], _p[4], cam, I, color, thickness);
+}
+
+/*!
+ * Display the projection of a 3D sphere in image \e I.
  *
  * \param I : Image used as background.
  * \param cam : Camera parameters.
@@ -265,6 +285,20 @@ void vpSphere::display(const vpImage<unsigned char> &I, const vpHomogeneousMatri
  * \param thickness : Thickness used to draw the sphere.
  */
 void vpSphere::display(const vpImage<unsigned char> &I, const vpCameraParameters &cam, const vpColor &color,
+                       unsigned int thickness)
+{
+  vpFeatureDisplay::displayEllipse(p[0], p[1], p[2], p[3], p[4], cam, I, color, thickness);
+}
+
+/*!
+ * Display the projection of a 3D sphere in image \e I.
+ *
+ * \param I : Image used as background.
+ * \param cam : Camera parameters.
+ * \param color : Color used to draw the sphere.
+ * \param thickness : Thickness used to draw the sphere.
+ */
+void vpSphere::display(const vpImage<vpRGBa> &I, const vpCameraParameters &cam, const vpColor &color,
                        unsigned int thickness)
 {
   vpFeatureDisplay::displayEllipse(p[0], p[1], p[2], p[3], p[4], cam, I, color, thickness);


### PR DESCRIPTION
The following classes support now display in `vpRGBa` images: `vpCircle`, `vpCylinder`, `vpLine`, `vpPoint`, `vpSphere` 