### PR TITLE
Improvement of vpPose::poseLagrangePlan + vpPose::coplanar

### DIFF
--- a/modules/core/include/visp3/core/vpUniRand.h
+++ b/modules/core/include/visp3/core/vpUniRand.h
@@ -74,6 +74,16 @@ typedef unsigned __int32 uint32_t;
 #include <inttypes.h>
 #endif
 
+#ifdef __cplusplus
+  #if (__cplusplus <= 201103L) 
+    #include <algorithm>    // std::random_shuffle
+  #else
+    #include <random> // std::shuffle
+    #include <numeric> // std::iota
+  #endif
+#endif
+
+#include <vector>
 /*!
   \class vpUniRand
 
@@ -123,6 +133,9 @@ public:
   float uniform(float a, float b);
   double uniform(double a, double b);
   void setSeed(uint64_t initstate, uint64_t initseq);
+
+  template<typename T>
+  static std::vector<T> shuffleVector(const std::vector<T> &inputVector);
 
 private:
   uint32_t boundedRand(uint32_t bound);

--- a/modules/core/src/math/random-generator/vpUniRand.cpp
+++ b/modules/core/src/math/random-generator/vpUniRand.cpp
@@ -68,6 +68,7 @@
 
 #include <stdint.h>
 #include <visp3/core/vpUniRand.h>
+#include <visp3/core/vpPoint.h>
 
 vpUniRand::vpUniRand()
   : m_maxInvDbl(1.0 / static_cast<double>(UINT32_MAX)), m_maxInvFlt(1.0f / static_cast<float>(UINT32_MAX)), m_rng()
@@ -208,3 +209,27 @@ void vpUniRand::setSeed(uint64_t initstate, uint64_t initseq)
   m_rng.state += initstate;
   next();
 }
+
+/**
+ * @brief Create a new vector that is a shuffled version of the \b inputVector.
+ * 
+ * @tparam T a class that possesses a copy constructor.
+ * @param inputVector The input vector that must be shuffled. It will not be modified.
+ * @return std::vector<T> A vector containing the same objects than \b inputVector, but that are shuffled.
+ */
+template<typename T>
+std::vector<T> vpUniRand::shuffleVector(const std::vector<T>& inputVector)
+{
+  std::vector<T> shuffled = inputVector;
+  #ifdef __cplusplus
+    #if (__cplusplus <= 201103L) 
+      std::random_shuffle ( shuffled.begin(), shuffled.end() );
+    #else
+      std::shuffle(shuffled.begin(), shuffled.end(), std::mt19937{std::random_device{}()});
+    #  endif
+  #endif
+  return shuffled;
+}
+
+template
+std::vector<vpPoint> vpUniRand::shuffleVector(const std::vector<vpPoint>& inputVector);

--- a/modules/vision/include/visp3/vision/vpPose.h
+++ b/modules/vision/include/visp3/vision/vpPose.h
@@ -221,13 +221,13 @@ public:
   bool computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &) = NULL);
   bool computePoseDementhonLagrangeVVS(vpHomogeneousMatrix &cMo);
   double computeResidual(const vpHomogeneousMatrix &cMo) const;
-  bool coplanar(int &coplanar_plane_type);
+  bool coplanar(int &coplanar_plane_type, double *p_a = NULL, double *p_b = NULL, double *p_c = NULL, double *p_d = NULL);
   void displayModel(vpImage<unsigned char> &I, vpCameraParameters &cam, vpColor col = vpColor::none);
   void displayModel(vpImage<vpRGBa> &I, vpCameraParameters &cam, vpColor col = vpColor::none);
 
   void poseDementhonPlan(vpHomogeneousMatrix &cMo);
   void poseDementhonNonPlan(vpHomogeneousMatrix &cMo);
-  void poseLagrangePlan(vpHomogeneousMatrix &cMo);
+  void poseLagrangePlan(vpHomogeneousMatrix &cMo, bool *p_isPlan = NULL, double *p_a = NULL, double *p_b = NULL, double *p_c = NULL, double *p_d = NULL);
   void poseLagrangeNonPlan(vpHomogeneousMatrix &cMo);
   void poseLowe(vpHomogeneousMatrix &cMo);
   bool poseRansac(vpHomogeneousMatrix &cMo, bool (*func)(const vpHomogeneousMatrix &) = NULL);

--- a/modules/vision/src/pose-estimation/vpPose.cpp
+++ b/modules/vision/src/pose-estimation/vpPose.cpp
@@ -49,6 +49,7 @@ pour faire du calcul de pose par difference methode
 #include <visp3/core/vpException.h>
 #include <visp3/core/vpMath.h>
 #include <visp3/core/vpMeterPixelConversion.h>
+#include <visp3/core/vpUniRand.h>
 #include <visp3/vision/vpPose.h>
 #include <visp3/vision/vpPoseException.h>
 
@@ -186,9 +187,13 @@ void vpPose::setDementhonSvThreshold(const double& svThresh){
    3: if plane z=cst
    4: if the points are collinear.
    0: any other plane
+  \param p_a: if different from null, it will be set to equal the a coefficient of the potential plan.
+  \param p_b: if different from null, it will be set to equal the b coefficient of the potential plan.
+  \param p_c: if different from null, it will be set to equal the c coefficient of the potential plan.
+  \param p_d: if different from null, it will be set to equal the d coefficient of the potential plan.
   \return true if points are coplanar false otherwise.
 */
-bool vpPose::coplanar(int &coplanar_plane_type)
+bool vpPose::coplanar(int &coplanar_plane_type, double *p_a, double *p_b, double *p_c, double *p_d)
 {
   coplanar_plane_type = 0;
   if (npt < 2) {
@@ -199,19 +204,22 @@ bool vpPose::coplanar(int &coplanar_plane_type)
   if (npt == 3)
     return true;
 
+  // Shuffling the points to limit the risk of using points close to each other
+  std::vector<vpPoint> shuffled_listP = vpUniRand::shuffleVector<vpPoint>(listOfPoints);
+  
   double x1 = 0, x2 = 0, x3 = 0, y1 = 0, y2 = 0, y3 = 0, z1 = 0, z2 = 0, z3 = 0;
 
-  std::list<vpPoint>::const_iterator it = listP.begin();
+  std::vector<vpPoint>::const_iterator it = shuffled_listP.begin();
 
   vpPoint P1, P2, P3;
 
   // Get three 3D points that are not collinear and that is not at origin
   bool degenerate = true;
   bool not_on_origin = true;
-  std::list<vpPoint>::const_iterator it_tmp;
+  std::vector<vpPoint>::const_iterator it_tmp;
 
-  std::list<vpPoint>::const_iterator it_i, it_j, it_k;
-  for (it_i = listP.begin(); it_i != listP.end(); ++it_i) {
+  std::vector<vpPoint>::const_iterator it_i, it_j, it_k;
+  for (it_i = shuffled_listP.begin(); it_i != shuffled_listP.end(); ++it_i) {
     if (degenerate == false) {
       // std::cout << "Found a non degenerate configuration" << std::endl;
       break;
@@ -228,7 +236,7 @@ bool vpPose::coplanar(int &coplanar_plane_type)
     if (not_on_origin) {
       it_tmp = it_i;
       ++it_tmp; // j = i+1
-      for (it_j = it_tmp; it_j != listP.end(); ++it_j) {
+      for (it_j = it_tmp; it_j != shuffled_listP.end(); ++it_j) {
         if (degenerate == false) {
           // std::cout << "Found a non degenerate configuration" << std::endl;
           break;
@@ -244,7 +252,7 @@ bool vpPose::coplanar(int &coplanar_plane_type)
         if (not_on_origin) {
           it_tmp = it_j;
           ++it_tmp; // k = j+1
-          for (it_k = it_tmp; it_k != listP.end(); ++it_k) {
+          for (it_k = it_tmp; it_k != shuffled_listP.end(); ++it_k) {
             P3 = *it_k;
             if ((std::fabs(P3.get_oX()) <= std::numeric_limits<double>::epsilon()) &&
                 (std::fabs(P3.get_oY()) <= std::numeric_limits<double>::epsilon()) &&
@@ -313,7 +321,7 @@ bool vpPose::coplanar(int &coplanar_plane_type)
 
   double D = sqrt(vpMath::sqr(a) + vpMath::sqr(b) + vpMath::sqr(c));
 
-  for (it = listP.begin(); it != listP.end(); ++it) {
+  for (it = shuffled_listP.begin(); it != shuffled_listP.end(); ++it) {
     P1 = *it;
     double dist = (a * P1.get_oX() + b * P1.get_oY() + c * P1.get_oZ() + d) / D;
     // std::cout << "dist= " << dist << std::endl;
@@ -327,6 +335,28 @@ bool vpPose::coplanar(int &coplanar_plane_type)
 
   vpDEBUG_TRACE(10, " points are  coplanar ");
   //  vpTRACE(" points are  coplanar ") ;
+
+  // If the points are coplanar and the input/output parameters are different from NULL,
+  // getting the values of the plan coefficient and storing in the input/output parameters
+  if(p_a != NULL)
+  {
+    *p_a = a;
+  }
+
+  if(p_b != NULL)
+  {
+    *p_b = b;
+  }
+
+  if(p_c != NULL)
+  {
+    *p_c = c;
+  }
+
+  if(p_d != NULL)
+  {
+    *p_d = d;
+  }
 
   return true;
 }
@@ -399,7 +429,7 @@ bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool
                             npt));
     }
 
-    // test si les point 3D sont coplanaires
+    // test if the 3D points are coplanar
     int coplanar_plane_type = 0;
     bool plan = coplanar(coplanar_plane_type);
     if (plan == true) {
@@ -411,9 +441,10 @@ bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool
   case LAGRANGE:
   case LAGRANGE_VIRTUAL_VS:
   case LAGRANGE_LOWE: {
-    // test si les point 3D sont coplanaires
-    int coplanar_plane_type;
-    bool plan = coplanar(coplanar_plane_type);
+    // test if the 3D points are coplanar
+    double a, b, c, d; // To get the plan coefficients if the points are coplanar
+    int coplanar_plane_type = 0;
+    bool plan = coplanar(coplanar_plane_type, &a, &b, &c, &d);
 
     if (plan == true) {
 
@@ -428,7 +459,7 @@ bool vpPose::computePose(vpPoseMethodType method, vpHomogeneousMatrix &cMo, bool
                               "Not enough point (%d) to compute the pose  ",
                               npt));
       }
-      poseLagrangePlan(cMo);
+      poseLagrangePlan(cMo, &plan, &a, &b, &c, &d);
     } else {
       if (npt < 6) {
         throw(vpPoseException(vpPoseException::notEnoughPointError,
@@ -492,8 +523,9 @@ bool vpPose::computePoseDementhonLagrangeVVS(vpHomogeneousMatrix& cMo)
   vpHomogeneousMatrix cMo_dementhon, cMo_lagrange;
   double r_dementhon = std::numeric_limits<double>::max(), r_lagrange = std::numeric_limits<double>::max();
   // test if the 3D points are coplanar
+  double a, b, c, d; // To get the plan coefficients if the points are coplanar
   int coplanar_plane_type = 0;
-  bool plan = coplanar(coplanar_plane_type);
+  bool plan = coplanar(coplanar_plane_type, &a, &b, &c, &d);
   bool hasDementhonSucceeded(false), hasLagrangeSucceeded(false);
   try
   {
@@ -539,7 +571,8 @@ bool vpPose::computePoseDementhonLagrangeVVS(vpHomogeneousMatrix& cMo)
   {
     if(plan)
     {
-      poseLagrangePlan(cMo_lagrange);
+      // If plan is true, then a, b, c, d will have been set when we called coplanar.
+      poseLagrangePlan(cMo_lagrange, &plan, &a, &b, &c, &d);
     }
     else
     {
@@ -562,7 +595,11 @@ bool vpPose::computePoseDementhonLagrangeVVS(vpHomogeneousMatrix& cMo)
       else
       {
         // Already tested poseLagrangeNonPlan, now trying poseLagrangePlan
-        poseLagrangePlan(cMo_lagrange);
+        // Because plan is false, then a, b, c, d will not have
+        // been initialized when calling coplanar
+        // We are expecting that the call to poseLagrangePlan will throw an exception
+        // because coplanar return false.
+        poseLagrangePlan(cMo_lagrange, &plan, &a, &b, &c, &d);
       }
       
       r_lagrange = computeResidual(cMo_lagrange);

--- a/modules/vision/src/pose-estimation/vpPoseLagrange.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseLagrange.cpp
@@ -251,106 +251,48 @@ static void lagrange(vpMatrix &a, vpMatrix &b, vpColVector &x1, vpColVector &x2)
 \brief  Compute the pose of a planar object using Lagrange approach.
 
 \param cMo : Estimated pose. No initialisation is requested to estimate cMo.
+\param p_a : if different from NULL, the a coefficient of the plan formed by the points.
+\param p_b : if different from NULL, the b coefficient of the plan formed by the points.
+\param p_c : if different from NULL, the c coefficient of the plan formed by the points.
+\param p_d : if different from NULL, the d coefficient of the plan formed by the points.
 */
 
-void vpPose::poseLagrangePlan(vpHomogeneousMatrix &cMo)
+void vpPose::poseLagrangePlan(vpHomogeneousMatrix &cMo, bool *p_isPlan, double *p_a, double *p_b, double *p_c, double *p_d)
 {
 #if (DEBUG_LEVEL1)
   std::cout << "begin vpPose::PoseLagrangePlan(...) " << std::endl;
 #endif
   // determination of the plane equation a X + b Y + c Z + d = 0
-  // FC : long copy/paste from vpPose::coplanar. To be improved...
-  vpPoint P1, P2, P3;
-  double x1 = 0, x2 = 0, x3 = 0, y1 = 0, y2 = 0, y3 = 0, z1 = 0, z2 = 0, z3 = 0;
-
-  // Get three 3D points that are not collinear and that are not at origin
-  // FC : I think one point could be at origin (to be checked)
-
-  bool degenerate = true;
-  bool not_on_origin = true;
-  std::list<vpPoint>::const_iterator it_tmp;
-
-  std::list<vpPoint>::const_iterator it_i, it_j, it_k;
-  for (it_i = listP.begin(); it_i != listP.end(); ++it_i) {
-    if (degenerate == false) {
-      // std::cout << "Found a non degenerate configuration" << std::endl;
-      break;
+  double a, b, c, d;
+  
+  // Checking if coplanar has already been called and if the plan coefficients have been given
+  if((p_isPlan != NULL) && (p_a != NULL) && (p_b != NULL) && (p_c != NULL) && (p_d != NULL))
+  {
+    if(*p_isPlan)
+    {
+      // All the pointers towards the plan coefficients are different from NULL => using them in the rest of the method
+      a = *p_a;
+      b = *p_b;
+      c = *p_c;
+      d = *p_d;
     }
-    P1 = *it_i;
-    // Test if point is on origin
-    if ((std::fabs(P1.get_oX()) <= std::numeric_limits<double>::epsilon()) &&
-        (std::fabs(P1.get_oY()) <= std::numeric_limits<double>::epsilon()) &&
-        (std::fabs(P1.get_oZ()) <= std::numeric_limits<double>::epsilon())) {
-      not_on_origin = false;
-    } else {
-      not_on_origin = true;
-    }
-    if (not_on_origin) {
-      it_tmp = it_i;
-      ++it_tmp; // j = i+1
-      for (it_j = it_tmp; it_j != listP.end(); ++it_j) {
-        if (degenerate == false) {
-          // std::cout << "Found a non degenerate configuration" << std::endl;
-          break;
-        }
-        P2 = *it_j;
-        if ((std::fabs(P2.get_oX()) <= std::numeric_limits<double>::epsilon()) &&
-            (std::fabs(P2.get_oY()) <= std::numeric_limits<double>::epsilon()) &&
-            (std::fabs(P2.get_oZ()) <= std::numeric_limits<double>::epsilon())) {
-          not_on_origin = false;
-        } else {
-          not_on_origin = true;
-        }
-        if (not_on_origin) {
-          it_tmp = it_j;
-          ++it_tmp; // k = j+1
-          for (it_k = it_tmp; it_k != listP.end(); ++it_k) {
-            P3 = *it_k;
-            if ((std::fabs(P3.get_oX()) <= std::numeric_limits<double>::epsilon()) &&
-                (std::fabs(P3.get_oY()) <= std::numeric_limits<double>::epsilon()) &&
-                (std::fabs(P3.get_oZ()) <= std::numeric_limits<double>::epsilon())) {
-              not_on_origin = false;
-            } else {
-              not_on_origin = true;
-            }
-            if (not_on_origin) {
-              x1 = P1.get_oX();
-              x2 = P2.get_oX();
-              x3 = P3.get_oX();
-
-              y1 = P1.get_oY();
-              y2 = P2.get_oY();
-              y3 = P3.get_oY();
-
-              z1 = P1.get_oZ();
-              z2 = P2.get_oZ();
-              z3 = P3.get_oZ();
-
-              vpColVector a_b(3), b_c(3), cross_prod;
-              a_b[0] = x1 - x2;
-              a_b[1] = y1 - y2;
-              a_b[2] = z1 - z2;
-              b_c[0] = x2 - x3;
-              b_c[1] = y2 - y3;
-              b_c[2] = z2 - z3;
-
-              cross_prod = vpColVector::crossProd(a_b, b_c);
-              if (cross_prod.sumSquare() <= std::numeric_limits<double>::epsilon())
-                degenerate = true; // points are collinear
-              else
-                degenerate = false;
-            }
-            if (degenerate == false)
-              break;
-          }
-        }
-      }
+    else
+    {
+      // The call to coplanar that was performed outside vpPose::poseLagrangePlan indicated that the points are not coplanar.
+      throw vpException(vpException::fatalError, "Called vpPose::poseLagrangePlan but the call to vpPose::coplanar done outside the method indicated that the points are not coplanar");
     }
   }
-  double a = y1 * z2 - y1 * z3 - y2 * z1 + y2 * z3 + y3 * z1 - y3 * z2;
-  double b = -x1 * z2 + x1 * z3 + x2 * z1 - x2 * z3 - x3 * z1 + x3 * z2;
-  double c = x1 * y2 - x1 * y3 - x2 * y1 + x2 * y3 + x3 * y1 - x3 * y2;
-  double d = -x1 * y2 * z3 + x1 * y3 * z2 + x2 * y1 * z3 - x2 * y3 * z1 - x3 * y1 * z2 + x3 * y2 * z1;
+  else
+  {
+    // At least one of the coefficient is a NULL pointer => calling coplanar by ourselves
+    int coplanarType;
+    bool areCoplanar = coplanar(coplanarType, &a, &b, &c, &d);
+    if(!areCoplanar)
+    {
+      throw vpException(vpException::fatalError, "Called vpPose::poseLagrangePlan but call to vpPose::coplanar indicates that the points are not coplanar");
+    }
+  }
+  
 
   if (c < 0.0) { // imposing c >= 0
     a = -a;


### PR DESCRIPTION
vpPose::coplanar can now indicates the computed plan coefficients + uses the 3D points after shuffling them in order to reduce the risk of using points close to each other. vpPose::poseLagrangePlan uses the a, b, c, d computed by coplanar instead of doing the job twice and throw an error if coplanar return false