### PR TITLE
Use png instead of pgm images

### DIFF
--- a/example/tracking/mbtEdgeKltTracking.cpp
+++ b/example/tracking/mbtEdgeKltTracking.cpp
@@ -81,7 +81,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.png\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -279,9 +279,9 @@ int main(int argc, const char **argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.png");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.png");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;

--- a/example/tracking/mbtEdgeTracking.cpp
+++ b/example/tracking/mbtEdgeTracking.cpp
@@ -83,7 +83,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.png\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -281,9 +281,9 @@ int main(int argc, const char **argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.png");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.png");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;

--- a/example/tracking/mbtGenericTracking.cpp
+++ b/example/tracking/mbtGenericTracking.cpp
@@ -85,7 +85,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.png\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -288,9 +288,9 @@ int main(int argc, const char **argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.png");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.png");
 
 #if USE_XML
     std::string configFile;

--- a/example/tracking/mbtGenericTracking2.cpp
+++ b/example/tracking/mbtGenericTracking2.cpp
@@ -85,7 +85,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.png\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -288,9 +288,9 @@ int main(int argc, const char **argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.png");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.png");
 
 #if USE_XML
     std::string configFile;

--- a/example/tracking/mbtGenericTrackingDepth.cpp
+++ b/example/tracking/mbtGenericTrackingDepth.cpp
@@ -275,7 +275,7 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<uns
   ss << input_directory << "/image_";
   ss << std::setfill('0') << std::setw(4);
   ss << cpt;
-  ss << ".pgm";
+  ss << ".png";
   std::string filename_image = ss.str();
   if (!vpIoTools::checkFilename(filename_image)) {
     std::cerr << "Cannot read: " << filename_image << std::endl;

--- a/example/tracking/mbtGenericTrackingDepthOnly.cpp
+++ b/example/tracking/mbtGenericTrackingDepthOnly.cpp
@@ -261,7 +261,7 @@ bool read_data(unsigned int cpt, const std::string &input_directory, vpImage<uns
   ss << input_directory << "/image_";
   ss << std::setfill('0') << std::setw(4);
   ss << cpt;
-  ss << ".pgm";
+  ss << ".png";
   std::string filename_image = ss.str();
 
   if (!vpIoTools::checkFilename(filename_image)) {

--- a/example/tracking/mbtKltTracking.cpp
+++ b/example/tracking/mbtKltTracking.cpp
@@ -80,7 +80,7 @@ OPTIONS:                                               \n\
   -i <input image path>                                \n\
      Set image input path.\n\
      From this path read images \n\
-     \"mbt/cube/image%%04d.ppm\". These \n\
+     \"mbt/cube/image%%04d.png\". These \n\
      images come from ViSP-images-x.y.z.tar.gz available \n\
      on the ViSP website.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
@@ -261,9 +261,9 @@ int main(int argc, const char **argv)
 
     // Get the option values
     if (!opt_ipath.empty())
-      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(opt_ipath, "mbt/cube/image%04d.png");
     else
-      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
+      ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.png");
 
     if (!opt_configFile.empty())
       configFile = opt_configFile;

--- a/modules/core/test/image-with-dataset/testImageNormalizedCorrelation.cpp
+++ b/modules/core/test/image-with-dataset/testImageNormalizedCorrelation.cpp
@@ -189,7 +189,7 @@ int main(int argc, const char **argv)
     //
 
     // Load cube sequence
-    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image%04d.pgm");
+    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image%04d.png");
 
     vpVideoReader reader;
     reader.setFileName(filename);

--- a/modules/core/test/image-with-dataset/testImageTemplateMatching.cpp
+++ b/modules/core/test/image-with-dataset/testImageTemplateMatching.cpp
@@ -254,7 +254,7 @@ int main(int argc, const char **argv)
     //
 
     // Load cube sequence
-    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image%04d.pgm");
+    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image%04d.png");
 
     vpVideoReader reader;
     reader.setFileName(filename);

--- a/modules/imgproc/test/with-dataset/testImgproc.cpp
+++ b/modules/imgproc/test/with-dataset/testImgproc.cpp
@@ -338,11 +338,11 @@ int main(int argc, const char **argv)
     vpImageIo::write(I_color_clahe, filename);
 
     //
-    // Test grayscale function using image0000.pgm
+    // Test grayscale function using image0000.png
     //
 
-    // Read image0000.pgm
-    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image0000.pgm");
+    // Read image0000.png
+    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image0000.png");
     vpImage<unsigned char> Iinput, I;
     std::cout << "\nRead image: " << filename << std::endl;
     vpImageIo::read(Iinput, filename);

--- a/modules/tracker/mbt/test/generic-with-dataset/perfGenericTracker.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/perfGenericTracker.cpp
@@ -60,7 +60,7 @@ bool read_data(const std::string &input_directory, int cpt, const vpCameraParame
   static_assert(std::is_same<Type, unsigned char>::value || std::is_same<Type, vpRGBa>::value,
                 "Template function supports only unsigned char and vpRGBa images!");
   char buffer[FILENAME_MAX];
-  snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Images/Image_%04d.pgm").c_str(), cpt);
+  snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Images/Image_%04d.png").c_str(), cpt);
   std::string image_filename = buffer;
 
   snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Depth/Depth_%04d.bin").c_str(), cpt);

--- a/modules/tracker/mbt/test/generic-with-dataset/testGenericTracker.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testGenericTracker.cpp
@@ -192,7 +192,7 @@ bool read_data(const std::string &input_directory, int cpt, const vpCameraParame
                 "Template function supports only unsigned char and vpRGBa images!");
 #endif
   char buffer[FILENAME_MAX];
-  snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Images/Image_%04d.pgm").c_str(), cpt);
+  snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Images/Image_%04d.png").c_str(), cpt);
   std::string image_filename = buffer;
 
   snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Depth/Depth_%04d.bin").c_str(), cpt);

--- a/modules/tracker/mbt/test/generic-with-dataset/testGenericTrackerDepth.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testGenericTrackerDepth.cpp
@@ -171,7 +171,7 @@ bool read_data(const std::string &input_directory, int cpt, const vpCameraParame
                 "Template function supports only unsigned char and vpRGBa images!");
 #endif
   char buffer[FILENAME_MAX];
-  snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Images/Image_%04d.pgm").c_str(), cpt);
+  snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Images/Image_%04d.png").c_str(), cpt);
   std::string image_filename = buffer;
 
   snprintf(buffer, FILENAME_MAX, std::string(input_directory + "/Depth/Depth_%04d.bin").c_str(), cpt);

--- a/modules/tracker/mbt/test/generic-with-dataset/testGenericTrackerDeterminist.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testGenericTrackerDeterminist.cpp
@@ -56,7 +56,7 @@ namespace
 bool read_data(int cpt, vpImage<unsigned char> &I)
 {
   const std::string env_ipath = vpIoTools::getViSPImagesDataPath();
-  const std::string ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.pgm");
+  const std::string ipath = vpIoTools::createFilePath(env_ipath, "mbt/cube/image%04d.png");
 
   char buffer[FILENAME_MAX];
   snprintf(buffer, FILENAME_MAX, ipath.c_str(), cpt);

--- a/modules/vision/test/keypoint-with-dataset/testKeyPoint-2.cpp
+++ b/modules/vision/test/keypoint-with-dataset/testKeyPoint-2.cpp
@@ -155,9 +155,9 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
   // Build the name of the image files
-  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");
+  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.png");
   vpImageIo::read(I, filenameRef);
-  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.pgm");
+  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.png");
 
 #if defined VISP_HAVE_X11
   vpDisplayX display;
@@ -258,7 +258,7 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   keypoints.buildReference(I, trainKeyPoints, points3f, false, 1);
 
   // Read image 150
-  filenameRef = vpIoTools::createFilePath(dirname, "image0150.pgm");
+  filenameRef = vpIoTools::createFilePath(dirname, "image0150.png");
   vpImageIo::read(I, filenameRef);
 
   // Init pose at image 150
@@ -281,7 +281,7 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   keypoints.buildReference(I, trainKeyPoints, points3f, true, 2);
 
   // Read image 200
-  filenameRef = vpIoTools::createFilePath(dirname, "image0200.pgm");
+  filenameRef = vpIoTools::createFilePath(dirname, "image0200.png");
   vpImageIo::read(I, filenameRef);
 
   // Init pose at image 200

--- a/modules/vision/test/keypoint-with-dataset/testKeyPoint-3.cpp
+++ b/modules/vision/test/keypoint-with-dataset/testKeyPoint-3.cpp
@@ -149,9 +149,9 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
   // Build the name of the image files
-  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");
+  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.png");
   vpImageIo::read(Iref, filenameRef);
-  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.pgm");
+  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.png");
 
   // Init keypoints
   cv::Ptr<cv::FeatureDetector> detector;

--- a/modules/vision/test/keypoint-with-dataset/testKeyPoint-4.cpp
+++ b/modules/vision/test/keypoint-with-dataset/testKeyPoint-4.cpp
@@ -153,10 +153,10 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
   // Build the name of the image files
-  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");
+  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.png");
   vpImageIo::read(I, filenameRef);
   Iref = I;
-  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.pgm");
+  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.png");
 
 #if defined VISP_HAVE_X11
   vpDisplayX display, display2;

--- a/modules/vision/test/keypoint-with-dataset/testKeyPoint.cpp
+++ b/modules/vision/test/keypoint-with-dataset/testKeyPoint.cpp
@@ -148,9 +148,9 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   std::string dirname = vpIoTools::createFilePath(env_ipath, "mbt/cube");
 
   // Build the name of the image files
-  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.pgm");
+  std::string filenameRef = vpIoTools::createFilePath(dirname, "image0000.png");
   vpImageIo::read(Iref, filenameRef);
-  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.pgm");
+  std::string filenameCur = vpIoTools::createFilePath(dirname, "image%04d.png");
 
   // Init keypoints
   vpKeyPoint keypoints("ORB", "ORB", "BruteForce-Hamming");

--- a/tutorial/java/mbt-generic/GenericTracker.java
+++ b/tutorial/java/mbt-generic/GenericTracker.java
@@ -141,7 +141,7 @@ public class GenericTracker extends JFrame {
                     tracker.loadModel(modelFilename);
                     tracker.setDisplayFeatures(true);
 
-                    input = new String(rootDir + "cube/image%04d.pgm");
+                    input = new String(rootDir + "cube/image%04d.png");
                     cMo_init = new VpHomogeneousMatrix(0.02231950571, 0.1071368004, 0.5071128378,
                             2.100485509, 1.146812236, -0.4560126437);
                 } else {
@@ -169,7 +169,7 @@ public class GenericTracker extends JFrame {
                     tracker.loadModel(modelFilename, false, T);
                     tracker.setDisplayFeatures(true);
 
-                    input = new String(rootDir + "Images/Image_%04d.pgm");
+                    input = new String(rootDir + "Images/Image_%04d.png");
                     inputDepth = new String(rootDir + "Depth/Depth_%04d.bin");
                     depthScale = 0.000030518F;
 


### PR DESCRIPTION
To reduce the files size of the ViSP-images repository.