### PR TITLE
Update calibrate-camera app with calibration board occupancy in color

### DIFF
--- a/example/calibration/calibrate-camera.cpp
+++ b/example/calibration/calibrate-camera.cpp
@@ -327,14 +327,39 @@ int main(int argc, const char *argv[])
 
     // Display calibration pattern occupancy
     drawCalibrationOccupancy(I, calib_info, s.boardSize.width);
-    vpDisplay::setTitle(I, "Calibration pattern occupancy");
-    vpDisplay::display(I);
-    vpDisplay::displayText(I, 15 * vpDisplay::getDownScalingFactor(I), 15 * vpDisplay::getDownScalingFactor(I),
+
+    cv::Mat1b img(I.getHeight(), I.getWidth());
+    vpImageConvert::convert(I, img);
+    cv::Mat3b imgColor(I.getHeight(), I.getWidth());
+    cv::applyColorMap(img, imgColor, cv::COLORMAP_JET);
+
+    // Draw calibration board corners
+    for (size_t idx1 = 0; idx1 < calib_info.size(); idx1++) {
+        const CalibInfo& calib = calib_info[idx1];
+
+        for (size_t idx2 = 0; idx2 < calib.m_imPts.size(); idx2++) {
+            const vpImagePoint& imPt = calib.m_imPts[idx2];
+            cv::rectangle(imgColor, cv::Rect(static_cast<int>(imPt.get_u() - 2), static_cast<int>(imPt.get_v() - 2),
+                          4 * vpDisplay::getDownScalingFactor(I), 4 * vpDisplay::getDownScalingFactor(I)),
+                          cv::Scalar(0, 0, 0), -1);
+        }
+    }
+
+    vpImage<vpRGBa> I_color;
+    vpImageConvert::convert(imgColor, I_color);
+    d.close(I);
+    d.init(I_color, 0, 0, "Calibration pattern occupancy");
+
+    vpDisplay::display(I_color);
+    vpDisplay::displayText(I_color, 15 * vpDisplay::getDownScalingFactor(I_color), 15 * vpDisplay::getDownScalingFactor(I_color),
                            "Calibration pattern occupancy in the image", vpColor::red);
-    vpDisplay::displayText(I, I.getHeight() - 15 * vpDisplay::getDownScalingFactor(I),
-                           15 * vpDisplay::getDownScalingFactor(I), "Click to continue...", vpColor::red);
-    vpDisplay::flush(I);
-    vpDisplay::getClick(I);
+    vpDisplay::displayText(I_color, I_color.getHeight() - 20 * vpDisplay::getDownScalingFactor(I_color),
+                           15 * vpDisplay::getDownScalingFactor(I_color), "Click to continue...", vpColor::red);
+    vpDisplay::flush(I_color);
+    vpDisplay::getClick(I_color);
+
+    d.close(I_color);
+    d.init(I);
 
     std::stringstream ss_additional_info;
     ss_additional_info << "<date>" << vpTime::getDateTime() << "</date>";
@@ -397,7 +422,7 @@ int main(int argc, const char *argv[])
           vpDisplay::displayCross(I, imPt, 12 * vpDisplay::getDownScalingFactor(I), vpColor::green);
         }
 
-        vpDisplay::displayText(I, I.getHeight() - 15 * vpDisplay::getDownScalingFactor(I),
+        vpDisplay::displayText(I, I.getHeight() - 20 * vpDisplay::getDownScalingFactor(I),
                                15 * vpDisplay::getDownScalingFactor(I), "Click to continue...", vpColor::red);
         vpDisplay::flush(I);
         vpDisplay::getClick(I);
@@ -461,7 +486,7 @@ int main(int argc, const char *argv[])
           vpDisplay::displayCross(I, imPt, 12 * vpDisplay::getDownScalingFactor(I), vpColor::green);
         }
 
-        vpDisplay::displayText(I, I.getHeight() - 15 * vpDisplay::getDownScalingFactor(I),
+        vpDisplay::displayText(I, I.getHeight() - 20 * vpDisplay::getDownScalingFactor(I),
                                15 * vpDisplay::getDownScalingFactor(I), "Click to continue...", vpColor::red);
         vpDisplay::flush(I);
         vpDisplay::getClick(I);
@@ -470,106 +495,91 @@ int main(int argc, const char *argv[])
       std::cout << "\nGlobal reprojection error: " << error << std::endl;
       ss_additional_info << "<with_distortion>" << error << "</with_distortion></global_reprojection_error>";
 
-      vpImage<unsigned char> I_undist = I;
-#ifdef VISP_HAVE_X11
-      vpDisplayX d_undist(I_undist, I.getWidth() / vpDisplay::getDownScalingFactor(I) + 100, 0, "Undistorted image",
-                          vpDisplay::SCALE_AUTO);
-#elif defined VISP_HAVE_GDI
-      vpDisplayGDI d_undist(I_undist, I.getWidth() / vpDisplay::getDownScalingFactor(I) + 100, 0, "Undistorted image",
-                            vpDisplay::SCALE_AUTO);
-#elif defined VISP_HAVE_GTK
-      vpDisplayGTK d_undist(I_undist, I.getWidth() / vpDisplay::getDownScalingFactor(I) + 100, 0, "Undistorted image",
-                            vpDisplay::SCALE_AUTO);
-#elif defined VISP_HAVE_OPENCV
-      vpDisplayOpenCV d_undist(I_undist, I.getWidth() / vpDisplay::getDownScalingFactor(I) + 100, 0,
-                               "Undistorted image", vpDisplay::SCALE_AUTO);
-#endif
+      vpImage<unsigned char> I_undist;
+      vpImage<unsigned char> I_dist_undist(I.getHeight(), 2 * I.getWidth());
+      d.close(I);
+      d.init(I_dist_undist, 0, 0, "Straight lines have to be straight - distorted image / undistorted image");
 
-      vpDisplay::setTitle(I, "Straight lines have to be straight (distorted image)");
-      vpDisplay::setTitle(I_undist, "Straight lines have to be straight (undistorted image)");
       for (size_t idx = 0; idx < calib_info.size(); idx++) {
-        std::cout << "\nThis tool computes the line fitting error (mean distance error) on image points extracted from "
-                     "the raw distorted image."
-                  << std::endl;
+          std::cout << "\nThis tool computes the line fitting error (mean distance error) on image points extracted from "
+                        "the raw distorted image."
+                    << std::endl;
 
-        I = calib_info[idx].m_img;
-        vpImageTools::undistort(I, cam, I_undist);
+          I = calib_info[idx].m_img;
+          vpImageTools::undistort(I, cam, I_undist);
 
-        vpDisplay::display(I);
-        vpDisplay::display(I_undist);
+          I_dist_undist.insert(I, vpImagePoint(0, 0));
+          I_dist_undist.insert(I_undist, vpImagePoint(0, I.getWidth()));
+          vpDisplay::display(I_dist_undist);
 
-        vpDisplay::displayText(I, 15 * vpDisplay::getDownScalingFactor(I), 15 * vpDisplay::getDownScalingFactor(I),
-                               calib_info[idx].m_frame_name, vpColor::red);
-        vpDisplay::displayText(I, 30 * vpDisplay::getDownScalingFactor(I), 15 * vpDisplay::getDownScalingFactor(I),
-                               "Draw lines from first / last points.", vpColor::red);
-        std::vector<vpImagePoint> grid_points = calib_info[idx].m_imPts;
-        for (int i = 0; i < s.boardSize.height; i++) {
-          std::vector<vpImagePoint> current_line(grid_points.begin() + i * s.boardSize.width,
-                                                 grid_points.begin() + (i + 1) * s.boardSize.width);
-
-          std::vector<vpImagePoint> current_line_undist = undistort(cam, current_line);
-          double a = 0, b = 0, c = 0;
-          double line_fitting_error = vpMath::lineFitting(current_line, a, b, c);
-          double line_fitting_error_undist = vpMath::lineFitting(current_line_undist, a, b, c);
-          std::cout << calib_info[idx].m_frame_name << " line " << i + 1
-                    << " fitting error on distorted points: " << line_fitting_error
-                    << " ; on undistorted points: " << line_fitting_error_undist << std::endl;
-
-          vpImagePoint ip1 = current_line.front();
-          vpImagePoint ip2 = current_line.back();
-          vpDisplay::displayLine(I, ip1, ip2, vpColor::red);
-        }
-
-        std::cout << "\nThis tool computes the line fitting error (mean distance error) on image points extracted from "
-                     "the undistorted image"
-                  << " (vpImageTools::undistort())." << std::endl;
-        cv::Mat cvI;
-        std::vector<cv::Point2f> pointBuf;
-        vpImageConvert::convert(I_undist, cvI);
-
-        bool found = extractCalibrationPoints(s, cvI, pointBuf);
-        if (found) {
-          std::vector<vpImagePoint> grid_points;
-          for (unsigned int i = 0; i < pointBuf.size(); i++) {
-            vpImagePoint ip(pointBuf[i].y, pointBuf[i].x);
-            grid_points.push_back(ip);
-          }
-
-          vpDisplay::displayText(I_undist, 15 * vpDisplay::getDownScalingFactor(I_undist),
-                                 15 * vpDisplay::getDownScalingFactor(I_undist),
-                                 calib_info[idx].m_frame_name + std::string(" undistorted"), vpColor::red);
-          vpDisplay::displayText(I_undist, 30 * vpDisplay::getDownScalingFactor(I_undist),
-                                 15 * vpDisplay::getDownScalingFactor(I_undist), "Draw lines from first / last points.",
-                                 vpColor::red);
+          vpDisplay::displayText(I_dist_undist, 15 * vpDisplay::getDownScalingFactor(I_dist_undist), 15 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                 calib_info[idx].m_frame_name + std::string(" distorted"), vpColor::red);
+          vpDisplay::displayText(I_dist_undist, 30 * vpDisplay::getDownScalingFactor(I_dist_undist), 15 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                 "Draw lines from first / last points.", vpColor::red);
+          std::vector<vpImagePoint> grid_points = calib_info[idx].m_imPts;
           for (int i = 0; i < s.boardSize.height; i++) {
-            std::vector<vpImagePoint> current_line(grid_points.begin() + i * s.boardSize.width,
-                                                   grid_points.begin() + (i + 1) * s.boardSize.width);
+              std::vector<vpImagePoint> current_line(grid_points.begin() + i * s.boardSize.width,
+                                                     grid_points.begin() + (i + 1) * s.boardSize.width);
 
-            double a = 0, b = 0, c = 0;
-            double line_fitting_error = vpMath::lineFitting(current_line, a, b, c);
-            std::cout << calib_info[idx].m_frame_name << " undistorted image, line " << i + 1
-                      << " fitting error: " << line_fitting_error << std::endl;
+              std::vector<vpImagePoint> current_line_undist = undistort(cam, current_line);
+              double a = 0, b = 0, c = 0;
+              double line_fitting_error = vpMath::lineFitting(current_line, a, b, c);
+              double line_fitting_error_undist = vpMath::lineFitting(current_line_undist, a, b, c);
+              std::cout << calib_info[idx].m_frame_name << " line " << i + 1
+                        << " fitting error on distorted points: " << line_fitting_error
+                        << " ; on undistorted points: " << line_fitting_error_undist << std::endl;
 
-            vpImagePoint ip1 = current_line.front();
-            vpImagePoint ip2 = current_line.back();
-            vpDisplay::displayLine(I_undist, ip1, ip2, vpColor::red);
+              vpImagePoint ip1 = current_line.front();
+              vpImagePoint ip2 = current_line.back();
+              vpDisplay::displayLine(I_dist_undist, ip1, ip2, vpColor::red);
           }
-        } else {
-          std::string msg("Unable to detect grid on undistorted image");
-          std::cout << msg << std::endl;
-          std::cout << "Check that the grid is not too close to the image edges" << std::endl;
-          vpDisplay::displayText(I_undist, 15 * vpDisplay::getDownScalingFactor(I_undist),
-                                 15 * vpDisplay::getDownScalingFactor(I_undist),
-                                 calib_info[idx].m_frame_name + std::string(" undistorted"), vpColor::red);
-          vpDisplay::displayText(I_undist, 30 * vpDisplay::getDownScalingFactor(I_undist),
-                                 15 * vpDisplay::getDownScalingFactor(I_undist), msg, vpColor::red);
-        }
 
-        vpDisplay::displayText(I, I.getHeight() - 15 * vpDisplay::getDownScalingFactor(I),
-                               15 * vpDisplay::getDownScalingFactor(I), "Click to continue...", vpColor::red);
-        vpDisplay::flush(I);
-        vpDisplay::flush(I_undist);
-        vpDisplay::getClick(I);
+          std::cout << "\nThis tool computes the line fitting error (mean distance error) on image points extracted from "
+                       "the undistorted image"
+                    << " (vpImageTools::undistort())." << std::endl;
+          cv::Mat cvI;
+          std::vector<cv::Point2f> pointBuf;
+          vpImageConvert::convert(I_undist, cvI);
+
+          bool found = extractCalibrationPoints(s, cvI, pointBuf);
+          if (found) {
+              std::vector<vpImagePoint> grid_points;
+              for (unsigned int i = 0; i < pointBuf.size(); i++) {
+                  vpImagePoint ip(pointBuf[i].y, pointBuf[i].x);
+                  grid_points.push_back(ip);
+              }
+
+              vpDisplay::displayText(I_dist_undist, 15 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                     I.getWidth() + 15 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                     calib_info[idx].m_frame_name + std::string(" undistorted"), vpColor::red);
+              for (int i = 0; i < s.boardSize.height; i++) {
+                  std::vector<vpImagePoint> current_line(grid_points.begin() + i * s.boardSize.width,
+                                                         grid_points.begin() + (i + 1) * s.boardSize.width);
+
+                  double a = 0, b = 0, c = 0;
+                  double line_fitting_error = vpMath::lineFitting(current_line, a, b, c);
+                  std::cout << calib_info[idx].m_frame_name << " undistorted image, line " << i + 1
+                            << " fitting error: " << line_fitting_error << std::endl;
+
+                  vpImagePoint ip1 = current_line.front() + vpImagePoint(0, I.getWidth());
+                  vpImagePoint ip2 = current_line.back() + vpImagePoint(0, I.getWidth());
+                  vpDisplay::displayLine(I_dist_undist, ip1, ip2, vpColor::red);
+              }
+          } else {
+              std::string msg("Unable to detect grid on undistorted image");
+              std::cout << msg << std::endl;
+              std::cout << "Check that the grid is not too close to the image edges" << std::endl;
+              vpDisplay::displayText(I_dist_undist, 15 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                     15 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                     calib_info[idx].m_frame_name + std::string(" undistorted"), vpColor::red);
+              vpDisplay::displayText(I_dist_undist, 30 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                     15 * vpDisplay::getDownScalingFactor(I_dist_undist), msg, vpColor::red);
+          }
+
+          vpDisplay::displayText(I_dist_undist, I_dist_undist.getHeight() - 20 * vpDisplay::getDownScalingFactor(I_dist_undist),
+                                 15 * vpDisplay::getDownScalingFactor(I_dist_undist), "Click to continue...", vpColor::red);
+          vpDisplay::flush(I_dist_undist);
+          vpDisplay::getClick(I_dist_undist);
       }
 
       std::cout << std::endl;


### PR DESCRIPTION
Update code to display the calibration board occupancy with a colormap and with squares for the extracted calibration points:

![image](https://user-images.githubusercontent.com/8035162/171068582-aa145baa-08b2-457b-9805-fb76283dd71d.png)

Display side-by-side the fitted lines for the distorted and the undistorted images:

![image](https://user-images.githubusercontent.com/8035162/171068679-5194bb20-ff54-4736-8fe3-9184b403b1bd.png)
