### PR TITLE
Add vpFont::getMeasure() to be able to get the text bounding box

### DIFF
--- a/modules/core/include/visp3/core/vpFont.h
+++ b/modules/core/include/visp3/core/vpFont.h
@@ -65,6 +65,7 @@ public:
   bool drawText(vpImage<vpRGBa> & I, const std::string & text, const vpImagePoint & position, const vpColor & color, const vpColor & background) const;
 
   unsigned int getHeight() const;
+  vpImagePoint getMeasure(const std::string & text) const;
   bool setHeight(unsigned int height);
 
 private:

--- a/modules/core/src/image/vpFont.cpp
+++ b/modules/core/src/image/vpFont.cpp
@@ -154,6 +154,15 @@ public:
   }
 
   /*!
+    (For ViSP type compatibility) Measures a size of region is need to draw given text.
+  */
+  vpImagePoint Measure2(const String & text) const
+  {
+    Point mes = Measure(text);
+    return vpImagePoint(mes.y, mes.x);
+  }
+
+  /*!
     Draws a text at the image.
 
     \param [out] canvas - a canvas (image where we draw text).
@@ -2023,6 +2032,16 @@ bool vpFont::drawText(vpImage<vpRGBa> & I, const std::string & text, const vpIma
 unsigned int vpFont::getHeight() const
 {
   return static_cast<unsigned int>(m_impl->Height());
+}
+
+/*!
+  Gets text bounding box size.
+
+  \return The width (\e j) and height (\e i) of the text bounding box.
+*/
+vpImagePoint vpFont::getMeasure(const std::string & text) const
+{
+  return m_impl->Measure2(text);
 }
 
 /*!

--- a/modules/core/test/image/testImageDraw.cpp
+++ b/modules/core/test/image/testImageDraw.cpp
@@ -59,6 +59,8 @@ int main(int argc ,char *argv[])
   }
   std::cout << "Save: " << save << std::endl;
 
+  const std::string visp = "ViSP: Open source Visual Servoing Platform";
+
   //vpRGBa
   {
     vpImage<vpRGBa> I(480, 640, vpRGBa(255));
@@ -78,6 +80,12 @@ int main(int argc ,char *argv[])
     iP1.set_i(200);
     iP1.set_j(200);
     font.drawText(I, "Test...", iP1, vpColor::white, vpColor::black);
+
+    vpFont font2(20);
+    vpImagePoint textSize = font2.getMeasure(visp);
+    vpImagePoint textPos = vpImagePoint(24, 620 - textSize.get_j());
+    font2.drawText(I, visp, textPos, vpColor::darkGreen);
+    vpImageDraw::drawRectangle(I, vpRect(textPos.get_u(), textPos.get_v(), textSize.get_u(), textSize.get_v()), vpColor::darkRed);
 
     iP1.set_i(80);
     iP1.set_j(220);
@@ -197,6 +205,12 @@ int main(int argc ,char *argv[])
     iP1.set_i(200);
     iP1.set_j(200);
     font.drawText(I, "Test...", iP1, 0, 255);
+
+    vpFont font2(20);
+    vpImagePoint textSize = font2.getMeasure(visp);
+    vpImagePoint textPos = vpImagePoint(24, 620 - textSize.get_j());
+    font2.drawText(I, visp, textPos, 255);
+    vpImageDraw::drawRectangle(I, vpRect(textPos.get_u(), textPos.get_v(), textSize.get_u(), textSize.get_v()), 255);
 
     iP1.set_i(80);
     iP1.set_j(220);


### PR DESCRIPTION
`vpImagePoint` type is used but can be changed for a better alternative.

Example:

![canvas_color](https://user-images.githubusercontent.com/8035162/148701519-d9d8c186-e4da-4013-a79b-02e57d1b5003.png)

![canvas_gray](https://user-images.githubusercontent.com/8035162/148701520-22f92d56-01df-4caf-a682-01a9a0475681.png)

