### PR TITLE
Rename Github actions for iOS CI tests

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,4 @@
-name: MacOS
+name: iOS
 
 # https://www.jeffgeerling.com/blog/2020/running-github-actions-workflow-on-schedule-and-other-events
 on:


### PR DESCRIPTION
To not have duplicated `MacOS` entries:

![image](https://user-images.githubusercontent.com/8035162/150222136-77cd4b7b-533e-414a-94d6-0e99cfabcabf.png)
