### PR TITLE
Increase Codecov threshold and set it to informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+# https://docs.codecov.com/docs/common-recipe-list
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%  # the leniency in hitting the target
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Probably set it to informational only is sufficient.

See:
- https://docs.codecov.com/docs/common-recipe-list#set-status-checks-to-block-coverage
- https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks