### PR TITLE
Update vpFeatureThetaU.cpp and PBVS examples

### DIFF
--- a/example/servo-franka/servoFrankaPBVS.cpp
+++ b/example/servo-franka/servoFrankaPBVS.cpp
@@ -335,7 +335,7 @@ int main(int argc, char **argv)
         vpTranslationVector cd_t_c = cdMc.getTranslationVector();
         vpThetaUVector cd_tu_c = cdMc.getThetaUVector();
         double error_tr = sqrt(cd_t_c.sumSquare());
-        double error_tu = vpMath::deg(sqrt(cd_tu_c.sumSquare()));
+        double error_tu = sqrt(cd_tu_c.sumSquare());
 
         ss.str("");
         ss << "error_t: " << error_tr;

--- a/example/servo-universal-robots/servoUniversalRobotsPBVS.cpp
+++ b/example/servo-universal-robots/servoUniversalRobotsPBVS.cpp
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
         vpTranslationVector cd_t_c = cdMc.getTranslationVector();
         vpThetaUVector cd_tu_c = cdMc.getThetaUVector();
         double error_tr = sqrt(cd_t_c.sumSquare());
-        double error_tu = vpMath::deg(sqrt(cd_tu_c.sumSquare()));
+        double error_tu = sqrt(cd_tu_c.sumSquare());
 
         ss.str("");
         ss << "error_t: " << error_tr;

--- a/modules/visual_features/src/visual-feature/vpFeatureThetaU.cpp
+++ b/modules/visual_features/src/visual-feature/vpFeatureThetaU.cpp
@@ -443,6 +443,7 @@ vpMatrix vpFeatureThetaU::interaction(unsigned int select)
 
   vpMatrix Lw(3, 3);
   Lw = vpColVector::skew(u); /* [theta/2  u]_x */
+  Lw = -Lw;
 
   vpMatrix U2(3, 3);
   U2.eye();


### PR DESCRIPTION
According to the paper, Lw should be -[theta/2 u]_x.

In PBVS examples, convergence_threshold_tu is in rad, but error_tu was in degree, which makes convergence very difficult.