### PR TITLE
vpPose: Dementhon or Lagrange followed by VVS

### DIFF
--- a/modules/vision/include/visp3/vision/vpPose.h
+++ b/modules/vision/include/visp3/vision/vpPose.h
@@ -105,8 +105,11 @@ public:
                              initialization from Lagrange or Dementhon aproach */
     DEMENTHON_VIRTUAL_VS, /*!< Non linear virtual visual servoing approach
                              initialized by Dementhon approach */
-    LAGRANGE_VIRTUAL_VS   /*!< Non linear virtual visual servoing approach
+    LAGRANGE_VIRTUAL_VS,  /*!< Non linear virtual visual servoing approach
                              initialized by Lagrange approach */
+    DEMENTHON_LAGRANGE_VIRTUAL_VS, /*!< Non linear virtual visual servoing approach
+                             initialized by either Dementhon or Lagrange approach,
+                             depending on which method has the smallest residual. */
   } vpPoseMethodType;
 
   enum RANSAC_FILTER_FLAGS {
@@ -215,6 +218,7 @@ public:
   void clearPoint();
 
   bool computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &) = NULL);
+  bool computePoseDementhonLagrangeVVS(vpHomogeneousMatrix &cMo);
   double computeResidual(const vpHomogeneousMatrix &cMo) const;
   bool coplanar(int &coplanar_plane_type);
   void displayModel(vpImage<unsigned char> &I, vpCameraParameters &cam, vpColor col = vpColor::none);

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -367,6 +367,9 @@ double vpPose::computeResidual(const vpHomogeneousMatrix &cMo) const
   initialized by Dementhon approach
   - vpPose::LAGRANGE_VIRTUAL_VS: Non linear virtual visual servoing approach
   initialized by Lagrange approach
+  - vpPose::DEMENTHON_LAGRANGE_VIRTUAL_VS: Non linear virtual visual servoing approach
+  initialized by either Dementhon or Lagrange approach, depending on which method
+  has the smallest residual.
   - vpPose::RANSAC: Robust Ransac aproach (doesn't need an initialization)
 
 */
@@ -442,6 +445,8 @@ bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool
   case LOWE:
   case VIRTUAL_VS:
     break;
+  case DEMENTHON_LAGRANGE_VIRTUAL_VS:
+    return computePoseDementhonLagrangeVVS(cMo);
   }
 
   switch (method) {
@@ -463,6 +468,118 @@ bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool
 
   // If here, there was no exception thrown so return true
   return true;
+}
+
+/**
+ * @brief Method that first computes the pose \b cMo using the linear approaches of Dementhon and Lagrange
+ * and then uses the non-linear Virtual Visual Servoing approach to affine the pose which
+ * had  the lowest residual.
+ * 
+ * @param cMo the pose of the object with regard to the camera.
+ * @return true the pose computation was succesful.
+ * @return false an error occured during the pose computation.
+ */
+bool vpPose::computePoseDementhonLagrangeVVS(vpHomogeneousMatrix& cMo)
+{
+  vpHomogeneousMatrix cMo_dementhon, cMo_lagrange;
+  double r_dementhon = std::numeric_limits<double>::max(), r_lagrange = std::numeric_limits<double>::max();
+  // test if the 3D points are coplanar
+  int coplanar_plane_type = 0;
+  bool plan = coplanar(coplanar_plane_type);
+  bool hasDementhonSucceeded(false), hasLagrangeSucceeded(false);
+  try
+  {
+    if(plan)
+    {
+      poseDementhonPlan(cMo_dementhon);
+    }
+    else
+    {
+      poseDementhonNonPlan(cMo_dementhon);
+    }
+    
+    r_dementhon = computeResidual(cMo_dementhon);
+    hasDementhonSucceeded = true; // We reached this point => no exception was thrown = method succeeded
+  }
+  catch (vpException e)
+  {
+    // An exception was thrown using the original assumption, trying we the other one
+    try
+    {
+      if(plan)
+      {
+        // Already tested poseDementhonPlan, now trying poseDementhonNonPlan
+        poseDementhonNonPlan(cMo_dementhon);
+      }
+      else
+      {
+        // Already tested poseDementhonNonPlan, now trying poseDementhonPlan
+        poseDementhonPlan(cMo_dementhon);
+      }
+      
+      r_dementhon = computeResidual(cMo_dementhon);
+      hasDementhonSucceeded = true; // We reached this point => no exception was thrown = method succeeded
+    }
+    catch(const vpException& e)
+    {
+      // The Dementhon method failed both with the planar and non-planar assumptions.
+      hasDementhonSucceeded = false;
+    }
+  }
+
+  try
+  {
+    if(plan)
+    {
+      poseLagrangePlan(cMo_lagrange);
+    }
+    else
+    {
+      poseLagrangeNonPlan(cMo_lagrange);
+    }
+    
+    r_lagrange = computeResidual(cMo_lagrange);
+    hasLagrangeSucceeded = true; // We reached this point => no exception was thrown = method succeeded
+  }
+  catch (vpException e)
+  {
+    // An exception was thrown using the original assumption, trying we the other one
+    try
+    {
+      if(plan)
+      {
+        // Already tested poseLagrangePlan, now trying poseLagrangeNonPlan
+        poseLagrangeNonPlan(cMo_lagrange);
+      }
+      else
+      {
+        // Already tested poseLagrangeNonPlan, now trying poseLagrangePlan
+        poseLagrangePlan(cMo_lagrange);
+      }
+      
+      r_lagrange = computeResidual(cMo_lagrange);
+      hasLagrangeSucceeded = true; // We reached this point => no exception was thrown = method succeeded
+    }
+    catch(const vpException& e)
+    {
+      // The Lagrange method both failed with the planar and non-planar assumptions.
+      hasLagrangeSucceeded = false;
+    }
+  }
+
+  if ((hasDementhonSucceeded || hasLagrangeSucceeded))
+  {
+    // At least one of the linear methods managed to compute an initial pose.
+    // We initialize cMo with the method that had the lowest residual
+    cMo = (r_dementhon < r_lagrange) ? cMo_dementhon : cMo_lagrange;
+    // We now use the non-linear Virtual Visual Servoing method to improve the estimated cMo
+    return computePose(vpPose::VIRTUAL_VS, cMo);
+  }
+  else
+  {
+    // None of the linear methods manage to compute an initial pose
+    return false;
+  }
 }
 
 void vpPose::printPoint()

--- a/modules/vision/test/pose/testPose.cpp
+++ b/modules/vision/test/pose/testPose.cpp
@@ -213,6 +213,13 @@ int main()
       print_pose(cMo, std::string("Pose estimated by Lagrange then by VVS"));
       fail = compare_pose(pose, cMo_ref, cMo, "pose by Lagrange then by VVS");
       test_planar_fail |= fail;
+
+      std::cout << "-------------------------------------------------" << std::endl;
+      pose.computePose(vpPose::DEMENTHON_LAGRANGE_VIRTUAL_VS, cMo);
+
+      print_pose(cMo, std::string("Pose estimated either by Dementhon or Lagrange then by VVS"));
+      fail = compare_pose(pose, cMo_ref, cMo, "pose either by Dementhon or Lagrange then by VVS");
+      test_planar_fail |= fail;
     }
 
     {
@@ -306,6 +313,13 @@ int main()
       print_pose(cMo, std::string("Pose estimated by Lagrange then by VVS"));
       fail = compare_pose(pose, cMo_ref, cMo, "pose by Lagrange then by VVS");
       test_non_planar_fail |= fail;
+
+      std::cout << "-------------------------------------------------" << std::endl;
+      pose.computePose(vpPose::DEMENTHON_LAGRANGE_VIRTUAL_VS, cMo);
+
+      print_pose(cMo, std::string("Pose estimated  either by Dementhon or Lagrange then by VVS"));
+      fail = compare_pose(pose, cMo_ref, cMo, "pose either by Dementhon or Lagrange then by VVS");
+      test_non_planar_fail |= fail;
     }
 
     //
@@ -373,6 +387,14 @@ int main()
 
       print_pose(cMo, std::string("Pose estimated by Dementhon then by VVS"));
       fail = compare_pose(pose, cMo_ref, cMo, "pose by Dementhon then by VVS");
+      test_non_planar_fail |= fail;
+
+      std::cout << "-------------------------------------------------" << std::endl;
+
+      pose.computePose(vpPose::DEMENTHON_LAGRANGE_VIRTUAL_VS, cMo);
+
+      print_pose(cMo, std::string("Pose estimated either by Dementhon or Lagrange then by VVS"));
+      fail = compare_pose(pose, cMo_ref, cMo, "pose either by Dementhon or Lagrange then by VVS");
       test_non_planar_fail |= fail;
 
       std::cout << "-------------------------------------------------" << std::endl;


### PR DESCRIPTION
Added a DEMENTHON_LAGRANGE_VVS type of vpPose estimation method, which basically tests both Dementhon and Lagrange to have a initial value of cMo that is thereafter refined thanks to VVS