### PR TITLE
Fix SIFT usage with OpenCV 4.5.4 on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,15 @@ if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW) # For check_include_file and cmake 3.12.0
 endif()
 
+if(APPLE)
+  # Fix following errors for libpng and libjpeg detection:
+  # - Application built with libpng-1.4.12 but running with 1.6.37,
+  # - Wrong JPEG library version: library is 90, caller expects 80.
+  # The reason is that headers were found in /Library/Frameworks/Mono.framework/Headers
+  # while libraries in /usr/local/lib
+  set(CMAKE_FIND_FRAMEWORK LAST)
+endif()
+
 project(VISP C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ ViSP 3.4.1 (under development)
     . [#950] Cannot build tutorial-grabber-multiple-realsense.cpp with Visual Studio 2017
     . [#961] Build error on Ubuntu 21.10 with glibc 2.34
     . [#963] Unable to read a sequence of non consecutive images
+    . [#970] testKeyPoint-5 and testKeyPoint-7 are failing with OpenCV 4.5.4 on MacOS 11
     . [#972] Error running some examples: Application built with libpng-1.4.12
              but running with 1.6.37
     . [#973] Error running some examples: Wrong JPEG library version: library is 90,

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,10 @@ ViSP 3.4.1 (under development)
     . [#950] Cannot build tutorial-grabber-multiple-realsense.cpp with Visual Studio 2017
     . [#961] Build error on Ubuntu 21.10 with glibc 2.34
     . [#963] Unable to read a sequence of non consecutive images
+    . [#972] Error running some examples: Application built with libpng-1.4.12
+             but running with 1.6.37
+    . [#973] Error running some examples: Wrong JPEG library version: library is 90,
+             caller expects 80
 ----------------------------------------------
 ViSP 3.4.0 (released February 26, 2021)
   - Contributors:

--- a/modules/core/include/visp3/core/vpFont.h
+++ b/modules/core/include/visp3/core/vpFont.h
@@ -65,6 +65,7 @@ public:
   bool drawText(vpImage<vpRGBa> & I, const std::string & text, const vpImagePoint & position, const vpColor & color, const vpColor & background) const;
 
   unsigned int getHeight() const;
+  vpImagePoint getMeasure(const std::string & text) const;
   bool setHeight(unsigned int height);
 
 private:

--- a/modules/core/src/image/vpFont.cpp
+++ b/modules/core/src/image/vpFont.cpp
@@ -154,6 +154,15 @@ public:
   }
 
   /*!
+    (For ViSP type compatibility) Measures a size of region is need to draw given text.
+  */
+  vpImagePoint Measure2(const String & text) const
+  {
+    Point mes = Measure(text);
+    return vpImagePoint(mes.y, mes.x);
+  }
+
+  /*!
     Draws a text at the image.
 
     \param [out] canvas - a canvas (image where we draw text).
@@ -2023,6 +2032,16 @@ bool vpFont::drawText(vpImage<vpRGBa> & I, const std::string & text, const vpIma
 unsigned int vpFont::getHeight() const
 {
   return static_cast<unsigned int>(m_impl->Height());
+}
+
+/*!
+  Gets text bounding box size.
+
+  \return The width (\e j) and height (\e i) of the text bounding box.
+*/
+vpImagePoint vpFont::getMeasure(const std::string & text) const
+{
+  return m_impl->Measure2(text);
 }
 
 /*!

--- a/modules/core/test/image/testImageDraw.cpp
+++ b/modules/core/test/image/testImageDraw.cpp
@@ -59,6 +59,8 @@ int main(int argc ,char *argv[])
   }
   std::cout << "Save: " << save << std::endl;
 
+  const std::string visp = "ViSP: Open source Visual Servoing Platform";
+
   //vpRGBa
   {
     vpImage<vpRGBa> I(480, 640, vpRGBa(255));
@@ -78,6 +80,12 @@ int main(int argc ,char *argv[])
     iP1.set_i(200);
     iP1.set_j(200);
     font.drawText(I, "Test...", iP1, vpColor::white, vpColor::black);
+
+    vpFont font2(20);
+    vpImagePoint textSize = font2.getMeasure(visp);
+    vpImagePoint textPos = vpImagePoint(24, 620 - textSize.get_j());
+    font2.drawText(I, visp, textPos, vpColor::darkGreen);
+    vpImageDraw::drawRectangle(I, vpRect(textPos.get_u(), textPos.get_v(), textSize.get_u(), textSize.get_v()), vpColor::darkRed);
 
     iP1.set_i(80);
     iP1.set_j(220);
@@ -197,6 +205,12 @@ int main(int argc ,char *argv[])
     iP1.set_i(200);
     iP1.set_j(200);
     font.drawText(I, "Test...", iP1, 0, 255);
+
+    vpFont font2(20);
+    vpImagePoint textSize = font2.getMeasure(visp);
+    vpImagePoint textPos = vpImagePoint(24, 620 - textSize.get_j());
+    font2.drawText(I, visp, textPos, 255);
+    vpImageDraw::drawRectangle(I, vpRect(textPos.get_u(), textPos.get_v(), textSize.get_u(), textSize.get_v()), 255);
 
     iP1.set_i(80);
     iP1.set_j(220);

--- a/modules/vision/test/key-point/testKeyPoint-5.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-5.cpp
@@ -210,9 +210,9 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
 
 #if defined(VISP_HAVE_OPENCV_NONFREE) || defined(VISP_HAVE_OPENCV_XFEATURES2D) || \
     (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || (VISP_HAVE_OPENCV_VERSION >= 0x040400)
+#if (VISP_HAVE_OPENCV_VERSION != 0x040504) && (defined(__APPLE__) && defined(__MACH__))
   detectorNames.push_back("PyramidSIFT");
-#if (VISP_HAVE_OPENCV_VERSION != 0x040504)
-  detectorNames.push_back("SIFT"); // SIFT is known unstable with OpenCV 4.5.4
+  detectorNames.push_back("SIFT"); // SIFT is known unstable with OpenCV 4.5.4 on macOS
 #endif
 #endif
 #if defined(VISP_HAVE_OPENCV_NONFREE) || defined(VISP_HAVE_OPENCV_XFEATURES2D)
@@ -255,6 +255,14 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
 
   std::map<vpKeyPoint::vpFeatureDetectorType, std::string> mapOfDetectorNames = keyPoints.getDetectorNames();
   for (int i = 0; i < vpKeyPoint::DETECTOR_TYPE_SIZE; i++) {
+#if defined(VISP_HAVE_OPENCV_NONFREE) || defined(VISP_HAVE_OPENCV_XFEATURES2D) || \
+    (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || (VISP_HAVE_OPENCV_VERSION >= 0x040400)
+#if (VISP_HAVE_OPENCV_VERSION == 0x040504) && (defined(__APPLE__) && defined(__MACH__))
+    if (i == vpKeyPoint::DETECTOR_SIFT) { // SIFT is known unstable with OpenCV 4.5.4 on macOS
+      continue;
+    }
+#endif
+#endif
     keyPoints.setDetector((vpKeyPoint::vpFeatureDetectorType)i);
 
     std::vector<cv::KeyPoint> kpts;

--- a/modules/vision/test/key-point/testKeyPoint-5.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-5.cpp
@@ -211,7 +211,9 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
 #if defined(VISP_HAVE_OPENCV_NONFREE) || defined(VISP_HAVE_OPENCV_XFEATURES2D) || \
     (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || (VISP_HAVE_OPENCV_VERSION >= 0x040400)
   detectorNames.push_back("PyramidSIFT");
-  detectorNames.push_back("SIFT");
+#if (VISP_HAVE_OPENCV_VERSION != 0x040504)
+  detectorNames.push_back("SIFT"); // SIFT is known unstable with OpenCV 4.5.4
+#endif
 #endif
 #if defined(VISP_HAVE_OPENCV_NONFREE) || defined(VISP_HAVE_OPENCV_XFEATURES2D)
   detectorNames.push_back("PyramidSURF");

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -441,11 +441,13 @@ void run_test(const std::string &env_ipath, const std::string &opath,  vpImage<T
     std::cout << "Saving / loading learning files with binary descriptor are ok !" << std::endl;
   }
 
+
 // Test with floating point descriptor
-#if defined(VISP_HAVE_OPENCV_NONFREE) ||                                                                               \
+#if defined(VISP_HAVE_OPENCV_NONFREE) || \
   ((VISP_HAVE_OPENCV_VERSION >= 0x030000) && defined(VISP_HAVE_OPENCV_XFEATURES2D) || \
-   (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || ((VISP_HAVE_OPENCV_VERSION >= 0x040400) && (VISP_HAVE_OPENCV_VERSION != 0x040504)))
+   (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || (VISP_HAVE_OPENCV_VERSION >= 0x040400))
   {
+#if !((VISP_HAVE_OPENCV_VERSION == 0x040504) && (defined(__APPLE__) && defined(__MACH__))) // OpenCV != 4.5.4 on macOS
     std::string keypointName = "SIFT"; // SIFT is known unstable with OpenCV 4.5.4
     keyPoints.setDetector(keypointName);
     keyPoints.setExtractor(keypointName);
@@ -623,6 +625,7 @@ void run_test(const std::string &env_ipath, const std::string &opath,  vpImage<T
     std::cout << "vpKeyPoint::reset() is ok with trainKeyPoints and "
                  "trainDescriptors !"
               << std::endl;
+#endif // OpenCV != 4.5.4 on macOS
   }
 #endif
 }

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -444,9 +444,9 @@ void run_test(const std::string &env_ipath, const std::string &opath,  vpImage<T
 // Test with floating point descriptor
 #if defined(VISP_HAVE_OPENCV_NONFREE) ||                                                                               \
   ((VISP_HAVE_OPENCV_VERSION >= 0x030000) && defined(VISP_HAVE_OPENCV_XFEATURES2D) || \
-   (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || (VISP_HAVE_OPENCV_VERSION >= 0x040400))
+   (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || ((VISP_HAVE_OPENCV_VERSION >= 0x040400) && (VISP_HAVE_OPENCV_VERSION != 0x040504)
   {
-    std::string keypointName = "SIFT";
+    std::string keypointName = "SIFT"; // SIFT is known unstable with OpenCV 4.5.4
     keyPoints.setDetector(keypointName);
     keyPoints.setExtractor(keypointName);
 

--- a/modules/vision/test/key-point/testKeyPoint-7.cpp
+++ b/modules/vision/test/key-point/testKeyPoint-7.cpp
@@ -444,7 +444,7 @@ void run_test(const std::string &env_ipath, const std::string &opath,  vpImage<T
 // Test with floating point descriptor
 #if defined(VISP_HAVE_OPENCV_NONFREE) ||                                                                               \
   ((VISP_HAVE_OPENCV_VERSION >= 0x030000) && defined(VISP_HAVE_OPENCV_XFEATURES2D) || \
-   (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || ((VISP_HAVE_OPENCV_VERSION >= 0x040400) && (VISP_HAVE_OPENCV_VERSION != 0x040504)
+   (VISP_HAVE_OPENCV_VERSION >= 0x030411 && CV_MAJOR_VERSION < 4) || ((VISP_HAVE_OPENCV_VERSION >= 0x040400) && (VISP_HAVE_OPENCV_VERSION != 0x040504)))
   {
     std::string keypointName = "SIFT"; // SIFT is known unstable with OpenCV 4.5.4
     keyPoints.setDetector(keypointName);


### PR DESCRIPTION
In `testKeyPoint-5.cpp` and `testKeyPoint-7.cpp` SIFT usage is disabled when using OpenCV 4.5.4

This PR is here to fix #970

[x] Fix tested with OpenCV 4.5.5 where SIFT usage is enabled
[x] Fix tested with OpenCV 4.5.4 where SIFT usage is **disabled**
[x] Fix tested with OpenCV 4.5.3 where SIFT usage is enabled

The fix consists right now to turn SIFT usage off in `testKeyPoint-5.cpp` and `testKeyPoint-7.cpp`
when OpenCV 4.5.4 AND macOS since is seems to work on Ubuntu and Windows