### PR TITLE
Added optional parameters for drawFrame allowing to display along wit…

### DIFF
--- a/modules/core/include/visp3/core/vpDisplay.h
+++ b/modules/core/include/visp3/core/vpDisplay.h
@@ -746,7 +746,8 @@ public:
                              unsigned int thickness = 1, bool display_center = false, bool display_arc = false);
   static void displayFrame(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo,
                            const vpCameraParameters &cam, double size, const vpColor &color = vpColor::none,
-                           unsigned int thickness = 1, const vpImagePoint &offset = vpImagePoint(0, 0));
+                           unsigned int thickness = 1, const vpImagePoint &offset = vpImagePoint(0, 0),
+                           const std::string& frameName = "", const vpColor& textColor = vpColor::black, const vpImagePoint& textOffset = vpImagePoint(15,15) );
   static void displayLine(const vpImage<unsigned char> &I, const vpImagePoint &ip1, const vpImagePoint &ip2,
                           const vpColor &color, unsigned int thickness = 1, bool segment = true);
   static void displayLine(const vpImage<unsigned char> &I, int i1, int j1, int i2, int j2, const vpColor &color,
@@ -850,7 +851,8 @@ public:
                              bool display_center = false, bool display_arc = false);
   static void displayFrame(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
                            double size, const vpColor &color = vpColor::none, unsigned int thickness = 1,
-                           const vpImagePoint &offset = vpImagePoint(0, 0));
+                           const vpImagePoint &offset = vpImagePoint(0, 0), const std::string& frameName = "", 
+                           const vpColor& textColor = vpColor::black, const vpImagePoint& textOffset = vpImagePoint(15,15) );
   static void displayLine(const vpImage<vpRGBa> &I, const vpImagePoint &ip1, const vpImagePoint &ip2,
                           const vpColor &color, unsigned int thickness = 1, bool segment = true);
   static void displayLine(const vpImage<vpRGBa> &I, int i1, int j1, int i2, int j2, const vpColor &color,

--- a/modules/core/src/display/vpDisplay_rgba.cpp
+++ b/modules/core/src/display/vpDisplay_rgba.cpp
@@ -384,9 +384,10 @@ void vpDisplay::displayEllipse(const vpImage<vpRGBa> &I, const vpImagePoint &cen
   image.
 */
 void vpDisplay::displayFrame(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &cMo, const vpCameraParameters &cam,
-                             double size, const vpColor &color, unsigned int thickness, const vpImagePoint &offset)
+                             double size, const vpColor &color, unsigned int thickness, const vpImagePoint &offset,
+                             const std::string& frameName, const vpColor& textColor, const vpImagePoint& textOffset)
 {
-  vp_display_display_frame(I, cMo, cam, size, color, thickness, offset);
+  vp_display_display_frame(I, cMo, cam, size, color, thickness, offset, frameName, textColor, textOffset);
 }
 
 /*!

--- a/modules/core/src/display/vpDisplay_uchar.cpp
+++ b/modules/core/src/display/vpDisplay_uchar.cpp
@@ -386,9 +386,9 @@ void vpDisplay::displayEllipse(const vpImage<unsigned char> &I, const vpImagePoi
 */
 void vpDisplay::displayFrame(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &cMo,
                              const vpCameraParameters &cam, double size, const vpColor &color, unsigned int thickness,
-                             const vpImagePoint &offset)
+                             const vpImagePoint &offset, const std::string& frameName, const vpColor& textColor, const vpImagePoint& textOffset)
 {
-  vp_display_display_frame(I, cMo, cam, size, color, thickness, offset);
+  vp_display_display_frame(I, cMo, cam, size, color, thickness, offset, frameName, textColor, textOffset);
 }
 
 /*!

--- a/tutorial/image/CMakeLists.txt
+++ b/tutorial/image/CMakeLists.txt
@@ -21,6 +21,7 @@ set(tutorial_cpp
   tutorial-draw-point.cpp
   tutorial-draw-cross.cpp
   tutorial-draw-text.cpp
+  tutorial-draw-frame.cpp
   tutorial-export-image.cpp
   tutorial-event-keyboard.cpp
   tutorial-video-manipulation.cpp)

--- a/tutorial/image/tutorial-draw-frame.cpp
+++ b/tutorial/image/tutorial-draw-frame.cpp
@@ -1,0 +1,59 @@
+//! \example tutorial-draw-frame.cpp
+#include <visp3/gui/vpDisplayGDI.h>
+#include <visp3/gui/vpDisplayX.h>
+#include <visp3/core/vpHomogeneousMatrix.h>
+
+int main()
+{
+  vpImage<unsigned char> I(2160, 3840, 128);
+
+  try {
+
+#if defined(VISP_HAVE_X11)
+    vpDisplayX d(I, vpDisplay::SCALE_AUTO);
+#elif defined(VISP_HAVE_GDI)
+    vpDisplayGDI d(I, vpDisplay::SCALE_AUTO);
+#endif
+
+    vpDisplay::setTitle(I, "My image");
+    vpDisplay::display(I);
+
+    double dTheta = 45;
+    double dOffset = 0.25;
+    std::string axisName[3] = {"x", "y", "z"};
+    double px = 600; double py = 600;
+    double u0 = 320; double v0 = 240;
+ 
+    // Create a camera parameter container
+    vpCameraParameters cam;
+ 
+    // Camera initialization with a perspective projection without distortion model 
+    cam.initPersProjWithoutDistortion(px,py,u0,v0);
+
+    for(unsigned int idAxis = 0; idAxis < 3; idAxis ++)
+    {
+      unsigned int tOffset = 0;
+      for(double theta = -180; theta < 180; theta += dTheta)
+      {
+        vpTranslationVector t(0.05, 0.25 * (idAxis + 1), 0.37);
+        vpRxyzVector r(0, 0, 0);
+        t[0] = t[0] + tOffset * dOffset;
+        tOffset++;
+        r[idAxis] = vpMath::rad(theta);
+        vpHomogeneousMatrix cMo;
+        cMo.buildFrom(t, vpRotationMatrix(r));
+        std::string name = "cMo_" + std::to_string((int)theta) + "_" + axisName[idAxis];
+
+        //! [frame]
+        vpDisplay::displayFrame(I, cMo, cam, 0.1, vpColor::none, 1, vpImagePoint(), name, vpColor::yellow, vpImagePoint(40,40));
+        //! [frame]
+      }
+    }
+    
+    vpDisplay::flush(I);
+    std::cout << "A click to quit..." << std::endl;
+    vpDisplay::getClick(I);
+  } catch (const vpException &e) {
+    std::cout << "Catch an exception: " << e.getMessage() << std::endl;
+  }
+}


### PR DESCRIPTION
Modification to vp_display_display_frame : 
- Changed its implementation due to visible errors when the camera has no distortion
- Added optional parameters to this method and vpDisplay::displayFrame in order to write the name of the frame beside the frame. The direction of the offset between the name and the frame is computed to avoid as much as possible crossing an axis.
- A tutorial tutorial-draw-frame has been added in tutorials/draw to show an example of how the method behaves.