### PR TITLE
Update vpFont TrueType support for old compiler

### DIFF
--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -282,6 +282,7 @@ vp_set_source_file_compile_flag(src/tools/network/vpServer.cpp -Wno-strict-overf
 vp_set_source_file_compile_flag(src/tools/optimization/vpQuadProg.cpp -Wno-strict-overflow)
 vp_set_source_file_compile_flag(src/tools/optimization/vpLinProg.cpp -Wno-strict-overflow)
 vp_set_source_file_compile_flag(src/tools/histogram/vpHistogram.cpp -Wno-strict-overflow)
+vp_set_source_file_compile_flag(src/image/vpFont.cpp -Wno-float-equal)
 vp_set_source_file_compile_flag(test/image/testImageBinarise.cpp -Wno-strict-overflow)
 vp_set_source_file_compile_flag(test/image/testImageOwnership.cpp -Wno-pessimizing-move)
 vp_set_source_file_compile_flag(test/network/testClient.cpp -Wno-strict-overflow)

--- a/modules/core/src/image/vpFont.cpp
+++ b/modules/core/src/image/vpFont.cpp
@@ -60,9 +60,9 @@
 #include <visp3/core/vpFont.h>
 #include <visp3/core/vpIoException.h>
 #include <visp3/core/vpIoTools.h>
+#include <visp3/core/vpMath.h>
 #include "private/Font.hpp"
-#include <cstdint>
-#include <iterator>
+
 #define STB_TRUETYPE_IMPLEMENTATION
 #include "private/stb_truetype.h"
 
@@ -109,7 +109,6 @@ public:
         throw(vpException(vpException::fatalError, "True type font file doesn't exist in %s", ttfFilename.c_str()));
       }
 
-      std::cout << "Load font from file: " << ttf_file << std::endl;
       LoadTTF(ttf_file);
 
       /* calculate font scaling */
@@ -118,8 +117,8 @@ public:
       int lineGap = 0;
       stbtt_GetFontVMetrics(&_info, &_fontAscent, &_fontDescent, &lineGap);
 
-      _fontAscent = std::roundf(_fontAscent * _fontScale);
-      _fontDescent = std::roundf(_fontDescent * _fontScale);
+      _fontAscent = vpMath::round(_fontAscent * _fontScale);
+      _fontDescent = vpMath::round(_fontDescent * _fontScale);
 
       break;
     }
@@ -237,7 +236,7 @@ public:
         int y = _fontAscent + c_y1;
         _y_vec.push_back(y);
 
-        int d_x = x + std::roundf(lsb * _fontScale);
+        int d_x = x + vpMath::round(lsb * _fontScale);
         int d_y = y;
         int d_w = (c_x2 - c_x1);
         int d_h = (c_y2 - c_y1);
@@ -248,13 +247,13 @@ public:
         _bb.setBottom(_bb.getBottom() < d_y+d_h ? d_y+d_h : _bb.getBottom());
 
         /* advance x */
-        x += std::roundf(ax * _fontScale);
+        x += vpMath::round(ax * _fontScale);
 
         /* add kerning */
         int kern = 0;
         if (i < _wordUTF32.size()-1) {
           kern = stbtt_GetCodepointKernAdvance(&_info, _wordUTF32[i], _wordUTF32[i + 1]);
-          x += std::roundf(kern * _fontScale);
+          x += vpMath::round(kern * _fontScale);
         }
       }
 
@@ -322,11 +321,11 @@ public:
 
       for (size_t i = 0, x = 0; i < _wordUTF32.size(); i++) {
         /* render character (stride and offset is important here) */
-        int byteOffset = x + std::roundf(_lsb_vec[i] * _fontScale) + (_y_vec[i] * _fontBuffer.getWidth());
+        int byteOffset = x + vpMath::round(_lsb_vec[i] * _fontScale) + (_y_vec[i] * _fontBuffer.getWidth());
         stbtt_MakeCodepointBitmap(&_info, _fontBuffer.bitmap + byteOffset, _bb_vec[i].getWidth(), _bb_vec[i].getHeight(),
                                   _fontBuffer.getWidth(), _fontScale, _fontScale, _wordUTF32[i]);
 
-        int d_x = x + std::roundf(_lsb_vec[i] * _fontScale);
+        int d_x = x + vpMath::round(_lsb_vec[i] * _fontScale);
         int d_y = _y_vec[i];
         int d_w = _bb_vec[i].getWidth();
         int d_h = _bb_vec[i].getHeight();
@@ -344,12 +343,12 @@ public:
         }
 
         /* advance x */
-        x += std::roundf(_ax_vec[i] * _fontScale);
+        x += vpMath::round(_ax_vec[i] * _fontScale);
 
         /* add kerning */
         if (i < _wordUTF32.size()-1) {
           int kern = stbtt_GetCodepointKernAdvance(&_info, _wordUTF32[i], _wordUTF32[i + 1]);
-          x += std::roundf(kern * _fontScale);
+          x += vpMath::round(kern * _fontScale);
         }
       }
 
@@ -428,11 +427,11 @@ public:
 
       for (size_t i = 0, x = 0; i < _wordUTF32.size(); i++) {
         /* render character (stride and offset is important here) */
-        int byteOffset = x + std::roundf(_lsb_vec[i] * _fontScale) + (_y_vec[i] * _fontBuffer.getWidth());
+        int byteOffset = x + vpMath::round(_lsb_vec[i] * _fontScale) + (_y_vec[i] * _fontBuffer.getWidth());
         stbtt_MakeCodepointBitmap(&_info, _fontBuffer.bitmap + byteOffset, _bb_vec[i].getWidth(), _bb_vec[i].getHeight(),
                                   _fontBuffer.getWidth(), _fontScale, _fontScale, _wordUTF32[i]);
 
-        int d_x = x + std::roundf(_lsb_vec[i] * _fontScale);
+        int d_x = x + vpMath::round(_lsb_vec[i] * _fontScale);
         int d_y = _y_vec[i];
         int d_w = _bb_vec[i].getWidth();
         int d_h = _bb_vec[i].getHeight();
@@ -453,12 +452,12 @@ public:
         }
 
         /* advance x */
-        x += std::roundf(_ax_vec[i] * _fontScale);
+        x += vpMath::round(_ax_vec[i] * _fontScale);
 
         /* add kerning */
         if (i < _wordUTF32.size()-1) {
           int kern = stbtt_GetCodepointKernAdvance(&_info, _wordUTF32[i], _wordUTF32[i + 1]);
-          x += std::roundf(kern * _fontScale);
+          x += vpMath::round(kern * _fontScale);
         }
       }
 

--- a/modules/core/src/image/vpFont.cpp
+++ b/modules/core/src/image/vpFont.cpp
@@ -117,7 +117,7 @@ public:
       LoadTTF(ttf_file);
 
       /* calculate font scaling */
-      _fontScale = stbtt_ScaleForPixelHeight(&_info, _fontHeight);
+      _fontScale = stbtt_ScaleForPixelHeight(&_info, static_cast<float>(_fontHeight));
 
       int lineGap = 0;
       stbtt_GetFontVMetrics(&_info, &_fontAscent, &_fontDescent, &lineGap);

--- a/modules/core/src/image/vpFont.cpp
+++ b/modules/core/src/image/vpFont.cpp
@@ -57,11 +57,15 @@
 * SOFTWARE.
 */
 
-#include <stdio.h>
 #include <visp3/core/vpFont.h>
 #include <visp3/core/vpIoException.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpMath.h>
+#if (VISP_CXX_STANDARD > VISP_CXX_STANDARD_98)
+#include <iterator>
+#else
+#include <stdio.h>
+#endif
 #include "private/Font.hpp"
 
 #define STB_TRUETYPE_IMPLEMENTATION
@@ -2172,19 +2176,21 @@ private:
 
   void LoadTTF(const std::string & filename)
   {
-#if 0 // disable for compatibility with old platform (Ubuntu 12.04)
+#if (VISP_CXX_STANDARD > VISP_CXX_STANDARD_98)
     std::ifstream fontFile(filename.c_str(), std::ios::binary |std::ios::ate);
     fontFile >> std::noskipws;
 
     std::streampos fileSize = fontFile.tellg();
     fontFile.seekg(0, std::ios::beg);
 
+    fontBuffer.clear();
     fontBuffer.reserve(fileSize);
 
     std::copy(std::istream_iterator<unsigned char>(fontFile),
               std::istream_iterator<unsigned char>(),
               std::back_inserter(fontBuffer));
 #else
+    // for compatibility with old platform (e.g. Ubuntu 12.04)
     FILE* fontFile = fopen(filename.c_str(), "rb");
     if (!fontFile) {
       fclose(fontFile);
@@ -2192,10 +2198,10 @@ private:
     }
 
     fseek(fontFile, 0, SEEK_END);
-    size_t size = ftell(fontFile);  /* how long is the file ? */
-    fseek(fontFile, 0, SEEK_SET);   /* reset */
+    size_t fileSize = ftell(fontFile);  /* how long is the file? */
+    fseek(fontFile, 0, SEEK_SET);       /* reset */
 
-    std::vector<unsigned char> fontBuffer(size);
+    fontBuffer.resize(fileSize);
     if (fread(&fontBuffer[0], sizeof(unsigned char), fontBuffer.size(), fontFile) != fontBuffer.size()) {
       fclose(fontFile);
       throw vpIoException(vpIoException::ioError, "Error when reading the font file.");


### PR DESCRIPTION
Hopefully replace #994

@fspindle 
If you have the time, can you try this PR for compatibility with old platforms on CDash?