### PR TITLE
"Fix" poseDementhon* hard-coded pseudo-inverse threshold

### DIFF
--- a/modules/vision/include/visp3/vision/vpPose.h
+++ b/modules/vision/include/visp3/vision/vpPose.h
@@ -201,6 +201,7 @@ private:
   };
 
 protected:
+  double dementhonSvThresh; //!< SVD threshold use for the pseudo-inverse computation in poseDementhonPlan
   double computeResidualDementhon(const vpHomogeneousMatrix &cMo);
 
   // method used in poseDementhonPlan()
@@ -229,6 +230,7 @@ public:
   void poseVirtualVSrobust(vpHomogeneousMatrix &cMo);
   void poseVirtualVS(vpHomogeneousMatrix &cMo);
   void printPoint();
+  void setDementhonSvThreshold(const double& svThresh);
   void setDistanceToPlaneForCoplanarityTest(double d);
   void setLambda(double a) { lambda = a; }
   void setVvsEpsilon(const double eps)

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -94,7 +94,7 @@ void vpPose::init()
 
 /*! Default constructor. */
 vpPose::vpPose()
-  : npt(0), listP(), residual(0), lambda(0.9), vvsIterMax(200), c3d(), computeCovariance(false), covarianceMatrix(),
+  : npt(0), listP(), residual(0), lambda(0.9), dementhonSvThresh(1e-6), vvsIterMax(200), c3d(), computeCovariance(false), covarianceMatrix(),
     ransacNbInlierConsensus(4), ransacMaxTrials(1000), ransacInliers(), ransacInlierIndex(), ransacThreshold(0.0001),
     distanceToPlaneForCoplanarityTest(0.001), ransacFlag(vpPose::NO_FILTER), listOfPoints(), useParallelRansac(false),
     nbParallelRansacThreads(0), // 0 means that we use C++11 (if available) to get the number of threads
@@ -168,6 +168,14 @@ void vpPose::addPoints(const std::vector<vpPoint> &lP)
 }
 
 void vpPose::setDistanceToPlaneForCoplanarityTest(double d) { distanceToPlaneForCoplanarityTest = d; }
+
+void vpPose::setDementhonSvThreshold(const double& svThresh){
+  if(svThresh < 0)
+  {
+    throw vpException(vpException::badValue, "The svd threshold must be positive");
+  }
+  dementhonSvThresh = svThresh;
+}
 
 /*!
   Test the coplanarity of the set of points

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -94,11 +94,11 @@ void vpPose::init()
 
 /*! Default constructor. */
 vpPose::vpPose()
-  : npt(0), listP(), residual(0), lambda(0.9), dementhonSvThresh(1e-6), vvsIterMax(200), c3d(), computeCovariance(false), covarianceMatrix(),
+  : npt(0), listP(), residual(0), lambda(0.9), vvsIterMax(200), c3d(), computeCovariance(false), covarianceMatrix(),
     ransacNbInlierConsensus(4), ransacMaxTrials(1000), ransacInliers(), ransacInlierIndex(), ransacThreshold(0.0001),
     distanceToPlaneForCoplanarityTest(0.001), ransacFlag(vpPose::NO_FILTER), listOfPoints(), useParallelRansac(false),
     nbParallelRansacThreads(0), // 0 means that we use C++11 (if available) to get the number of threads
-    vvsEpsilon(1e-8)
+    vvsEpsilon(1e-8), dementhonSvThresh(1e-6)
 {
 }
 
@@ -108,7 +108,7 @@ vpPose::vpPose(const std::vector<vpPoint> &lP)
     ransacInliers(), ransacInlierIndex(), ransacThreshold(0.0001), distanceToPlaneForCoplanarityTest(0.001),
     ransacFlag(vpPose::NO_FILTER), listOfPoints(lP), useParallelRansac(false),
     nbParallelRansacThreads(0), // 0 means that we use C++11 (if available) to get the number of threads
-    vvsEpsilon(1e-8)
+    vvsEpsilon(1e-8), dementhonSvThresh(1e-6)
 {
 }
 

--- a/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
@@ -493,7 +493,7 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
     errorMsg << "In Dementhon planar, after ";
     errorMsg << nbMaxIter;
     errorMsg << " trials multiplying the svd threshold by ";
-    errorMsg << nbMaxIter;
+    errorMsg << svdFactorUsedWhenFailure;
     errorMsg << ", rank (";
     errorMsg << irank;
     errorMsg << ") is still not 3";

--- a/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
@@ -469,11 +469,11 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
   }
   vpColVector sv;
   vpMatrix Ap, imA, imAt, kAt;
-  bool isRankEqualTo3(false); // Indicates if the rank of A is the expected one
+  bool isRankEqualTo3 = false; // Indicates if the rank of A is the expected one
   double logNofSvdThresh = std::log(dementhonSvThresh)/lnOfSvdFactorUsed; // Get the log_n(dementhonSvThresh), where n is the factor by which we will multiply it if the svd decomposition fails.
   int nbMaxIter = std::max(std::ceil(logNOfSvdThresholdLimit - logNofSvdThresh), 1.); // Ensure that if the user chose a threshold > svdThresholdLimit, at least 1 iteration of svd decomposition is performed
   double svdThreshold = dementhonSvThresh;
-  int irank(0);
+  int irank = 0;
   for(int i = 0; i < nbMaxIter && !isRankEqualTo3; i++)
   {
     irank = A.pseudoInverse(Ap, sv, svdThreshold, imA, imAt, kAt);
@@ -489,14 +489,15 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
   }
   
   if (!isRankEqualTo3) {
-    std::string errorMsg("In Dementhon planar, after ");
-    errorMsg += std::to_string(nbMaxIter);
-    errorMsg += std::string(" trials multiplying the svd threshold by ");
-    errorMsg += std::to_string(nbMaxIter);
-    errorMsg += std::string(", rank (");
-    errorMsg += std::to_string(irank);
-    errorMsg += std::string(") is still not 3");
-    throw(vpException(vpException::fatalError, errorMsg));
+    std::stringstream errorMsg;
+    errorMsg << "In Dementhon planar, after ";
+    errorMsg << nbMaxIter;
+    errorMsg << " trials multiplying the svd threshold by ";
+    errorMsg << nbMaxIter;
+    errorMsg << ", rank (";
+    errorMsg << irank;
+    errorMsg << ") is still not 3";
+    throw(vpException(vpException::fatalError, errorMsg.str()));
   }
   // calcul de U
   vpColVector U(4);

--- a/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
@@ -431,7 +431,10 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
 #if (DEBUG_LEVEL1)
   std::cout << "begin CCalculPose::PoseDementhonPlan()" << std::endl;
 #endif
-
+  const double svdFactorUsedWhenFailure = 10.; // Factor by which is multipled dementhonSvThresh each time the svdDecomposition fails
+  const double svdThresholdLimit = 1e-2; // The svd decomposition will be tested with a threshold up to this value. If with this threshold, the rank of A is still !=3, an exception is thrown
+  const double lnOfSvdFactorUsed = std::log(svdFactorUsedWhenFailure);
+  const double logNOfSvdThresholdLimit = std::log(svdThresholdLimit)/lnOfSvdFactorUsed;
   vpPoint P;
   double cdg[3];
   /* compute the cog of the 3D points */
@@ -466,9 +469,34 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
   }
   vpColVector sv;
   vpMatrix Ap, imA, imAt, kAt;
-  int irank = A.pseudoInverse(Ap, sv, dementhonSvThresh, imA, imAt, kAt);
-  if (irank != 3) {
-    throw(vpException(vpException::fatalError, "In Dementhon planar, rank (" + std::to_string(irank) +  ") is not 3"));
+  bool isRankEqualTo3(false); // Indicates if the rank of A is the expected one
+  double logNofSvdThresh = std::log(dementhonSvThresh)/lnOfSvdFactorUsed; // Get the log_n(dementhonSvThresh), where n is the factor by which we will multiply it if the svd decomposition fails.
+  int nbMaxIter = std::max(std::ceil(logNOfSvdThresholdLimit - logNofSvdThresh), 1.); // Ensure that if the user chose a threshold > svdThresholdLimit, at least 1 iteration of svd decomposition is performed
+  double svdThreshold = dementhonSvThresh;
+  int irank(0);
+  for(int i = 0; i < nbMaxIter && !isRankEqualTo3; i++)
+  {
+    irank = A.pseudoInverse(Ap, sv, svdThreshold, imA, imAt, kAt);
+    if(irank == 3)
+    {
+      isRankEqualTo3 = true;
+    }
+    else
+    {
+      isRankEqualTo3 = false;
+      svdThreshold *= svdFactorUsedWhenFailure;
+    }
+  }
+  
+  if (!isRankEqualTo3) {
+    std::string errorMsg("In Dementhon planar, after ");
+    errorMsg += std::to_string(nbMaxIter);
+    errorMsg += std::string(" trials multiplying the svd threshold by ");
+    errorMsg += std::to_string(nbMaxIter);
+    errorMsg += std::string(", rank (");
+    errorMsg += std::to_string(irank);
+    errorMsg += std::string(") is still not 3");
+    throw(vpException(vpException::fatalError, errorMsg));
   }
   // calcul de U
   vpColVector U(4);

--- a/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
@@ -139,7 +139,7 @@ void vpPose::poseDementhonNonPlan(vpHomogeneousMatrix &cMo)
     A[i][2] = c3d[i].get_oZ();
     A[i][3] = 1.0;
   }
-  Ap = A.pseudoInverse();
+  Ap = A.pseudoInverse(dementhonSvThresh);
 
 #if (DEBUG_LEVEL2)
   {
@@ -466,9 +466,9 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
   }
   vpColVector sv;
   vpMatrix Ap, imA, imAt, kAt;
-  int irank = A.pseudoInverse(Ap, sv, 1.e-6, imA, imAt, kAt);
+  int irank = A.pseudoInverse(Ap, sv, dementhonSvThresh, imA, imAt, kAt);
   if (irank != 3) {
-    throw(vpException(vpException::fatalError, "In Dementhon planar, rank is not 3"));
+    throw(vpException(vpException::fatalError, "In Dementhon planar, rank (" + std::to_string(irank) +  ") is not 3"));
   }
   // calcul de U
   vpColVector U(4);


### PR DESCRIPTION
[CORPS] Added a dementhonSvThresh attribute, a setter and using it when computing pseudo-inverse in poseDementhon*
It can be useful when your application require a fine-tuning of the pseudo-inverse svd threshold to determine if the configuration is planar or not