### PR TITLE
Add vpDetectorAprilTag::displayFrames() and vpDetectorAprilTag::displayTags()

### DIFF
--- a/modules/detection/include/visp3/detection/vpDetectorAprilTag.h
+++ b/modules/detection/include/visp3/detection/vpDetectorAprilTag.h
@@ -29,7 +29,7 @@
  * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  *
  * Description:
- * Base class for April Tag detection.
+ * Base class for AprilTag detection.
  *
  *****************************************************************************/
 #ifndef _vpDetectorAprilTag_h_
@@ -241,7 +241,7 @@ public:
     BEST_RESIDUAL_VIRTUAL_VS,       /*!< Non linear virtual visual servoing approach
                                       initialized by the approach that gives the
                                       lowest residual */
-    HOMOGRAPHY_ORTHOGONAL_ITERATION /*!< Pose from homography followed by a refine by Orthogonal Iteration */
+    HOMOGRAPHY_ORTHOGONAL_ITERATION /*!< Pose from homography followed by a refinement by Orthogonal Iteration */
   };
 
   vpDetectorAprilTag(const vpAprilTagFamily &tagFamily = TAG_36h11,
@@ -254,6 +254,16 @@ public:
   bool detect(const vpImage<unsigned char> &I, double tagSize, const vpCameraParameters &cam,
               std::vector<vpHomogeneousMatrix> &cMo_vec, std::vector<vpHomogeneousMatrix> *cMo_vec2 = NULL,
               std::vector<double> *projErrors = NULL, std::vector<double> *projErrors2 = NULL);
+
+  void displayFrames(const vpImage<unsigned char> &I, const std::vector<vpHomogeneousMatrix> &cMo_vec,
+                     const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness = 1) const;
+  void displayFrames(const vpImage<vpRGBa> &I, const std::vector<vpHomogeneousMatrix> &cMo_vec,
+                     const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness = 1) const;
+
+  void displayTags(const vpImage<unsigned char> &I, const std::vector<std::vector<vpImagePoint> > &tagsCorners,
+                   const vpColor &color = vpColor::none, unsigned int thickness = 1) const;
+  void displayTags(const vpImage<vpRGBa> &I, const std::vector<std::vector<vpImagePoint> > &tagsCorners,
+                   const vpColor &color = vpColor::none, unsigned int thickness = 1) const;
 
   bool getPose(size_t tagIndex, double tagSize, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
                vpHomogeneousMatrix *cMo2 = NULL, double *projError = NULL, double *projError2 = NULL);

--- a/modules/detection/src/tag/vpDetectorAprilTag.cpp
+++ b/modules/detection/src/tag/vpDetectorAprilTag.cpp
@@ -29,7 +29,7 @@
  * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  *
  * Description:
- * Base class for April Tag detection.
+ * Base class for AprilTag detection.
  *
  *****************************************************************************/
 #include <visp3/core/vpConfig.h>
@@ -377,6 +377,70 @@ public:
     }
 
     return detected;
+  }
+
+  void displayFrames(const vpImage<unsigned char> &I, const std::vector<vpHomogeneousMatrix> &cMo_vec,
+                     const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness) const
+  {
+    for (size_t i = 0; i < cMo_vec.size(); i++) {
+      const vpHomogeneousMatrix &cMo = cMo_vec[i];
+      vpDisplay::displayFrame(I, cMo, cam, size, color, thickness);
+    }
+  }
+
+  void displayFrames(const vpImage<vpRGBa> &I, const std::vector<vpHomogeneousMatrix> &cMo_vec,
+                     const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness) const
+  {
+    for (size_t i = 0; i < cMo_vec.size(); i++) {
+      const vpHomogeneousMatrix &cMo = cMo_vec[i];
+      vpDisplay::displayFrame(I, cMo, cam, size, color, thickness);
+    }
+  }
+
+  void displayTags(const vpImage<unsigned char> &I, const std::vector<std::vector<vpImagePoint> > &tagsCorners,
+                   const vpColor &color, unsigned int thickness) const
+  {
+    for (size_t i = 0; i < tagsCorners.size(); i++) {
+      const vpColor Ox = (color == vpColor::none) ? vpColor::red : color;
+      const vpColor Oy = (color == vpColor::none) ? vpColor::green : color;
+      const vpColor Ox2 = (color == vpColor::none) ? vpColor::yellow : color;
+      const vpColor Oy2 = (color == vpColor::none) ? vpColor::blue : color;
+
+      const std::vector<vpImagePoint> &corners = tagsCorners[i];
+      assert(corners.size() == 4);
+
+      vpDisplay::displayLine(I, (int)corners[0].get_i(), (int)corners[0].get_j(), (int)corners[1].get_i(), (int)corners[1].get_j(),
+                             Ox, thickness);
+      vpDisplay::displayLine(I, (int)corners[0].get_i(), (int)corners[0].get_j(), (int)corners[3].get_i(), (int)corners[3].get_j(),
+                             Oy, thickness);
+      vpDisplay::displayLine(I, (int)corners[1].get_i(), (int)corners[1].get_j(), (int)corners[2].get_i(), (int)corners[2].get_j(),
+                             Ox2, thickness);
+      vpDisplay::displayLine(I, (int)corners[2].get_i(), (int)corners[2].get_j(), (int)corners[3].get_i(), (int)corners[3].get_j(),
+                             Oy2, thickness);
+    }
+  }
+
+  void displayTags(const vpImage<vpRGBa> &I, const std::vector<std::vector<vpImagePoint> > &tagsCorners,
+                   const vpColor &color, unsigned int thickness) const
+  {
+    for (size_t i = 0; i < tagsCorners.size(); i++) {
+      const vpColor Ox = (color == vpColor::none) ? vpColor::red : color;
+      const vpColor Oy = (color == vpColor::none) ? vpColor::green : color;
+      const vpColor Ox2 = (color == vpColor::none) ? vpColor::yellow : color;
+      const vpColor Oy2 = (color == vpColor::none) ? vpColor::blue : color;
+
+      const std::vector<vpImagePoint> &corners = tagsCorners[i];
+      assert(corners.size() == 4);
+
+      vpDisplay::displayLine(I, (int)corners[0].get_i(), (int)corners[0].get_j(), (int)corners[1].get_i(), (int)corners[1].get_j(),
+                             Ox, thickness);
+      vpDisplay::displayLine(I, (int)corners[0].get_i(), (int)corners[0].get_j(), (int)corners[3].get_i(), (int)corners[3].get_j(),
+                             Oy, thickness);
+      vpDisplay::displayLine(I, (int)corners[1].get_i(), (int)corners[1].get_j(), (int)corners[2].get_i(), (int)corners[2].get_j(),
+                             Ox2, thickness);
+      vpDisplay::displayLine(I, (int)corners[2].get_i(), (int)corners[2].get_j(), (int)corners[3].get_i(), (int)corners[3].get_j(),
+                             Oy2, thickness);
+    }
   }
 
   bool getPose(size_t tagIndex, double tagSize, const vpCameraParameters &cam, vpHomogeneousMatrix &cMo,
@@ -825,6 +889,66 @@ bool vpDetectorAprilTag::detect(const vpImage<unsigned char> &I, double tagSize,
   m_nb_objects = m_message.size();
 
   return detected;
+}
+
+/*!
+  Display the tag frames on a grayscale image.
+
+  \param[in] I : The image.
+  \param[in] cMo_vec : The vector of computed tag poses.
+  \param[in] cam : Camera intrinsic parameters.
+  \param[out] size : Size of the frame.
+  \param[out] color : The desired color, if none the X-axis is red, the Y-axis green and the Z-axis blue.
+  \param[out] thickness : The thickness of the lines.
+ */
+void vpDetectorAprilTag::displayFrames(const vpImage<unsigned char> &I, const std::vector<vpHomogeneousMatrix> &cMo_vec,
+                                       const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness) const
+{
+  m_impl->displayFrames(I, cMo_vec, cam, size, color, thickness);
+}
+
+/*!
+  Display the tag frames on a vpRGBa image.
+
+  \param[in] I : The image.
+  \param[in] cMo_vec : The vector of computed tag poses.
+  \param[in] cam : Camera intrinsic parameters.
+  \param[out] size : Size of the frame.
+  \param[out] color : The desired color, if none the X-axis is red, the Y-axis green and the Z-axis blue.
+  \param[out] thickness : The thickness of the lines.
+ */
+void vpDetectorAprilTag::displayFrames(const vpImage<vpRGBa> &I, const std::vector<vpHomogeneousMatrix> &cMo_vec,
+                                       const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness) const
+{
+  m_impl->displayFrames(I, cMo_vec, cam, size, color, thickness);
+}
+
+/*!
+  Display the tag contours on a grayscale image.
+
+  \param[in] I : The image.
+  \param[in] tagsCorners : The vector of tag contours.
+  \param[out] color : The desired color, if none RGBY colors are used.
+  \param[out] thickness : The thickness of the lines.
+ */
+void vpDetectorAprilTag::displayTags(const vpImage<unsigned char> &I, const std::vector<std::vector<vpImagePoint> > &tagsCorners,
+                                     const vpColor &color, unsigned int thickness) const
+{
+  m_impl->displayTags(I, tagsCorners, color, thickness);
+}
+
+/*!
+  Display the tag contours on a vpRGBa image.
+
+  \param[in] I : The image.
+  \param[in] tagsCorners : The vector of tag contours.
+  \param[out] color : The desired color, if none RGBY colors are used.
+  \param[out] thickness : The thickness of the lines.
+ */
+void vpDetectorAprilTag::displayTags(const vpImage<vpRGBa> &I, const std::vector<std::vector<vpImagePoint> > &tagsCorners,
+                                     const vpColor &color, unsigned int thickness) const
+{
+  m_impl->displayTags(I, tagsCorners, color, thickness);
 }
 
 /*!

--- a/tutorial/detection/tag/tutorial-apriltag-detector.cpp
+++ b/tutorial/detection/tag/tutorial-apriltag-detector.cpp
@@ -84,15 +84,17 @@ int main(int argc, const char **argv)
   std::cout << "Z aligned: " << z_aligned << std::endl;
 
   try {
+    vpImage<vpRGBa> I_color;
+    vpImageIo::read(I_color, input_filename);
     vpImage<unsigned char> I;
-    vpImageIo::read(I, input_filename);
+    vpImageConvert::convert(I_color, I);
 
 #ifdef VISP_HAVE_X11
-    vpDisplayX d(I);
+    vpDisplayX d(I), d2(I_color, 50, 50);
 #elif defined(VISP_HAVE_GDI)
-    vpDisplayGDI d(I);
+    vpDisplayGDI d(I), d2(I_color, 50, 50);
 #elif defined(VISP_HAVE_OPENCV)
-    vpDisplayOpenCV d(I);
+    vpDisplayOpenCV d(I), d2(I_color, 50, 50);
 #endif
 
     //! [Create AprilTag detector]
@@ -163,6 +165,21 @@ int main(int argc, const char **argv)
     vpDisplay::displayText(I, 20, 20, "Click to quit.", vpColor::red);
     vpDisplay::flush(I);
     vpDisplay::getClick(I);
+
+    // To test the displays on a vpRGBa image
+    vpDisplay::display(I_color);
+
+    // Display frames and tags but remove the display of the last element
+    std::vector<std::vector<vpImagePoint> > tagsCorners = detector.getTagsCorners();
+    tagsCorners.pop_back();
+    detector.displayTags(I_color, tagsCorners, vpColor::none, 3);
+
+    cMo_vec.pop_back();
+    detector.displayFrames(I_color, cMo_vec, cam, tagSize / 2, vpColor::none, 3);
+
+    vpDisplay::displayText(I_color, 20, 20, "Click to quit.", vpColor::red);
+    vpDisplay::flush(I_color);
+    vpDisplay::getClick(I_color);
   } catch (const vpException &e) {
     std::cerr << "Catch an exception: " << e.getMessage() << std::endl;
   }

--- a/tutorial/detection/tag/tutorial-apriltag-detector.cpp
+++ b/tutorial/detection/tag/tutorial-apriltag-detector.cpp
@@ -90,11 +90,11 @@ int main(int argc, const char **argv)
     vpImageConvert::convert(I_color, I);
 
 #ifdef VISP_HAVE_X11
-    vpDisplayX d(I), d2(I_color, 50, 50);
+    vpDisplayX d(I);
 #elif defined(VISP_HAVE_GDI)
-    vpDisplayGDI d(I), d2(I_color, 50, 50);
+    vpDisplayGDI d(I);
 #elif defined(VISP_HAVE_OPENCV)
-    vpDisplayOpenCV d(I), d2(I_color, 50, 50);
+    vpDisplayOpenCV d(I);
 #endif
 
     //! [Create AprilTag detector]
@@ -166,6 +166,13 @@ int main(int argc, const char **argv)
     vpDisplay::flush(I);
     vpDisplay::getClick(I);
 
+#ifdef VISP_HAVE_X11
+    vpDisplayX d2(I_color, 50, 50);
+#elif defined(VISP_HAVE_GDI)
+    vpDisplayGDI d2(I_color, 50, 50);
+#elif defined(VISP_HAVE_OPENCV)
+    vpDisplayOpenCV d2(I_color, 50, 50);
+#endif
     // To test the displays on a vpRGBa image
     vpDisplay::display(I_color);
 


### PR DESCRIPTION
Not sure if `vpDetectorAprilTag::displayFrames()` is useful.

Adding `vpDetectorAprilTag::displayTags()` to be able to draw AprilTag contours on grayscale and color images.