### PR TITLE
Tracking: fix search for .init file in vpMbTracker

### DIFF
--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -321,6 +321,11 @@ void vpMbTracker::initClick(const vpImage<unsigned char> *const I, const vpImage
 
     pose.clearPoint();
 
+
+
+    // Clear string stream that previously contained the path to the "object.0.pos" file.
+    ss.str(std::string());
+
     // file parser
     // number of points
     // X Y Z

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -321,8 +321,6 @@ void vpMbTracker::initClick(const vpImage<unsigned char> *const I, const vpImage
 
     pose.clearPoint();
 
-
-
     // Clear string stream that previously contained the path to the "object.0.pos" file.
     ss.str(std::string());
 


### PR DESCRIPTION
This pull request fixes issue #1125

The method initClick from vpMbTracker looked for the .init file in an incorrect location. Previously, the file path looked something like:

`path/to/cube.0.pospath/to/cube.init`

It is now correct and is:
`path/to/cube.init`