### PR TITLE
Implement makeTempDirectory() for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,12 @@ if(WIN32)
   if(HAVE_LIBWINMM)
     list(APPEND VISP_LINKER_LIBS "winmm.lib")
   endif()
+
+  # rpcrt4.lib for timeGetTime() under windows
+  check_library_exists("rpcrt4.lib" getch "" HAVE_LIBRPCRT4) # for UuidToString()
+  if(HAVE_LIBRPCRT4)
+    list(APPEND VISP_LINKER_LIBS "rpcrt4.lib")
+  endif()
 endif()
 
 # Add library ws2_32.a or ws2_32.lib for vpNetwork class

--- a/modules/core/include/visp3/core/vpIoTools.h
+++ b/modules/core/include/visp3/core/vpIoTools.h
@@ -160,6 +160,7 @@ class VISP_EXPORT vpIoTools
 
 public:
   static const std::string &getBuildInformation();
+  static std::string getTempPath();
   static void getUserName(std::string &username);
   static std::string getUserName();
   static std::string getenv(const std::string &env);

--- a/modules/core/test/tools/io/testIoTools.cpp
+++ b/modules/core/test/tools/io/testIoTools.cpp
@@ -558,11 +558,10 @@ int main(int argc, const char **argv)
 #endif
 
   // Test makeTempDirectory()
-#if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
+#if defined(_WIN32) || (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX or Windows
   try {
-    std::string username, directory_filename_tmp;
-    vpIoTools::getUserName(username);
-    std::string tmp_dir = "/tmp/" + username;
+    std::string directory_filename_tmp;
+    std::string tmp_dir = vpIoTools::getTempPath();
 
     // Test 1
     directory_filename_tmp = tmp_dir + "/" + "vpIoTools_test_XXXXXX";


### PR DESCRIPTION
fix #948

It uses `UuidCreate()` to have something more or less unique. Maybe we should add a check to verify that the folder does not already exist, and if so generate another uuid?

Maybe we should add also `!defined(WINRT)` at some appropriate locations.