### PR TITLE
vpRGBa and vpRGBf : allow == and != for const variables

### DIFF
--- a/modules/core/include/visp3/core/vpRGBa.h
+++ b/modules/core/include/visp3/core/vpRGBa.h
@@ -125,8 +125,8 @@ public:
   vpRGBa &operator=(const vpRGBa &&v);
 #endif
   vpRGBa &operator=(const vpColVector &v);
-  bool operator==(const vpRGBa &v);
-  bool operator!=(const vpRGBa &v);
+  bool operator==(const vpRGBa &v) const;
+  bool operator!=(const vpRGBa &v) const;
 
   vpColVector operator-(const vpRGBa &v) const;
   vpRGBa operator+(const vpRGBa &v) const;

--- a/modules/core/include/visp3/core/vpRGBf.h
+++ b/modules/core/include/visp3/core/vpRGBf.h
@@ -108,8 +108,8 @@ public:
   vpRGBf &operator=(const vpRGBf &&v);
 #endif
   vpRGBf &operator=(const vpColVector &v);
-  bool operator==(const vpRGBf &v);
-  bool operator!=(const vpRGBf &v);
+  bool operator==(const vpRGBf &v) const;
+  bool operator!=(const vpRGBf &v) const;
 
   vpColVector operator-(const vpRGBf &v) const;
   vpRGBf operator+(const vpRGBf &v) const;

--- a/modules/core/src/image/vpRGBa.cpp
+++ b/modules/core/src/image/vpRGBa.cpp
@@ -115,25 +115,16 @@ vpRGBa &vpRGBa::operator=(const vpColVector &v)
 
   \return true if the values are the same, false otherwise.
 */
-bool vpRGBa::operator==(const vpRGBa &v)
+bool vpRGBa::operator==(const vpRGBa &v) const
 {
-  if (R != v.R)
-    return false;
-  if (G != v.G)
-    return false;
-  if (B != v.B)
-    return false;
-  if (A != v.A)
-    return false;
-
-  return true;
+  return R == v.R && G == v.G && B == v.B && A == v.A;
 }
 /*!
   Compare two color pixels.
 
   \return true if the images are different, false if they are the same.
 */
-bool vpRGBa::operator!=(const vpRGBa &v) { return (R != v.R || G != v.G || B != v.B || A != v.A); }
+bool vpRGBa::operator!=(const vpRGBa &v) const { return (R != v.R || G != v.G || B != v.B || A != v.A); }
 
 /*!
   subtraction operator : "this" - v.

--- a/modules/core/src/image/vpRGBf.cpp
+++ b/modules/core/src/image/vpRGBf.cpp
@@ -107,7 +107,7 @@ vpRGBf &vpRGBf::operator=(const vpColVector &v)
 
   \return true if the values are exactly the same, false otherwise.
 */
-bool vpRGBf::operator==(const vpRGBf &v)
+bool vpRGBf::operator==(const vpRGBf &v) const
 {
   if (std::fabs(R - v.R) > std::numeric_limits<float>::epsilon())
     return false;
@@ -123,7 +123,7 @@ bool vpRGBf::operator==(const vpRGBf &v)
 
   \return true if the values are different, false if they are exactly the same.
 */
-bool vpRGBf::operator!=(const vpRGBf &v)
+bool vpRGBf::operator!=(const vpRGBf &v) const
 {
   return (std::fabs(R - v.R) > std::numeric_limits<float>::epsilon() ||
           std::fabs(G - v.G) > std::numeric_limits<float>::epsilon() ||


### PR DESCRIPTION
As of now, the definition of the operators `==` and `!=` of the `vpRGBa` and `vpRGBf` were not marked as const.
This prevents the user of doing the following:

```
const vpRGBa c1 = ...;
const vpRGBa c2 = ...;

const bool x = c1 == c2; // or !=, this fails as c1 is marked as const and == is not
```

This PR marks the operators as const allowing the behaviour above.
I also simplified the operator == of the `vpRGBa` class to avoid unecessary `if` (replaced by a simple boolean expression, same as in the != operator).