### PR TITLE
Fix wrong function call for BgraToRgb() and for AVX2 code path

### DIFF
--- a/3rdparty/simdlib/Simd/SimdAvx2BgraToBgr.cpp
+++ b/3rdparty/simdlib/Simd/SimdAvx2BgraToBgr.cpp
@@ -87,10 +87,10 @@ namespace Simd
             for (size_t row = 0; row < height; ++row)
             {
                 for (size_t col = 0; col < widthF; col += F)
-                    Store<false>((__m256i*)(rgb + 3 * col), BgraToBgr<align>(bgra + 4 * col));
-                Store24<false>(rgb + 3 * widthF, BgraToBgr<align>(bgra + 4 * widthF));
+                    Store<false>((__m256i*)(rgb + 3 * col), BgraToRgb<align>(bgra + 4 * col));
+                Store24<false>(rgb + 3 * widthF, BgraToRgb<align>(bgra + 4 * widthF));
                 if (widthF + F != width)
-                    Store24<false>(rgb + 3 * (width - F), BgraToBgr<false>(bgra + 4 * (width - F)));
+                    Store24<false>(rgb + 3 * (width - F), BgraToRgb<false>(bgra + 4 * (width - F)));
                 bgra += bgraStride;
                 rgb += rgbStride;
             }


### PR DESCRIPTION
See https://github.com/ermig1979/Simd/commit/a4e52f517f537160c1a73f131b28279df7af56dc