### PR TITLE
Add vpRotationMatrix::orthogonalize() to have a proper rotation matrix

### DIFF
--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -229,6 +229,8 @@ public:
   vpHomogeneousMatrix& operator<<(double val);
   vpHomogeneousMatrix& operator,(double val);
 
+  void orthogonalizeRotation();
+
   void print() const;
 
   /*!

--- a/modules/core/include/visp3/core/vpRotationMatrix.h
+++ b/modules/core/include/visp3/core/vpRotationMatrix.h
@@ -183,6 +183,7 @@ public:
   vpRotationMatrix& operator<<(double val);
   vpRotationMatrix& operator,(double val);
 
+  void orthogonalize();
 
   void printVector();
 

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -935,6 +935,19 @@ void vpHomogeneousMatrix::load(std::ifstream &f)
   }
 }
 
+/*!
+  Perform orthogonalization of the rotation part of the homogeneous transformation.
+ */
+void vpHomogeneousMatrix::orthogonalizeRotation()
+{
+  vpRotationMatrix R(*this);
+  R.orthogonalize();
+
+  data[0] = R[0][0]; data[1] = R[0][1]; data[2] = R[0][2];
+  data[4] = R[1][0]; data[5] = R[1][1]; data[6] = R[1][2];
+  data[8] = R[2][0]; data[9] = R[2][1]; data[10] = R[2][2];
+}
+
 //! Print the matrix as a pose vector \f$({\bf t}^T \theta {\bf u}^T)\f$
 void vpHomogeneousMatrix::print() const
 {

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -717,6 +717,8 @@ vpHomogeneousMatrix& vpHomogeneousMatrix::operator,(double val)
 /*!
   Test if the 3x3 rotational part of the homogeneous matrix is a valid
   rotation matrix and the last row is equal to [0, 0, 0, 1].
+
+  \return true if the matrix is a homogeneous matrix, false otherwise.
 */
 bool vpHomogeneousMatrix::isAnHomogeneousMatrix(double threshold) const
 {

--- a/modules/core/src/math/transformation/vpRotationMatrix.cpp
+++ b/modules/core/src/math/transformation/vpRotationMatrix.cpp
@@ -398,6 +398,9 @@ vpRotationMatrix &vpRotationMatrix::operator*=(double x)
 
 /*!
   Test if the rotation matrix is really a rotation matrix.
+
+  \return true if the matrix is a rotation matrix, false otherwise.
+
 */
 bool vpRotationMatrix::isARotationMatrix(double threshold) const
 {

--- a/modules/core/test/math/testHomogeneousMatrix.cpp
+++ b/modules/core/test/math/testHomogeneousMatrix.cpp
@@ -53,6 +53,27 @@ TEST_CASE("vpHomogeneousMatrix re-orthogonalize rotation matrix", "[vpHomogeneou
     };
   }());
 
+  SECTION("check re-orthogonalize rotation part")
+  {
+    vpHomogeneousMatrix M1 {
+      0.9835, -0.0581,  0.1716, 0.0072,
+      -0.0489, -0.9972, -0.0571, 0.0352,
+      0.1744,  0.0478, -0.9835, 0.9470
+    };
+
+    vpHomogeneousMatrix M2;
+    M2[0][0] = 0.9835;   M2[0][1] = -0.0581;  M2[0][2] = 0.1716;   M2[0][3] = 0.0072;
+    M2[1][0] = -0.0489;  M2[1][1] = -0.9972;  M2[1][2] = -0.0571;  M2[1][3] = 0.0352;
+    M2[2][0] = 0.1744;   M2[2][1] = 0.0478;   M2[2][2] = -0.9835;  M2[2][3] = 0.9470;
+    M2.orthogonalizeRotation();
+
+    for (unsigned int i = 0; i < 4; i++) {
+      for (unsigned int j = 0; j < 4; j++) {
+        CHECK(M1[i][j] == Approx(M2[i][j]).margin(std::numeric_limits<double>::epsilon()));
+      }
+    }
+  }
+
   CHECK_NOTHROW([](){
     vpHomogeneousMatrix M {
       0.9835, -0.0581,  0.1716, 0.0072,

--- a/modules/core/test/math/testHomogeneousMatrix.cpp
+++ b/modules/core/test/math/testHomogeneousMatrix.cpp
@@ -75,9 +75,7 @@ TEST_CASE("vpHomogeneousMatrix re-orthogonalize rotation matrix", "[vpHomogeneou
       0.1551, -0.2199, -0.9631, 0.9583
     };
 
-    // if M1 contains a proper rotation matrix
-    // following R init should not throw exception since re-orthogonalization
-    // is done only in vpHomogeneousMatrix, not in vpRotationMatrix
+    // following R init should not throw an exception
     vpRotationMatrix R {
       M1[0][0], M1[0][1], M1[0][2],
       M1[1][0], M1[1][1], M1[1][2],
@@ -90,6 +88,67 @@ TEST_CASE("vpHomogeneousMatrix re-orthogonalize rotation matrix", "[vpHomogeneou
       0.983, -0.058,  0.171, 0.0072,
       -0.093, -0.973,  0.207, 0.0481,
       0.155, -0.219, -0.963, 0.9583
+    };
+  }());
+}
+
+TEST_CASE("vpRotationMatrix re-orthogonalize rotation matrix", "[vpRotationMatrix]") {
+  CHECK_NOTHROW([](){
+    vpRotationMatrix R {
+      0.9835, -0.0581,  0.1716,
+      -0.0489, -0.9972, -0.0571,
+      0.1744,  0.0478, -0.9835
+    };
+  }());
+
+  CHECK_NOTHROW([](){
+    vpRotationMatrix R {
+      0.9835, -0.0581,  0.1716,
+      -0.0937, -0.9738,  0.2072,
+      0.1551, -0.2199, -0.9631
+    };
+
+    std::cout << "Original data:" << std::endl;
+    std::cout << "0.9835 -0.0581  0.1716" << std::endl;
+    std::cout << " -0.0937 -0.9738  0.2072" << std::endl;
+    std::cout << "0.1551 -0.2199 -0.9631" << std::endl;
+    std::cout << "R after rotation re-orthogonalization:\n" << R << std::endl;
+  }());
+
+  CHECK_NOTHROW([](){
+    vpRotationMatrix R {
+      0.46682, -0.74434,  0.47754,
+      -0.83228, -0.55233, -0.04733,
+      0.29899, -0.37535, -0.87734,
+    };
+
+    std::cout << "Original data:" << std::endl;
+    std::cout << "0.46682, -0.74434,  0.47754" << std::endl;
+    std::cout << "-0.83228, -0.55233, -0.04733" << std::endl;
+    std::cout << "0.29899, -0.37535, -0.87734" << std::endl;
+    std::cout << "R after rotation re-orthogonalization:\n" << R << std::endl;
+  }());
+
+  CHECK_NOTHROW([](){
+    vpRotationMatrix R;
+    R = {
+      0.46682, -0.74434,  0.47754,
+      -0.83228, -0.55233, -0.04733,
+      0.29899, -0.37535, -0.87734,
+    };
+
+    std::cout << "Original data:" << std::endl;
+    std::cout << "0.46682, -0.74434,  0.47754" << std::endl;
+    std::cout << "-0.83228, -0.55233, -0.04733" << std::endl;
+    std::cout << "0.29899, -0.37535, -0.87734" << std::endl;
+    std::cout << "R after rotation re-orthogonalization:\n" << R << std::endl;
+  }());
+
+  CHECK_THROWS([](){
+    vpRotationMatrix R {
+      0.983, -0.058,  0.171,
+      -0.093, -0.973,  0.207,
+      0.155, -0.219, -0.963
     };
   }());
 }


### PR DESCRIPTION
related https://github.com/lagadic/visp/pull/903

---

Without rotation matrix orthogonalization, initializing a `vpRotationMatrix` with custom values must pass [`isARotationMatrix()`](https://visp-doc.inria.fr/doxygen/visp-daily/classvpRotationMatrix.html#a3d3a25cdcfe64aa469bbc2d14502597b) test.

Since often I copy-paste rotation values from other programs, the default print precision can be lower than the required precision in `isARotationMatrix()`.