### PR TITLE
Feature: JSON integration in ViSP: Model-based tracker configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -610,6 +610,7 @@ VP_OPTION(USE_ZBAR        ZBAR         ""    "Include zbar support"         "" O
 VP_OPTION(USE_DMTX        DMTX         ""    "Include dmtx support"         "" ON IF NOT WINRT AND NOT IOS)
 VP_OPTION(USE_PCL         PCL          QUIET "Include Point Cloud Library support" "" ON IF NOT WINRT AND NOT IOS)
 VP_OPTION(USE_TENSORRT    TensorRT     ""    "Include TensorRT support"     "" ON IF NOT WINRT AND NOT IOS)
+VP_OPTION(USE_NLOHMANN_JSON  nlohmann_json  "" "Include nlohmann json support" "" ON)
 
 # ----------------------------------------------------------------------------
 # Handle cxx standard depending on specific 3rd parties. Should be before module parsing and VISP3rdParty.cmake include
@@ -918,6 +919,7 @@ VP_SET(VISP_HAVE_PTHREAD     TRUE IF (BUILD_MODULE_visp_core AND USE_PTHREAD))
 VP_SET(VISP_HAVE_XML2        TRUE IF (BUILD_MODULE_visp_core AND USE_XML2))
 VP_SET(VISP_HAVE_PCL         TRUE IF (BUILD_MODULE_visp_core AND USE_PCL))
 VP_SET(VISP_HAVE_TENSORRT    TRUE IF (BUILD_MODULE_visp_core AND USE_TENSORRT))
+VP_SET(VISP_HAVE_NLOHMANN_JSON   TRUE IF (BUILD_MODULE_visp_core AND USE_NLOHMANN_JSON))
 
 VP_SET(VISP_HAVE_OGRE        TRUE IF (BUILD_MODULE_visp_ar AND USE_OGRE))
 VP_SET(VISP_HAVE_OIS         TRUE IF (BUILD_MODULE_visp_ar AND USE_OIS))
@@ -1617,6 +1619,7 @@ status("  Misc: ")
 status("    Use Clipper (built-in):"  WITH_CLIPPER     THEN "yes (ver ${CLIPPER_VERSION})" ELSE "no")
 status("    Use pugixml (built-in):"                        "yes (ver ${PUGIXML_VERSION})")
 status("    Use libxml2:"             USE_XML2         THEN "yes (ver ${XML2_VERSION_STRING})" ELSE "no")
+status("    Use json (nlohmann):"     USE_NLOHMANN_JSON THEN "yes (ver ${nlohmann_json_VERSION})" ELSE "no")
 status("")
 status("  Optimization: ")
 status("    Use OpenMP:"             USE_OPENMP         THEN "yes" ELSE "no")

--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -481,6 +481,9 @@
 // Defined if we want to use openmp
 #cmakedefine VISP_HAVE_OPENMP
 
+// Defined if nlohmann json parser is found
+#cmakedefine VISP_HAVE_NLOHMANN_JSON
+
 // Define c++ standard values also available in __cplusplus when gcc is used
 #define VISP_CXX_STANDARD_98 ${VISP_CXX_STANDARD_98}
 #define VISP_CXX_STANDARD_11 ${VISP_CXX_STANDARD_11}

--- a/doc/config-doxygen.in
+++ b/doc/config-doxygen.in
@@ -2180,6 +2180,7 @@ PREDEFINED             = @DOXYGEN_SHOULD_SKIP_THIS@ \
                          VISP_HAVE_LIBFREENECT_AND_DEPENDENCIES \
                          VISP_HAVE_LIBUSB_1 \
                          VISP_HAVE_MAVSDK \
+                         VISP_HAVE_NLOHMANN_JSON \
                          VISP_HAVE_OCCIPITAL_STRUCTURE \
                          VISP_HAVE_OGRE \
                          VISP_HAVE_OGRE_PLUGINS_PATH \

--- a/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
+++ b/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
@@ -379,7 +379,51 @@ Other common settings include:
 
 \subsubsection json-feature-settings Tracker Feature settings
 
+
 Each type of tracked feature can be customized in the JSON file.
+
+\section json-settings-usage Example: Initializing a tracker from a JSON file 
+
+Let's now look at an example of how to use JSON to track an object.
+
+This example is similar to tutorial-mb-generic-tracker-rgbd-realsense.cpp, where an XML configuration file is used to configure camera per camera.
+Instead, here, we will use a JSON file to fully configure the tracker.
+
+The full code can be found in tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp
+
+To run the example:
+\code{.sh}
+# If no CAD model is defined in the JSON file
+./tutorial-mb-generic-tracker-rgbd-realsense-json-settings --config model/cube/realsense-color-and-depth.json --model model/cube/cube.cao
+
+# If CAD model is defined in JSON
+./tutorial-mb-generic-tracker-rgbd-realsense-json-settings --config model/cube/realsense-color-and-depth.json 
+\endcode
+
+The main difference with tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp is that specifying which features to use is done in the config file.
+
+First, we initialize the camera (here, a Realsense2 camera) and query the camera intrinsics, as well as declare the vpImage we will use to store the data feed and display it
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Init
+
+To load the json configuration, we simply call:
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Loading
+
+We then query what features are used by the tracker and update its input accordingly
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Init maps
+
+To finish with the configuration, we load the 3D CAD model if none was defined in the JSON file. If none is given by the user, then an exception is thrown.
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Load 3D model
+
+To ensure the best performance, we might still prefer to use the camera intrinsics and transformation between color and depth cameras by provided the Realsense SDK.
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Update params
+
+We then initialize tracking by click:
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Init tracking
+
+Finally, we can start tracking:
+\snippet tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp Tracking
+
+
 
 
 */

--- a/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
+++ b/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
@@ -8,132 +8,19 @@ With the inclusion of a 3rd-party JSON serialization library into ViSP, it is no
 
 A case that is of particular interest is the configuration of the generic Model-Based Tracker. As this tracker is complex, providing an easy to use configuration file is essential.
 Loading the configuration for each camera is already possible with XML (already used in \ref tutorial-tracking-mb-generic-rgbd). 
-This however, does not load the full state of the tracker but rather the configuration of each camera.
+This however, does not load the full state of the tracker but rather the configuration of each camera and combining everything is left to the user.
 
 With JSON serialization, a single file stores the full configuration of the generic tracker, containing the configuration of each camera, their associated name as well as their transformation with respect to the reference camera.
 Moreover, the path to the 3D model can be given in the JSON file and the model will be directly loaded.
 
-
 \section tutorial-mb-generic-json-structure JSON file structure
 Let us first examine the structure of a JSON file used to load a vpMbGenericTracker, given below:
-\code{.json}
-{
-    "referenceCameraName": "Camera1",
-    "trackers": {
-        "Camera1": {
-            "angleAppear": 65.0,
-            "angleDisappear": 75.00000000000001,
-            "camTref": [
-                1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
-                0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
-            ],
-            "camera": {
-                "model": "perspectiveWithoutDistortion",
-                "px": 605.146728515625,
-                "py": 604.79150390625,
-                "u0": 325.53253173828125,
-                "v0": 244.95083618164063
-            },
-            "clipping": {
-                "far": 0.9,
-                "near": 0.1,
-                "useFOVClipping": false
-            },
-            "display": {
-                "features": true,
-                "projectionError": true
-            },
-            "edge_tracker": {
-                "angleStep": 1,
-                "maskSign": 0,
-                "maskSize": 5,
-                "minSampleStep": 4.0,
-                "mu": [
-                    0.5,
-                    0.5
-                ],
-                "nMask": 180,
-                "ntotal_sample": 0,
-                "pointsToTrack": 500,
-                "range": 7,
-                "sampleStep": 4.0,
-                "strip": 2,
-                "threshold": 5000.0
-            },
-            "klt": {
-                "blockSize": 3,
-                "harris": 0.01,
-                "maskBorder": 5,
-                "maxFeatures": 300,
-                "minDistance": 5.0,
-                "pyramidLevels": 3,
-                "quality": 0.01,
-                "windowSize": 5
-            },
-            "lod": {
-                "minLineLengthThresholdGeneral": 50.0,
-                "minPolygonAreaThresholdGeneral": 2500.0,
-                "useLod": false
-            },
-            "type": [
-                "edge",
-                "klt"
-            ],
-            "visibilityTest": {
-                "ogre": false,
-                "scanline": true
-            }
-        },
-        "Camera2": {
-            "angleAppear": 70.0,
-            "angleDisappear": 80.0,
-            "camTref": [
-                0.999972403049469, -0.006713358219712973, -0.003179509425535798, -0.01465611346065998,
-                0.006699616555124521, 0.9999682307243347, -0.004313052631914616, 9.024870814755559e-05,
-                0.003208363428711891, 0.00429163221269846, 0.9999856352806091, -0.0004482123476918787,
-                0.0, 0.0, 0.0, 1.0
-            ],
-            "camera": {
-                "model": "perspectiveWithoutDistortion",
-                "px": 381.7528076171875,
-                "py": 381.7528076171875,
-                "u0": 323.3261413574219,
-                "v0": 236.82505798339844
-            },
-            "clipping": {
-                "far": 2.0,
-                "near": 0.01,
-                "useFOVClipping": false
-            },
-            "dense": {
-                "sampling": {
-                    "x": 1,
-                    "y": 1
-                }
-            },
-            "display": {
-                "features": true,
-                "projectionError": true
-            },
-            "lod": {
-                "minLineLengthThresholdGeneral": 50.0,
-                "minPolygonAreaThresholdGeneral": 2500.0,
-                "useLod": false
-            },
-            "type": [
-                "depthDense"
-            ],
-            "visibilityTest": {
-                "ogre": false,
-                "scanline": true
-            }
-        }
-    }
-}
-\endcode
+\include realsense-color-and-depth.json
+
 
 Many settings are optional: if a setting is not present in the .json file, then the value already set in the tracker is kept.
-This means that the .json can contain a partial configuration, while the rest is of the configuration is done in the code.
+This means that the .json can contain a partial configuration, while the rest of the configuration is done in the code.
+Beware however, that previously defined cameras that are not in the .json file are removed.
 
 As this file is fairly dense, let us examine each part separetely so that you may tweak it for your use case.
 
@@ -158,6 +45,12 @@ If they are defined globally, they will take precedence over the values defined 
 
 <table>
 <tr><th colspan="2">Key</th><th>Type</th><th>Description</th><th>Optional</th></tr>
+<tr>
+    <td colspan="2">version</td>
+    <td>String</td>
+    <td>Version of the JSON parsing for the MBT tracker</td>
+    <td>No</td>
+</tr>
 <tr>
     <td colspan="2">referenceCameraName</td>
     <td>String</td>
@@ -205,108 +98,24 @@ If they are defined globally, they will take precedence over the values defined 
 
 \subsection json-per-tracker-settings Individual camera tracker settings
 
-Each camera has a name (the key in the "trackers" dictionary, e.g., "Camera1", "Camera2") and is associated to a combination of tracker.
+Each camera has a name (the key in the "trackers" dictionary, e.g., "Color", "Depth") and is associated to a combination of tracker.
 
-First, consider, the tracker for the key "Camera1":
-\code{.json}
-//...
-"Camera1": {
-    "angleAppear": 65.0,
-    "angleDisappear": 75.00000000000001,
-    "camTref": [
-        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
-    ],
-    "camera": {
-        "model": "perspectiveWithoutDistortion",
-        "px": 605.146728515625,
-        "py": 604.79150390625,
-        "u0": 325.53253173828125,
-        "v0": 244.95083618164063
-    },
-    "clipping": {
-        "far": 0.9,
-        "near": 0.1,
-        "useFOVClipping": false
-    },
-    "display": {
-        "features": true,
-        "projectionError": true
-    },
-    "edge_tracker": {
-        "angleStep": 1,
-        "maskSign": 0,
-        "maskSize": 5,
-        "minSampleStep": 4.0,
-        "mu": [
-            0.5,
-            0.5
-        ],
-        "nMask": 180,
-        "ntotal_sample": 0,
-        "pointsToTrack": 500,
-        "range": 7,
-        "sampleStep": 4.0,
-        "strip": 2,
-        "threshold": 5000.0
-    },
-    "klt": {
-        "blockSize": 3,
-        "harris": 0.01,
-        "maskBorder": 5,
-        "maxFeatures": 300,
-        "minDistance": 5.0,
-        "pyramidLevels": 3,
-        "quality": 0.01,
-        "windowSize": 5
-    },
-    "lod": {
-        "minLineLengthThresholdGeneral": 50.0,
-        "minPolygonAreaThresholdGeneral": 2500.0,
-        "useLod": false
-    },
-    "type": [
-        "edge",
-        "klt"
-    ],
-    "visibilityTest": {
-        "ogre": false,
-        "scanline": true
-    }
-} //...
-\endcode
+First, consider, the tracker for the key "Color":
+\snippet realsense-color-and-depth.json.example Color
 
 This JSON object contains multiple components which we'll go through one by one.
 
 First each camera-specific tracker definition must contain its type. Here, it is defined as:
-\code{.json}
-"type": [
-    "edge",
-    "klt"
-],
-\endcode
+\snippet realsense-color-and-depth.json.example Features
 stating that this tracker uses both edge (see the vpMe class) and KLT (see vpKltOpencv) features. other possible values are "depthDense" and "depthNormal" for depth-related features.
 
 the next important definition is:
-\code{.json}
-"camTref": [
-    1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
-    0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
-],
-\endcode
-Describing the transformation between this camera and the reference camera. 
+\snippet realsense-color-and-depth.json.example Transformation
+Describing the transformation between this camera and the reference camera. It can also be given as a vpPoseVector JSON representation
 If the current camera is the reference, then "camTref" may be ommitted or set as the identity transformation.
 
 Next, we must define the camera intrinsics (see vpCameraParameters):
-\code{.json}
-"camera": {
-    "model": "perspectiveWithoutDistortion",
-    "px": 605.146728515625,
-    "py": 604.79150390625,
-    "u0": 325.53253173828125,
-    "v0": 244.95083618164063
-},
-\endcode
+\snippet realsense-color-and-depth.json.example Camera
 This JSON object follows the convention defined in vpCameraParameters::from_json.
 
 Other common settings include:
@@ -328,9 +137,11 @@ Other common settings include:
 </tr>
 <tr><th colspan="5">clipping (optional)</th></tr>
 <tr>
-    <td>useFovClipping</td>
-    <td>boolean</td>
-    <td>Whether to use field of view clipping.</td>
+    <td>flags</td>
+    <td>List of vpPolygon3D::vpPolygon3DClippingType</td>
+    <td>The clipping flags used for this tracker. a list that can combine different values in:
+    ["none", "all", "fov", "left", "right", "top", "down", "near", "far"]
+    </td>
     <td>vpPolygon3D, vpMbTracker::setClipping</td>
     <td>Yes</td>
 </tr>
@@ -379,8 +190,33 @@ Other common settings include:
 
 \subsubsection json-feature-settings Tracker Feature settings
 
-
 Each type of tracked feature can be customized in the JSON file.
+
+<h4>Edge</h4>
+Edge feature parameters are defined by the conversion vpMe::from_json
+All parameters are optional: if not filled in the JSON file, then the value that is already set will be used
+
+Example configuration (all parameters):
+\snippet realsense-color-and-depth.json.example Edge
+
+<h4>KLT</h4>
+Each parameter of the KLT tracker (see vpKltOpencv) is optional: if not present it will be set to a fixed default value.
+
+The default configuration is:
+\snippet realsense-color-and-depth.json.example KLT
+<h4>Depth normals</h4>
+The configuration for the depth normal features is the following
+\snippet realsense-color-and-depth.json.example DepthNormal
+
+the "featureEstimationMethod" must be one of "robust", "robustSVD" or "pcl". The latter requires PCL to be installed.
+
+See vpMbDepthNormalTracker for more details.
+
+<h4>Dense depth</h4>
+The configuration for the dense depth features only contain the sampling step, as shown below:
+\snippet realsense-color-and-depth.json.example DepthDense
+
+
 
 \section json-settings-usage Example: Initializing a tracker from a JSON file 
 

--- a/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
+++ b/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
@@ -1,0 +1,209 @@
+/**
+
+\page tutorial-mb-generic-json Tutorial: Loading a model-based generic tracker from JSON
+\tableofcontents
+
+\section tutorial-mb-generic-json-intro Introduction
+With the inclusion of a 3rd-party JSON serialization library into ViSP, it is now possible to store and load a variety of ViSP datatypes in JSON format.
+
+A case that is of particular interest is the configuration of the generic Model-Based Tracker. As this tracker is complex, providing an easy to use configuration file is essential.
+Loading the configuration for each camera is already possible with XML (already used in \ref tutorial-tracking-mb-generic-rgbd). 
+This however, does not load the full state of the tracker but rather the configuration of each camera.
+
+With JSON serialization, a single file stores the full configuration of the generic tracker, containing the configuration of each camera, their associated name as well as their transformation with respect to the reference camera.
+Moreover, the path to the 3D model can be given in the JSON file and the model will be directly loaded.
+
+
+\section tutorial-mb-generic-json-structure JSON file structure
+Let us first examine the structure of a JSON file used to load a vpMbGenericTracker, given below:
+\code{.json}
+{
+    "referenceCameraName": "Camera1",
+    "trackers": {
+        "Camera1": {
+            "angleAppear": 65.0,
+            "angleDisappear": 75.00000000000001,
+            "camTref": [
+                1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
+            ],
+            "camera": {
+                "model": "perspectiveWithoutDistortion",
+                "px": 605.146728515625,
+                "py": 604.79150390625,
+                "u0": 325.53253173828125,
+                "v0": 244.95083618164063
+            },
+            "clipping": {
+                "far": 0.9,
+                "near": 0.1,
+                "useFOVClipping": false
+            },
+            "display": {
+                "features": true,
+                "projectionError": true
+            },
+            "edge_tracker": {
+                "angleStep": 1,
+                "maskSign": 0,
+                "maskSize": 5,
+                "minSampleStep": 4.0,
+                "mu": [
+                    0.5,
+                    0.5
+                ],
+                "nMask": 180,
+                "ntotal_sample": 0,
+                "pointsToTrack": 500,
+                "range": 7,
+                "sampleStep": 4.0,
+                "strip": 2,
+                "threshold": 5000.0
+            },
+            "klt": {
+                "blockSize": 3,
+                "harris": 0.01,
+                "maskBorder": 5,
+                "maxFeatures": 300,
+                "minDistance": 5.0,
+                "pyramidLevels": 3,
+                "quality": 0.01,
+                "windowSize": 5
+            },
+            "lod": {
+                "minLineLengthThresholdGeneral": 50.0,
+                "minPolygonAreaThresholdGeneral": 2500.0,
+                "useLod": false
+            },
+            "type": [
+                "edge",
+                "klt"
+            ],
+            "visibilityTest": {
+                "ogre": false,
+                "scanline": true
+            }
+        },
+        "Camera2": {
+            "angleAppear": 70.0,
+            "angleDisappear": 80.0,
+            "camTref": [
+                0.999972403049469, -0.006713358219712973, -0.003179509425535798, -0.01465611346065998,
+                0.006699616555124521, 0.9999682307243347, -0.004313052631914616, 9.024870814755559e-05,
+                0.003208363428711891, 0.00429163221269846, 0.9999856352806091, -0.0004482123476918787,
+                0.0, 0.0, 0.0, 1.0
+            ],
+            "camera": {
+                "model": "perspectiveWithoutDistortion",
+                "px": 381.7528076171875,
+                "py": 381.7528076171875,
+                "u0": 323.3261413574219,
+                "v0": 236.82505798339844
+            },
+            "clipping": {
+                "far": 2.0,
+                "near": 0.01,
+                "useFOVClipping": false
+            },
+            "dense": {
+                "sampling": {
+                    "x": 1,
+                    "y": 1
+                }
+            },
+            "display": {
+                "features": true,
+                "projectionError": true
+            },
+            "lod": {
+                "minLineLengthThresholdGeneral": 50.0,
+                "minPolygonAreaThresholdGeneral": 2500.0,
+                "useLod": false
+            },
+            "type": [
+                "depthDense"
+            ],
+            "visibilityTest": {
+                "ogre": false,
+                "scanline": true
+            }
+        }
+    }
+}
+\endcode
+
+Many settings are optional: if a setting is not present in the .json file, then the value already set in the tracker is kept.
+This means that the .json can contain a partial configuration, while the rest is of the configuration is done in the code.
+
+As this file is fairly dense, let us examine each part separetely so that you may tweak it for your use case.
+
+\subsection json-global-tracker-settings Global tracker settings
+
+Let us first examine the global settings (located at the root of the JSON structure). Some settings are optional such as:
+
+\code{.json}
+    //...
+    "model": "../models/cube/cube.cao",
+    "display": {
+        "features": true,
+        "projectionError": true
+    },
+    "visibilityTest": {
+        "ogre": false,
+        "scanline": true
+    }
+\endcode
+
+If they are defined globally, they will take precedence over the values defined per tracker.
+
+<table>
+<tr><th colspan="2">Key</th><th>Type</th><th>Description</th><th>Optional</th></tr>
+<tr>
+    <td colspan="2">referenceCameraName</td>
+    <td>String</td>
+    <td>The name of the reference camera, see vpMbGenericTracker::getReferenceCameraName</td>
+    <td>No</td>
+</tr>
+<tr>
+    <td colspan="2">trackers</td>
+    <td>Dictionary</td>
+    <td>The set of camera trackers. Each element of the dictionary associates a camera name to a tracker, that is parsed with vpMbGenericTracker::from_json</td>
+    <td>No</td>
+</tr>
+<tr>
+    <td colspan="2">model</td>
+    <td>String</td>
+    <td>The path to a .cao model file, describing the object to track. See vpMbGenericTracker::loadModel</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td colspan="2">display:features</td>
+    <td>boolean</td>
+    <td>Show features when calling vpMbGenericTracker::display.</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td colspan="2">display:projectionError</td>
+    <td>boolean</td>
+    <td>Whether to display the projection error when calling vpMbGenericTracker::display</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td colspan="2">visibilityTest:scanline</td>
+    <td>boolean</td>
+    <td>Whether to use scanline for visibility testing. see vpMbGenericTracker::setScanLineVisibilityTest</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td colspan="2">visibilityTest:ogre</td>
+    <td>boolean</td>
+    <td>Whether to use ogre for visibility testing. OGRE must be installed, otherwise ignored. See vpMbGenericTracker::setOgreVisibilityTest</td>
+    <td>Yes</td>
+</tr>
+</table>
+
+
+\subsection json-per-tracker-settings Individual camera tracker settings
+
+
+*/

--- a/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
+++ b/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
@@ -205,5 +205,181 @@ If they are defined globally, they will take precedence over the values defined 
 
 \subsection json-per-tracker-settings Individual camera tracker settings
 
+Each camera has a name (the key in the "trackers" dictionary, e.g., "Camera1", "Camera2") and is associated to a combination of tracker.
+
+First, consider, the tracker for the key "Camera1":
+\code{.json}
+//...
+"Camera1": {
+    "angleAppear": 65.0,
+    "angleDisappear": 75.00000000000001,
+    "camTref": [
+        1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
+    ],
+    "camera": {
+        "model": "perspectiveWithoutDistortion",
+        "px": 605.146728515625,
+        "py": 604.79150390625,
+        "u0": 325.53253173828125,
+        "v0": 244.95083618164063
+    },
+    "clipping": {
+        "far": 0.9,
+        "near": 0.1,
+        "useFOVClipping": false
+    },
+    "display": {
+        "features": true,
+        "projectionError": true
+    },
+    "edge_tracker": {
+        "angleStep": 1,
+        "maskSign": 0,
+        "maskSize": 5,
+        "minSampleStep": 4.0,
+        "mu": [
+            0.5,
+            0.5
+        ],
+        "nMask": 180,
+        "ntotal_sample": 0,
+        "pointsToTrack": 500,
+        "range": 7,
+        "sampleStep": 4.0,
+        "strip": 2,
+        "threshold": 5000.0
+    },
+    "klt": {
+        "blockSize": 3,
+        "harris": 0.01,
+        "maskBorder": 5,
+        "maxFeatures": 300,
+        "minDistance": 5.0,
+        "pyramidLevels": 3,
+        "quality": 0.01,
+        "windowSize": 5
+    },
+    "lod": {
+        "minLineLengthThresholdGeneral": 50.0,
+        "minPolygonAreaThresholdGeneral": 2500.0,
+        "useLod": false
+    },
+    "type": [
+        "edge",
+        "klt"
+    ],
+    "visibilityTest": {
+        "ogre": false,
+        "scanline": true
+    }
+} //...
+\endcode
+
+This JSON object contains multiple components which we'll go through one by one.
+
+First each camera-specific tracker definition must contain its type. Here, it is defined as:
+\code{.json}
+"type": [
+    "edge",
+    "klt"
+],
+\endcode
+stating that this tracker uses both edge (see the vpMe class) and KLT (see vpKltOpencv) features. other possible values are "depthDense" and "depthNormal" for depth-related features.
+
+the next important definition is:
+\code{.json}
+"camTref": [
+    1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0,
+    0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0
+],
+\endcode
+Describing the transformation between this camera and the reference camera. 
+If the current camera is the reference, then "camTref" may be ommitted or set as the identity transformation.
+
+Next, we must define the camera intrinsics (see vpCameraParameters):
+\code{.json}
+"camera": {
+    "model": "perspectiveWithoutDistortion",
+    "px": 605.146728515625,
+    "py": 604.79150390625,
+    "u0": 325.53253173828125,
+    "v0": 244.95083618164063
+},
+\endcode
+This JSON object follows the convention defined in vpCameraParameters::from_json.
+
+Other common settings include:
+<table>
+<tr><th>Key</th><th>Type</th><th>Description</th><th>Reference</th><th>Optional</th></tr>
+<tr>
+    <td>angleAppear</td>
+    <td>float</td>
+    <td>Angle at which a face is considered as appearing, defined in degrees.</td>
+    <td>vpMbTracker::setAngleAppear</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>angleDisappear</td>
+    <td>float</td>
+    <td>Angle at which a face is considered as disappearing, defined in degrees.</td>
+    <td>vpMbTracker::setAngleDisappear</td>
+    <td>Yes</td>
+</tr>
+<tr><th colspan="5">clipping (optional)</th></tr>
+<tr>
+    <td>useFovClipping</td>
+    <td>boolean</td>
+    <td>Whether to use field of view clipping.</td>
+    <td>vpPolygon3D, vpMbTracker::setClipping</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>near</td>
+    <td>float</td>
+    <td>Near plane clipping distance.</td>
+    <td>vpMbTracker::setNearClippingDistance</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>far</td>
+    <td>float</td>
+    <td>Far plane clipping distance. </td>
+    <td>vpMbTracker::setFarClippingDistance</td>
+    <td>Yes</td>
+</tr>
+<tr><th colspan="5">lod (optional)</th></tr>
+<tr>
+    <td>useLod</td>
+    <td>boolean</td>
+    <td>Whether to use level of detail.</td>
+    <td>vpMbTracker::setLod</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>minLineLengthThresholdGeneral</td>
+    <td>float</td>
+    <td>Minimum line length to be considered as visible in LOD.</td>
+    <td>vpMbTracker::setMinLineLengthThresh</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>minPolygonAreaThresholdGeneral</td>
+    <td>float</td>
+    <td>Minimum polygon area to be considered as visible in LOD. </td>
+    <td>vpMbTracker::setMinPolygonAreaThresh</td>
+    <td>Yes</td>
+</tr>
+<tr><th colspan="5">display (optional)</th></tr>
+<tr><td colspan="5">See \ref json-global-tracker-settings</td></tr>
+<tr><th colspan="5">visibilityTest (optional)</th></tr>
+<tr><td colspan="5">See \ref json-global-tracker-settings</td></tr>
+</table>
+
+
+\subsubsection json-feature-settings Tracker Feature settings
+
+Each type of tracked feature can be customized in the JSON file.
+
 
 */

--- a/doc/tutorial/tutorial-users.dox
+++ b/doc/tutorial/tutorial-users.dox
@@ -91,6 +91,7 @@ This page introduces the user to the way to track objects in images.
 - \subpage tutorial-tracking-mb-generic-stereo <br>This tutorial focuses on model-based trackers using either edges, or keypoints, or a combination of them as visual features on images acquired by a stereo color camera.
 - \subpage tutorial-tracking-mb-generic-rgbd <br>This tutorial focuses on generic model-based trackers combining moving edges and/or keypoints with depth visual features.
 - \subpage tutorial-tracking-mb-generic-apriltag-live <br>This tutorial is a simple use case. Using a webcam or an Intel RGB-D camera it shows how to test the generic model tracker on a cube that has an AprilTag glued on one face. The tag is here used to automate the tracker initialization.
+- \subpage tutorial-mb-generic-json <br> This tutorial shows how to load and save the full tracker configuration from a json file.
 - \subpage tutorial-tracking-mb-deprecated <br>This deprecated tutorial focuses on model-based trackers using either edges, keypoints or and hybrid scheme that uses edges and keypoints.
 - \subpage tutorial-tracking-mb-CAO-editor <br>This tutorial presents the project done during the GSoC 2017: two Blender plugins to import/export .cao model file and a Qt-based .cao editor.
 - \subpage tutorial-tracking-mb-generic-rgbd-Blender <br>This tutorial shows how to use Blender to generate simulated data to test the model-based tracker.

--- a/doc/tutorial/unix/tutorial-install-centos.dox
+++ b/doc/tutorial/unix/tutorial-install-centos.dox
@@ -31,7 +31,7 @@ In this section, we give minimal instructions to build ViSP from source just to 
 
 - Install a small number of recommended 3rd parties
 \verbatim
-$ sudo yum install opencv-devel libX11-devel lapack-devel libv4l-devel libjpeg-devel libpng-devel
+$ sudo yum install opencv-devel libX11-devel lapack-devel libv4l-devel libjpeg-devel libpng-devel json-devel
 \endverbatim
 
 - Get ViSP source code
@@ -68,15 +68,16 @@ ViSP is interfaced with several 3rd party libraries. The <a href="http://visp.in
 
 We recommend to install the following:
 
-- OpenCV
-- libX11 to be able to open a window to display images
-- lapack and eigen to benefit from optimized mathematical capabilities
-- libdc1394 to grab images from firewire cameras
-- libv4l to grab images from usb or analogic cameras
+- `opencv` to get advanced image processing and computer vision features coming with ViSP
+- `libX11` to be able to open a window to display images
+- `lapack` and `eigen` to benefit from optimized mathematical capabilities
+- `libdc1394` to grab images from firewire cameras
+- `libv4l` to grab images from usb or analogic cameras
+- `nlohmann-json` to be able to parse json files
 
 Installation of recommended 3rd parties could be performed running:
 \verbatim
-$ sudo yum install opencv-devel libX11-devel lapack-devel libv4l-devel
+$ sudo yum install opencv-devel libX11-devel lapack-devel eigen3-devel libv4l-devel json-devel
 \endverbatim
 
 \subsubsection install_centos_3rdparty_other Other optional 3rd parties

--- a/doc/tutorial/unix/tutorial-install-fedora.dox
+++ b/doc/tutorial/unix/tutorial-install-fedora.dox
@@ -31,7 +31,7 @@ In this section, we give minimal instructions to build ViSP from source just to 
 
 - Install a small number of recommended 3rd parties
 \verbatim
-$ sudo dnf install opencv-devel libX11-devel lapack-devel eigen3-devel libdc1394-devel libv4l-devel zbar-devel libxcb-devel libjpeg-devel libpng-devel
+$ sudo dnf install opencv-devel libX11-devel lapack-devel eigen3-devel libdc1394-devel libv4l-devel zbar-devel libxcb-devel libjpeg-devel libpng-devel nlohmann-json-devel
 \endverbatim
 
 - Get ViSP source code
@@ -68,17 +68,17 @@ ViSP is interfaced with several optional 3rd party libraries. The <a href="http:
 
 We recommend to install the following:
 
-- OpenCV
-- libX11 to be able to open a window to display images
-- lapack and eigen to benefit from optimized mathematical capabilities
-- libdc1394 to grab images from firewire cameras
-- libv4l to grab images from usb or analogic cameras
-- libzbar to be able to detect QR codes
-- pthread library
+- `opencv` to get advanced image processing and computer vision features coming with ViSP
+- `libX11` to be able to open a window to display images
+- `lapack` and `eigen` to benefit from optimized mathematical capabilities
+- `libdc1394` to grab images from firewire cameras
+- `libv4l` to grab images from usb or analogic cameras
+- `libzbar` to be able to detect QR codes
+- `nlohmann-json` to be able to parse json files
 
 Installation of recommended 3rd parties could be performed running:
 \verbatim
-$ sudo dnf install opencv-devel libX11-devel lapack-devel eigen3-devel libdc1394-devel libv4l-devel zbar-devel libxcb-devel
+$ sudo dnf install opencv-devel libX11-devel lapack-devel eigen3-devel libdc1394-devel libv4l-devel zbar-devel libxcb-devel nlohmann-json-devel
 \endverbatim
 
 \subsubsection install_fedora_3rdparty_other Other optional 3rd parties
@@ -397,15 +397,15 @@ General configuration information for ViSP 3.4.1
 
   Python (for build):            /usr/bin/python
 
-  Java:                          
+  Java:
     ant:                         NO
     JNI:                         /usr/lib/jvm/java/include /usr/lib/jvm/java/include/linux /usr/lib/jvm/java/include
 
-  Build options: 
+  Build options:
     Build deprecated:            yes
     Build with moment combine:   no
 
-  Mathematics: 
+  Mathematics:
     Blas/Lapack:                 yes
     \- Use MKL:                  no
     \- Use OpenBLAS:             no
@@ -416,11 +416,11 @@ General configuration information for ViSP 3.4.1
     Use Eigen3:                  yes (ver 3.3.9)
     Use OpenCV:                  yes (ver 4.5.3)
 
-  Simulator: 
-    Ogre simulator: 
+  Simulator:
+    Ogre simulator:
     \- Use Ogre3D:               yes (ver 1.9.0)
     \- Use OIS:                  yes (ver 1.3.0)
-    Coin simulator: 
+    Coin simulator:
     \- Use Coin3D:               yes (ver 3.1.3)
     \- Use SoWin:                no
     \- Use SoXt:                 no
@@ -429,14 +429,14 @@ General configuration information for ViSP 3.4.1
     \- Use Qt4:                  no
     \- Use Qt3:                  no
 
-  Media I/O: 
+  Media I/O:
     Use JPEG:                    yes (ver 62)
     Use PNG:                     yes (ver 1.6.37)
     \- Use ZLIB:                 yes (ver 1.2.11)
     Use OpenCV:                  yes (ver 4.5.3)
     Use stb_image (built-in):    no
 
-  Real robots: 
+  Real robots:
     Use Afma4:                   no
     Use Afma6:                   no
     Use Franka:                  no
@@ -453,14 +453,14 @@ General configuration information for ViSP 3.4.1
     Use qbdevice (built-in):     yes (ver 2.6.0)
     Use takktile2 (built-in):    yes (ver 1.0.0)
 
-  GUI: 
+  GUI:
     Use X11:                     yes
     Use GTK:                     no
     Use OpenCV:                  yes (ver 4.5.3)
     Use GDI:                     no
     Use Direct3D:                no
 
-  Cameras: 
+  Cameras:
     Use DC1394-2.x:              yes (ver 2.2.6)
     Use CMU 1394:                no
     Use V4L2:                    yes (ver 1.22.1)
@@ -470,7 +470,7 @@ General configuration information for ViSP 3.4.1
     Use Basler Pylon:            no
     Use IDS uEye:                no
 
-  RGB-D sensors: 
+  RGB-D sensors:
     Use Realsense:               no
     Use Realsense2:              no
     Use Occipital Structure:     no
@@ -481,33 +481,33 @@ General configuration information for ViSP 3.4.1
     Use PCL:                     yes (ver 1.12.0)
     \- Use VTK:                  yes (ver 9.0.3)
 
-  F/T sensors: 
+  F/T sensors:
     Use atidaq (built-in):       no
     Use comedi:                  no
     Use IIT SDK:                 no
 
-  Detection: 
+  Detection:
     Use zbar:                    yes (ver 0.23)
     Use dmtx:                    yes (ver 0.7.5)
     Use AprilTag (built-in):     yes (ver 3.1.1)
     \- Use AprilTag big family:  no
 
-  Misc: 
+  Misc:
     Use Clipper (built-in):      yes (ver 6.4.2)
     Use pugixml (built-in):      yes (ver 1.9.0)
     Use libxml2:                 yes (ver 2.9.12)
 
-  Optimization: 
+  Optimization:
     Use OpenMP:                  yes
     Use pthread:                 yes
     Use pthread (built-in):      no
     Use cxx standard:            14
 
-  DNN: 
+  DNN:
     Use CUDA Toolkit:            no
     Use TensorRT:                no
 
-  Documentation: 
+  Documentation:
     Use doxygen:                 yes
 
   Tests and samples:

--- a/doc/tutorial/unix/tutorial-install-osx-homebrew.dox
+++ b/doc/tutorial/unix/tutorial-install-osx-homebrew.dox
@@ -82,15 +82,16 @@ ViSP is interfaced with several 3rd party libraries. The <a href="http://visp.in
 
 We recommend to install the following 3rd parties:
 
-- OpenCV to get advanced image processing and computer vision features coming with ViSP
-- libX11 to be able to open a window to display images
-- lapack and eigen to benefit from optimized mathematical capabilities
-- libdc1394 to grab images from firewire cameras
-- libzbar to be able to detect QR codes
+- `opencv` to get advanced image processing and computer vision features coming with ViSP
+- `libX11` to be able to open a window to display images
+- `lapack` and `eigen` to benefit from optimized mathematical capabilities
+- `libdc1394` to grab images from firewire cameras
+- `libzbar` to be able to detect QR codes
+- `nlohmann-json` to be able to parse json files
 
 Installation of recommended 3rd parties could be performed running:
 \verbatim
-$ brew install opencv glog lapack eigen libdc1394 zbar
+$ brew install opencv glog lapack eigen libdc1394 zbar nlohmann-json
 \endverbatim
 
 \subsubsection install_brew_3rdparty_realsense librealsense 3rd party

--- a/doc/tutorial/unix/tutorial-install-ubuntu.dox
+++ b/doc/tutorial/unix/tutorial-install-ubuntu.dox
@@ -38,13 +38,13 @@ In this section, we give minimal instructions to build ViSP from source just to 
   - Since Ubuntu 20.04 or Debian 11
   \verbatim
   $ sudo apt-get install libopencv-dev libx11-dev liblapack-dev libeigen3-dev libv4l-dev \
-    libzbar-dev libpthread-stubs0-dev libdc1394-dev
+    libzbar-dev libpthread-stubs0-dev libdc1394-dev nlohmann-json3-dev
   \endverbatim
 
   - On older Ubuntu or Debian distros
   \verbatim
   $ sudo apt-get install libopencv-dev libx11-dev liblapack-dev libeigen3-dev libv4l-dev \
-    libzbar-dev libpthread-stubs0-dev libdc1394-22-dev
+    libzbar-dev libpthread-stubs0-dev libdc1394-22-dev nlohmann-json3-dev
   \endverbatim
 
 - Get ViSP source code
@@ -100,12 +100,12 @@ Installation of recommended 3rd parties could be performed running:
 - Since Ubuntu 20.04 or Debian 11
 \verbatim
 $ sudo apt-get install libopencv-dev libx11-dev liblapack-dev libeigen3-dev libv4l-dev libzbar-dev \
-  libpthread-stubs0-dev libdc1394-dev
+  libpthread-stubs0-dev libdc1394-dev nlohmann-json3-dev
 \endverbatim
 - On older Ubuntu or Debian distros
 \verbatim
 $ sudo apt-get install libopencv-dev libx11-dev liblapack-dev libeigen3-dev libv4l-dev libzbar-dev \
-  libpthread-stubs0-dev libdc1394-22-dev
+  libpthread-stubs0-dev libdc1394-22-dev nlohmann-json3-dev
 \endverbatim
 
 \subsubsection install_ubuntu_3rdparty_realsense librealsense 2.x 3rd party

--- a/modules/core/include/visp3/core/vpCameraParameters.h
+++ b/modules/core/include/visp3/core/vpCameraParameters.h
@@ -400,4 +400,65 @@ private:
   vpCameraParametersProjType projModel; //!< used projection model
 };
 
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include<nlohmann/json.hpp>
+
+inline void to_json(nlohmann::json& j, const vpCameraParameters& cam) {
+  j["px"] = cam.get_px();
+  j["py"] = cam.get_py();
+  j["u0"] = cam.get_u0();
+  j["v0"] = cam.get_v0();
+  j["model"] = cam.get_projModel();
+  
+  switch(cam.get_projModel()) {
+    case vpCameraParameters::vpCameraParametersProjType::perspectiveProjWithDistortion:
+    {
+      j["kud"] = cam.get_kud();
+      j["kdu"] = cam.get_kdu();
+      break;
+    }
+    case vpCameraParameters::vpCameraParametersProjType::ProjWithKannalaBrandtDistortion:
+    {
+      j["dist_coeffs"] = cam.getKannalaBrandtDistortionCoefficients();
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+inline void from_json(const nlohmann::json& j, vpCameraParameters& cam) {
+  const double px = j.at("px").get<double>();
+  const double py = j.at("px").get<double>();
+  const double u0 = j.at("u0").get<double>();
+  const double v0 = j.at("v0").get<double>();
+  const vpCameraParameters::vpCameraParametersProjType model = j.at("model").get<vpCameraParameters::vpCameraParametersProjType>();
+  
+  switch(model) {
+
+    case vpCameraParameters::vpCameraParametersProjType::perspectiveProjWithoutDistortion:
+    {
+      cam.initPersProjWithoutDistortion(px, py, u0, v0);
+      break;
+    }
+    case vpCameraParameters::vpCameraParametersProjType::perspectiveProjWithDistortion:
+    {
+      const double kud = j.at("kud").get<double>();
+      const double kdu = j.at("kdu").get<double>();
+      cam.initPersProjWithDistortion(px, py, u0, v0, kud, kdu);
+      break;
+    }
+    case vpCameraParameters::vpCameraParametersProjType::ProjWithKannalaBrandtDistortion:
+    {
+      const std::vector<double> coeffs = j.at("dist_coeffs").get<std::vector<double>>();
+      cam.initProjWithKannalaBrandtDistortion(px, py, u0, v0, coeffs);
+      break;
+    }
+  }
+
+
+}
+#endif
+
 #endif

--- a/modules/core/include/visp3/core/vpCameraParameters.h
+++ b/modules/core/include/visp3/core/vpCameraParameters.h
@@ -436,7 +436,6 @@ inline void from_json(const nlohmann::json& j, vpCameraParameters& cam) {
   const vpCameraParameters::vpCameraParametersProjType model = j.at("model").get<vpCameraParameters::vpCameraParametersProjType>();
   
   switch(model) {
-
     case vpCameraParameters::vpCameraParametersProjType::perspectiveProjWithoutDistortion:
     {
       cam.initPersProjWithoutDistortion(px, py, u0, v0);

--- a/modules/core/include/visp3/core/vpCameraParameters.h
+++ b/modules/core/include/visp3/core/vpCameraParameters.h
@@ -476,7 +476,7 @@ inline void to_json(nlohmann::json& j, const vpCameraParameters& cam) {
 */
 inline void from_json(const nlohmann::json& j, vpCameraParameters& cam) {
   const double px = j.at("px").get<double>();
-  const double py = j.at("px").get<double>();
+  const double py = j.at("py").get<double>();
   const double u0 = j.at("u0").get<double>();
   const double v0 = j.at("v0").get<double>();
   const vpCameraParameters::vpCameraParametersProjType model = j.value("model", vpCameraParameters::perspectiveProjWithoutDistortion);

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -425,6 +425,15 @@ inline void to_json(nlohmann::json& j, const vpColVector& v) {
   to_json(j, *asArray);
   j["type"] = "vpColVector";
 }
+inline void from_json(const nlohmann::json& j, vpColVector& v) {
+  vpArray2D<double>* asArray = (vpArray2D<double>*) &v;
+  from_json(j, *asArray);
+  if(v.getCols() != 1) {
+    throw vpException(vpException::badValue, "From JSON, tried to read a 2D array into a vpColVector");
+  }
+}
+
+
 #endif
 
 #endif

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -419,4 +419,12 @@ VISP_EXPORT
 #endif
 vpColVector operator*(const double &x, const vpColVector &v);
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+inline void to_json(nlohmann::json& j, const vpColVector& v) {
+  const vpArray2D<double>* asArray = (vpArray2D<double>*) &v;
+  to_json(j, *asArray);
+  j["type"] = "vpColVector";
+}
+#endif
+
 #endif

--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -62,6 +62,10 @@ class vpPoint;
 //#include <visp3/core/vpTranslationVector.h>
 #include <visp3/core/vpPoseVector.h>
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+#endif
+
 /*!
   \class vpHomogeneousMatrix
 
@@ -270,24 +274,22 @@ public:
 
 protected:
   unsigned int m_index;
+#ifdef VISP_HAVE_NLOHMANN_JSON
+private:
+  friend void from_json(const nlohmann::json& j, vpHomogeneousMatrix& T);
+  void parse_json(const nlohmann::json& j); // Conversion helper function to avoid circular dependencies
+#endif
 };
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
-inline void to_json(nlohmann::json& j, const vpHomogeneousMatrix& m) {
-    std::vector<double> values;
-    values.reserve(16);
-    for(unsigned i = 0; i < 16; ++i) {
-        values.push_back(m.data[i]);
-    }
-    j = values;
+inline void to_json(nlohmann::json& j, const vpHomogeneousMatrix& T) {
+  const vpArray2D<double>* asArray = (vpArray2D<double>*) &T;
+  to_json(j, *asArray);
+  j["type"] = "vpHomogeneousMatrix";
 }
-inline void from_json(const nlohmann::json& j, vpHomogeneousMatrix& m) {
-    std::vector<double> values = j;
-    assert(values.size() == 16);
-    std::copy(values.begin(), values.end(), m.data);
+inline void from_json(const nlohmann::json& j, vpHomogeneousMatrix& T) {
+  T.parse_json(j);
 }
-
 #endif
 
 #endif

--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -272,4 +272,22 @@ protected:
   unsigned int m_index;
 };
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+inline void to_json(nlohmann::json& j, const vpHomogeneousMatrix& m) {
+    std::vector<double> values;
+    values.reserve(16);
+    for(unsigned i = 0; i < 16; ++i) {
+        values.push_back(m.data[i]);
+    }
+    j = values;
+}
+inline void from_json(const nlohmann::json& j, vpHomogeneousMatrix& m) {
+    std::vector<double> values = j;
+    assert(values.size() == 16);
+    std::copy(values.begin(), values.end(), m.data);
+}
+
+#endif
+
 #endif

--- a/modules/core/include/visp3/core/vpJsonParsing.h
+++ b/modules/core/include/visp3/core/vpJsonParsing.h
@@ -1,0 +1,55 @@
+#ifndef vpJsonParsing_HH
+#define vpJsonParsing_HH
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+
+
+/*!
+Parse the flag values defined in a JSON object.
+if the flags are defined as an int, then this is int is directly returned.
+If it is defined as a combination of options (defined from an enumeration T) then the logical or of theses enum values is returned.
+Beware that invalid values may be defined in the JSON object: the int value may be invalid, or the parsing of enum values may fail.
+
+\param j: the JSON object to parse
+
+
+*/
+template<typename E>
+int flagsFromJSON(const nlohmann::json& j) {
+    int flags = 0;
+    if(j.is_array()) {
+        flags = 0;
+        for(const auto& v: j) {
+            E value = v.get<E>();
+            flags |= value;
+        }
+    } else if(j.is_number_integer()) {
+        flags = j.get<int>();
+    }
+    return flags;
+}
+
+/*!
+    Serialize flag values as a json array.
+    \param flags the value to serialize
+    \param options the possible values that can be contained in flags. A flag i is set if flags & options[i] != 0.
+
+    \return a json object (an array) that contains the different flags of the variable flags.
+
+*/
+template<typename E>
+nlohmann::json flagsToJSON(const int flags, const std::vector<E>& options) {
+    nlohmann::json j = nlohmann::json::array();
+    for(const E option: options) {
+        if(flags & option) {
+            j.push_back(option);
+        }
+    }
+    return j;
+}
+
+
+
+
+#endif
+#endif

--- a/modules/core/include/visp3/core/vpJsonParsing.h
+++ b/modules/core/include/visp3/core/vpJsonParsing.h
@@ -1,8 +1,8 @@
 #ifndef vpJsonParsing_HH
 #define vpJsonParsing_HH
+
 #ifdef VISP_HAVE_NLOHMANN_JSON
 #include <nlohmann/json.hpp>
-
 
 /*!
 Parse the flag values defined in a JSON object.
@@ -48,9 +48,6 @@ nlohmann::json flagsToJSON(const int flags, const std::vector<E>& options) {
     }
     return j;
 }
-
-
-
 
 #endif
 #endif

--- a/modules/core/include/visp3/core/vpJsonParsing.h
+++ b/modules/core/include/visp3/core/vpJsonParsing.h
@@ -7,11 +7,12 @@
 /*!
 Parse the flag values defined in a JSON object.
 if the flags are defined as an int, then this is int is directly returned.
-If it is defined as a combination of options (defined from an enumeration T) then the logical or of theses enum values is returned.
+If it is defined as a combination of options (defined from an enumeration E) then the logical or of theses enum values is returned.
 Beware that invalid values may be defined in the JSON object: the int value may be invalid, or the parsing of enum values may fail.
 
 \param j: the JSON object to parse
 
+\return an int, corresponding to the combination of boolean flags
 
 */
 template<typename E>
@@ -20,7 +21,7 @@ int flagsFromJSON(const nlohmann::json& j) {
     if(j.is_array()) {
         flags = 0;
         for(const auto& v: j) {
-            E value = v.get<E>();
+            E value = v.get<E>(); // If a value is incorrect, this will default to the first value of the enum
             flags |= value;
         }
     } else if(j.is_number_integer()) {

--- a/modules/core/include/visp3/core/vpPolygon3D.h
+++ b/modules/core/include/visp3/core/vpPolygon3D.h
@@ -219,4 +219,43 @@ public:
   static bool roiInsideImage(const vpImage<unsigned char> &I, const std::vector<vpImagePoint> &corners);
 };
 
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+#include <visp3/core/vpJsonParsing.h>
+NLOHMANN_JSON_SERIALIZE_ENUM( vpPolygon3D::vpPolygon3DClippingType, {
+    {vpPolygon3D::NO_CLIPPING, "none"},
+    {vpPolygon3D::NEAR_CLIPPING, "near"},
+    {vpPolygon3D::FAR_CLIPPING, "far"},
+    {vpPolygon3D::LEFT_CLIPPING, "left"},
+    {vpPolygon3D::RIGHT_CLIPPING, "right"},
+    {vpPolygon3D::UP_CLIPPING, "up"},
+    {vpPolygon3D::DOWN_CLIPPING, "down"},
+    {vpPolygon3D::FOV_CLIPPING, "fov"},
+    {vpPolygon3D::ALL_CLIPPING, "all"}
+});
+
+inline nlohmann::json clippingFlagsToJSON(const int flags) {
+  constexpr std::array<vpPolygon3D::vpPolygon3DClippingType, 3> specificFlags = {
+    vpPolygon3D::ALL_CLIPPING,
+    vpPolygon3D::FOV_CLIPPING,
+    vpPolygon3D::NO_CLIPPING
+  };
+  for(const auto f: specificFlags) {
+    if(flags == f) {
+      return nlohmann::json::array({ f });
+    }
+  }
+  return flagsToJSON<vpPolygon3D::vpPolygon3DClippingType>(flags, {
+    vpPolygon3D::NEAR_CLIPPING,
+    vpPolygon3D::FAR_CLIPPING,
+    vpPolygon3D::LEFT_CLIPPING,
+    vpPolygon3D::RIGHT_CLIPPING,
+    vpPolygon3D::UP_CLIPPING,
+    vpPolygon3D::DOWN_CLIPPING,
+  });
+}
+
+#endif
+
 #endif

--- a/modules/core/include/visp3/core/vpPoseVector.h
+++ b/modules/core/include/visp3/core/vpPoseVector.h
@@ -60,6 +60,10 @@ class vpRowVector;
 #include <visp3/core/vpMatrix.h>
 #include <visp3/core/vpRotationMatrix.h>
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+#endif
+
 /*!
   \class vpPoseVector
 
@@ -267,6 +271,23 @@ public:
   vp_deprecated void init(){};
 //@}
 #endif
+#ifdef VISP_HAVE_NLOHMANN_JSON
+private:
+  friend void from_json(const nlohmann::json& j, vpPoseVector& r);
+  void parse_json(const nlohmann::json& j);
+#endif
 };
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+inline void to_json(nlohmann::json& j, const vpPoseVector& r) {
+  const vpArray2D<double>* asArray = (vpArray2D<double>*) &r;
+  to_json(j, *asArray);
+  j["type"] = "vpPoseVector";
+}
+inline void from_json(const nlohmann::json& j, vpPoseVector& r) {
+  r.parse_json(j);
+}
+#endif
 
 #endif

--- a/modules/core/src/camera/vpCameraParameters.cpp
+++ b/modules/core/src/camera/vpCameraParameters.cpp
@@ -206,11 +206,13 @@ void vpCameraParameters::initPersProjWithoutDistortion(double cam_px, double cam
   this->kud = 0;
   this->kdu = 0;
 
+  this->m_dist_coefs.clear();
+
   if (fabs(px) < 1e-6) {
     throw(vpException(vpException::divideByZeroError, "Camera parameter px = 0"));
   }
   if (fabs(py) < 1e-6) {
-    throw(vpException(vpException::divideByZeroError, "Camera parameter px = 0"));
+    throw(vpException(vpException::divideByZeroError, "Camera parameter py = 0"));
   }
   this->inv_px = 1. / px;
   this->inv_py = 1. / py;
@@ -269,6 +271,7 @@ void vpCameraParameters::initPersProjWithDistortion(double cam_px, double cam_py
   this->v0 = cam_v0;
   this->kud = cam_kud;
   this->kdu = cam_kdu;
+  this->m_dist_coefs.clear();
 
   if (fabs(px) < 1e-6) {
     throw(vpException(vpException::divideByZeroError, "Camera parameter px = 0"));
@@ -295,6 +298,9 @@ void vpCameraParameters::initProjWithKannalaBrandtDistortion(double cam_px, doub
   this->py = cam_py;
   this->u0 = cam_u0;
   this->v0 = cam_v0;
+  
+  this->kud = 0.0;
+  this->kdu = 0.0;
 
   if (fabs(px) < 1e-6) {
     throw(vpException(vpException::divideByZeroError, "Camera parameter px = 0"));
@@ -436,6 +442,9 @@ bool vpCameraParameters::operator==(const vpCameraParameters &c) const
       !vpMath::equal(kdu, c.kdu, std::numeric_limits<double>::epsilon()) ||
       !vpMath::equal(inv_px, c.inv_px, std::numeric_limits<double>::epsilon()) ||
       !vpMath::equal(inv_py, c.inv_py, std::numeric_limits<double>::epsilon()))
+    return false;
+  
+  if(m_dist_coefs.size() != c.m_dist_coefs.size())
     return false;
 
   for (unsigned int i = 0; i < m_dist_coefs.size(); i++)

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -1196,3 +1196,25 @@ vpHomogeneousMatrix vpHomogeneousMatrix::mean(const std::vector<vpHomogeneousMat
 void vpHomogeneousMatrix::setIdentity() { eye(); }
 
 #endif //#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS)
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+
+void vpHomogeneousMatrix::parse_json(const nlohmann::json& j) {
+  vpArray2D<double>* asArray = (vpArray2D<double>*) this;
+  if(j.is_object() && j.contains("type")) { // Specific conversions
+    if(j["type"] == "vpPoseVector") {
+      vpPoseVector r = j;
+      buildFrom(r);
+    }
+  } else { // Generic 2D array conversion
+    from_json(j, *asArray);
+  }
+  
+  if(getCols() != 1 && getRows() != 4) {
+    throw vpException(vpException::badValue, "From JSON, tried to read something that is not a 4x4 matrix");
+  }
+  if(!isAnHomogeneousMatrix()) {
+    throw vpException(vpException::badValue, "From JSON read a non homogeneous matrix into a vpHomogeneousMatrix");
+  }
+}
+#endif

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -49,6 +49,9 @@
 #include <visp3/core/vpPoint.h>
 #include <visp3/core/vpQuaternionVector.h>
 
+
+
+
 /*!
   Construct an homogeneous matrix from a translation vector and quaternion
   rotation vector.

--- a/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
+++ b/modules/core/src/math/transformation/vpHomogeneousMatrix.cpp
@@ -49,9 +49,6 @@
 #include <visp3/core/vpPoint.h>
 #include <visp3/core/vpQuaternionVector.h>
 
-
-
-
 /*!
   Construct an homogeneous matrix from a translation vector and quaternion
   rotation vector.

--- a/modules/core/src/math/transformation/vpPoseVector.cpp
+++ b/modules/core/src/math/transformation/vpPoseVector.cpp
@@ -512,3 +512,21 @@ std::vector<double> vpPoseVector::toStdVector() const
     v[i] = data[i];
   return v;
 }
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+void vpPoseVector::parse_json(const nlohmann::json& j) {
+  vpArray2D<double>* asArray = (vpArray2D<double>*) this;
+  if(j.is_object() && j.contains("type")) { // Specific conversions
+    if(j["type"] == "vpHomogeneousMatrix") {
+      vpHomogeneousMatrix T = j;
+      buildFrom(T);
+    }
+  } else { // Generic 2D array conversion
+    from_json(j, *asArray);
+  }
+  
+  if(getCols() != 1 && getRows() != 6) {
+    throw vpException(vpException::badValue, "From JSON, tried to read something that is not a 6D pose vector");
+  }
+}
+#endif

--- a/modules/core/test/camera/testJsonCamera.cpp
+++ b/modules/core/test/camera/testJsonCamera.cpp
@@ -1,0 +1,170 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test vpCameraParameters JSON parse / save.
+ *
+ *****************************************************************************/
+
+/*!
+  \file testJsonCamera.cpp
+
+  Test test saving and parsing JSON configuration for vpCameraParameters
+*/
+
+#include <visp3/core/vpIoTools.h>
+#include <visp3/core/vpCameraParameters.h>
+
+#if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_CATCH2)
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+#include <random>
+namespace {
+
+
+// This class shows how to implement a simple generator for Catch tests
+class RandomCamGenerator : public Catch::Generators::IGenerator<vpCameraParameters> {
+private:
+    std::minstd_rand m_rand;
+    std::uniform_int_distribution<> m_count_dist;
+    std::uniform_int_distribution<> m_type_dist;
+    std::uniform_real_distribution<> m_dist;
+    
+    vpCameraParameters current;
+public:
+
+    RandomCamGenerator(double low, double high):
+        m_rand(std::random_device{}()),
+        m_count_dist(1, 5),
+        m_type_dist(0, 3),
+        m_dist(low, high)
+    {
+        static_cast<void>(next());
+    }
+
+    vpCameraParameters const& get() const override {
+        return current;
+    }
+    bool next() override {
+        const double px = m_dist(m_rand);
+        const double py = m_dist(m_rand);
+        const double u0 = m_dist(m_rand);
+        const double v0 = m_dist(m_rand);
+
+        const int type = m_type_dist(m_rand);
+        switch(type) {
+        case 0:
+            current.initPersProjWithoutDistortion(px, py, u0, v0);
+            break;
+        case 1:
+            current.initPersProjWithDistortion(px, py, u0, v0, m_dist(m_rand), m_dist(m_rand));
+            break;
+        case 2:
+            std::vector<double> coeffs;
+            const int count = m_count_dist(m_rand);
+            for(int i = 0; i < count; ++i) {
+                coeffs.push_back(m_dist(m_rand));
+            }
+            current.initProjWithKannalaBrandtDistortion(px, py, u0, v0, coeffs);
+        }
+        return true;
+    }
+};
+
+// Catch::Generators::GeneratorWrapper<vpCameraParameters> random(double low, double high) {
+//     return Catch::Generators::GeneratorWrapper<vpCameraParameters>(
+//         new RandomCamGenerator(low, high)
+//     );
+// }
+
+}
+
+SCENARIO("Serializing and deserializing a single vpCameraParameters", "[json]") {
+  GIVEN("Some camera intrinsics") {
+
+    RandomCamGenerator g(50.0, 500.0);
+    for(int i = 0; i < 100; ++i) { // Not sure why, but the catch2 generator wrappers dont work
+        g.next();
+        vpCameraParameters cam = g.get();
+        THEN("Serializing and deserializing does not modify the object") {
+            const json j = cam;
+            const vpCameraParameters otherCam = j;
+
+            REQUIRE( cam == otherCam );
+        }
+    }
+  }
+}
+
+SCENARIO("Serializing two cameras", "[json]") {
+  GIVEN("Some camera intrinsics") {
+
+    RandomCamGenerator g(50.0, 500.0);
+    for(int i = 0; i < 100; ++i) { // Not sure why, but the catch2 generator wrappers dont work
+        g.next();
+        vpCameraParameters cam = g.get();
+        g.next();
+        vpCameraParameters cam2 = g.get();
+        if(cam != cam2) {
+            WHEN("serializing and deserializing two different cameras") {
+                THEN("The deserialized cams are still different") {
+                    const json j1 = cam;
+                    const json j2 = cam2;
+
+                    const vpCameraParameters resCam = j1;
+                    const vpCameraParameters resCam2 = j2;
+                    REQUIRE( resCam != resCam2 );
+                }
+            }
+        }
+    }
+  }
+}
+
+int main(int argc, char *argv[])
+{
+  Catch::Session session; // There must be exactly one instance
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+  return numFailed;
+}
+
+#else
+
+int main() {
+  return EXIT_SUCCESS;
+}
+
+#endif

--- a/modules/core/test/math/testJsonArrayConversion.cpp
+++ b/modules/core/test/math/testJsonArrayConversion.cpp
@@ -1,0 +1,252 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test vpArray2D and children JSON parse / save.
+ *
+ *****************************************************************************/
+
+/*!
+  \file testJsonArrayConversion.cpp
+
+  Test test saving and parsing JSON configuration for vpArray2D and children classes
+*/
+
+#include <random>
+#include <visp3/core/vpIoTools.h>
+#include <visp3/core/vpArray2D.h>
+
+#if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_CATCH2)
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#define CATCH_CONFIG_RUNNER
+#include "catch.hpp"
+
+
+namespace {
+using StringMatcherBase =  Catch::Matchers::StdString::StringMatcherBase;
+class vpExceptionMatcher : public Catch::Matchers::Impl::MatcherBase<vpException> {
+    vpException::generalExceptionEnum m_type;
+    const StringMatcherBase&  m_messageMatcher;
+public:
+    vpExceptionMatcher(vpException::generalExceptionEnum type,
+     const StringMatcherBase& messageMatcher) : m_type(type), m_messageMatcher(messageMatcher) {}
+
+    bool match(vpException const& in) const override {
+        return m_type == in.getCode() && m_messageMatcher.match(in.getStringMessage());
+    }
+
+    std::string describe() const override {
+        std::ostringstream ss;
+        ss << "vpException has type " << m_type << " and message " << m_messageMatcher.describe();
+        return ss.str();
+    }
+};
+
+class RandomArray2DGenerator : public Catch::Generators::IGenerator<vpArray2D<double>> {
+private:
+    std::minstd_rand m_rand;
+    std::uniform_real_distribution<> m_val_dist;
+    std::uniform_int_distribution<> m_dim_dist;
+    
+    vpArray2D<double> current;
+public:
+
+    RandomArray2DGenerator(double valueRange, int minSize, int maxSize):
+        m_rand(std::random_device{}()),
+        m_val_dist(-valueRange, valueRange),
+        m_dim_dist(minSize, maxSize)
+
+    {
+        static_cast<void>(next());
+    }
+
+    vpArray2D<double> const& get() const override {
+        return current;
+    }
+    bool next() override {
+        const unsigned nCols = m_dim_dist(m_rand);
+        const unsigned nRows = m_dim_dist(m_rand);
+        current.resize(nRows, nCols);
+        for(unsigned i = 0; i < nRows; ++i) {
+            for(unsigned j = 0; j < nCols; ++j) {
+                current[i][j] = m_val_dist(m_rand);
+            }
+        }
+        return true;
+    }
+};
+Catch::Generators::GeneratorWrapper<vpArray2D<double>> randomArray(double v, int minSize, int maxSize) {
+    return Catch::Generators::GeneratorWrapper<vpArray2D<double>>(
+      std::unique_ptr<Catch::Generators::IGenerator<vpArray2D<double>>>(
+        new RandomArray2DGenerator(v, minSize, maxSize)
+      )
+    );
+}
+vpExceptionMatcher matchVpException(vpException::generalExceptionEnum type,
+ const StringMatcherBase& matcher) {
+    return vpExceptionMatcher(type, matcher);
+}
+}
+SCENARIO("Serializing a vpArray2D", "[json]") {
+    GIVEN("A random vpArray2D<double>") {
+        const vpArray2D<double> array = GENERATE(take(10, randomArray(50.0, 1, 10)));
+        WHEN("Serializing to a JSON object") {
+            const json j = array;
+            THEN("JSON object is a dictionary") {
+                REQUIRE(j.is_object());
+            }
+            THEN("JSON object contains correct number of columns") {
+                REQUIRE(j.at("cols").get<unsigned int>() == array.getCols());
+            }
+            THEN("JSON object contains correct number of rows") {
+                REQUIRE(j.at("rows").get<unsigned int>() == array.getRows());
+            }
+            THEN("JSON object contains the array values") {
+                const json jData = j.at("data");
+                THEN("The data field is an array") {
+                    REQUIRE(jData.is_array());
+                }
+                THEN("The data field contains the correct number of values") {
+                    REQUIRE(jData.size() == array.size());
+                }
+                THEN("The data field contains the correct number of values") {
+                    const double* const start = array[0];
+                    const std::vector<double> vec(start, start + array.size());
+                    REQUIRE(vec == jData.get<std::vector<double>>());
+                }
+            }
+        }
+    }
+}
+
+SCENARIO("Trying to instanciate a vpArray with a wrong type of object", "[json]") {
+    GIVEN("A random scalar converted to a JSON representation") {
+        vpArray2D<double> array;
+        std::minstd_rand rand;
+        std::uniform_real_distribution<> dist;
+        const json j = GENERATE(take(50, random(-200.0, 200.0)));
+        THEN("An exception is thrown") {
+            const auto matcher = Catch::Matchers::Contains("is not an array or object");
+            REQUIRE_THROWS_MATCHES(from_json(j, array), vpException,
+                                    matchVpException(vpException::badValue, matcher));
+        }
+    }
+}
+
+SCENARIO("Recovering a vpArray2D from a JSON array", "[json]") {
+    GIVEN("An empty array") {
+        const json j = json::array_t();
+        WHEN("Converting to a vpArray2D") {
+            vpArray2D<double> array = j;
+            THEN("The resulting array is empty") {
+                REQUIRE(array.size() == 0);
+            }
+        }
+    }
+    GIVEN("A 1D array") {
+        const json j = {10.0, 20.0, 30.0};
+        WHEN("Converting to a vpArray2D") {
+            THEN("An exception is thrown, since this is an ambiguous array") {
+                vpArray2D<double> array;
+                const auto matcher = Catch::Matchers::Contains("is not an array of array");
+                REQUIRE_THROWS_MATCHES(from_json(j, array), vpException,
+                                        matchVpException(vpException::badValue, matcher));
+            }
+        }
+    }
+    GIVEN("A vpArray2D converted to a json 2D array") {
+        vpArray2D<double> array = GENERATE(take(10, randomArray(50.0, 2, 10)));
+        json j;
+        for(unsigned i = 0; i < array.getRows(); ++i) {
+            json jRow;
+            for(unsigned j = 0; j < array.getCols(); ++j) {
+                jRow.push_back(array[i][j]);
+            }
+            j.push_back(jRow);
+        }
+        WHEN("Converting back to a vpArray2D") {
+            vpArray2D<double> array2 = j;
+            THEN("The values are correct") {
+                REQUIRE(array == array2);
+            }
+        }
+        WHEN("Removing elements from rows so that they do not have the same size") {
+            j[0].erase(0); // Generating at least a 2x2 array
+            THEN("An exception is thrown") {
+                const auto matcher = Catch::Matchers::Contains("row arrays that are not of the same size");
+                REQUIRE_THROWS_MATCHES(from_json(j, array), vpException,
+                                        matchVpException(vpException::badValue, matcher));
+            }
+        }
+    }
+}
+
+SCENARIO("Recovering a vpArray2D from a JSON object as serialized by ViSP", "[json]") {
+    GIVEN("A vpArray2D converted to JSON format") {
+        const vpArray2D<double> array = GENERATE(take(10, randomArray(50.0, 1, 10)));
+        json j = array;
+        WHEN("Converting back to a vpArray2D") {
+            const vpArray2D<double> array2 = j;
+            THEN("The 2 arrays are equal") {
+                REQUIRE(array == array2);
+            }
+        }
+        WHEN("Removing or adding some values from the data field so that its size does not match the expected array size") {
+            j.at("data").erase(0);
+            THEN("An exception is thrown") {
+                vpArray2D<double> array2;
+                const auto matcher = Catch::Matchers::Contains("must be an array of size");
+                REQUIRE_THROWS_MATCHES(from_json(j, array2), vpException,
+                                        matchVpException(vpException::badValue, matcher));
+            }
+        }
+    }
+}
+
+
+
+int main(int argc, char *argv[])
+{
+  Catch::Session session; // There must be exactly one instance
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+  return numFailed;
+}
+
+#else
+
+int main() {
+  return EXIT_SUCCESS;
+}
+
+#endif

--- a/modules/java/generator/gen_java.py
+++ b/modules/java/generator/gen_java.py
@@ -709,6 +709,9 @@ class JavaWrapperGenerator(object):
 
             if fi.name in ['detByLUGsl', 'svdGsl', 'inverseByLUGsl', 'pseudoInverseGsl', 'inverseByGsl', 'inverseByCholeskyGsl', 'inverseByQRGsl']:
                 c_prologue.append('#if defined(VISP_BUILD_DEPRECATED_FUNCTIONS) && defined(VISP_HAVE_LAPACK)')
+            if fi.name in ['from_json', 'to_json', 'loadConfigFileJSON', 'saveConfigFile']:
+                c_prologue.append('#if defined(VISP_HAVE_NLOHMANN_JSON)')
+
 
             if type_dict[fi.ctype]["jni_type"] == "jdoubleArray" and type_dict[fi.ctype]["suffix"] != "[D":
                 fields = type_dict[fi.ctype]["jn_args"]
@@ -1000,6 +1003,8 @@ class JavaWrapperGenerator(object):
                 ret += '\n    #endif'
 
             if fi.name in ['detByLUGsl', 'svdGsl', 'inverseByLUGsl', 'pseudoInverseGsl', 'inverseByGsl', 'inverseByCholeskyGsl', 'inverseByQRGsl']:
+                ret += '\n    #endif'
+            if fi.name in ['from_json', 'to_json', 'loadConfigFileJSON', 'saveConfigFile']:
                 ret += '\n    #endif'
 
             rtype = type_dict[fi.ctype].get("jni_type", "jdoubleArray")

--- a/modules/tracker/mbt/CMakeLists.txt
+++ b/modules/tracker/mbt/CMakeLists.txt
@@ -131,6 +131,11 @@ if(USE_PCL)
   list(APPEND opt_libs ${PCL_DEPS_LIBRARIES})
 endif()
 
+if(USE_NLOHMANN_JSON)
+  get_target_property(_inc_dirs "nlohmann_json::nlohmann_json" INTERFACE_INCLUDE_DIRECTORIES)
+  list(APPEND opt_incs ${_inc_dirs})
+endif()
+
 if(WITH_CLIPPER)
   # clipper is private
   include_directories(${CLIPPER_INCLUDE_DIRS})

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -789,9 +789,9 @@ inline void to_json(nlohmann::json& j, const vpMbGenericTracker::TrackerWrapper&
     j["normals"] = nlohmann::json {
       {"featureEstimationMethod", t.m_depthNormalFeatureEstimationMethod},
       {"pcl", {
-        {"method", t.m_depthNormalPclPlaneEstimationMethod,
-        "ransacMaxIter", t.m_depthNormalPclPlaneEstimationRansacMaxIter,
-        "ransacThreshold", t.m_depthNormalPclPlaneEstimationRansacThreshold}
+        {"method", t.m_depthNormalPclPlaneEstimationMethod},
+        {"ransacMaxIter", t.m_depthNormalPclPlaneEstimationRansacMaxIter},
+        {"ransacThreshold", t.m_depthNormalPclPlaneEstimationRansacThreshold}
       }},
       {"sampling", {
         {"x", t.m_depthNormalSamplingStepX},

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -100,8 +100,6 @@ public:
 
   virtual ~vpMbGenericTracker();
 
-  
-
   virtual double computeCurrentProjectionError(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &_cMo,
                                                const vpCameraParameters &_cam);
   virtual double computeCurrentProjectionError(const vpImage<vpRGBa> &I, const vpHomogeneousMatrix &_cMo,
@@ -572,8 +570,8 @@ private:
 
     virtual void loadConfigFile(const std::string &configFile, bool verbose = true);
 #ifdef VISP_HAVE_NLOHMANN_JSON
-  nlohmann::json asJson() const;
-  void fromJson(const nlohmann::json& j);
+    nlohmann::json asJson() const;
+    void fromJson(const nlohmann::json& j);
 #endif
 
     virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -873,7 +873,7 @@ inline void from_json(const nlohmann::json& j, vpMbGenericTracker::TrackerWrappe
   //Check tracker type: for each type, load settings for this specific tracker type
   //Edge tracker settings
   if(t.m_trackerType & vpMbGenericTracker::EDGE_TRACKER) {
-    t.me = j.at("edge");
+    from_json(j.at("edge"), t.me);
   }
   //KLT tracker settings
   if(t.m_trackerType & vpMbGenericTracker::KLT_TRACKER) {

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -45,6 +45,10 @@
 #include <visp3/mbt/vpMbEdgeTracker.h>
 #include <visp3/mbt/vpMbKltTracker.h>
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json_fwd.hpp>
+#endif
+
 /*!
   \class vpMbGenericTracker
   \ingroup group_mbt_trackers
@@ -95,6 +99,8 @@ public:
   vpMbGenericTracker(const std::vector<std::string> &cameraNames, const std::vector<int> &trackerTypes);
 
   virtual ~vpMbGenericTracker();
+
+  
 
   virtual double computeCurrentProjectionError(const vpImage<unsigned char> &I, const vpHomogeneousMatrix &_cMo,
                                                const vpCameraParameters &_cam);
@@ -309,6 +315,10 @@ public:
   loadModel(const std::map<std::string, std::string> &mapOfModelFiles, bool verbose = false,
             const std::map<std::string, vpHomogeneousMatrix> &mapOfT = std::map<std::string, vpHomogeneousMatrix>());
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+  void loadJSONSettings(const std::string& settingsFile);
+  void saveJSONSettings(const std::string& settingsFile);
+#endif
   virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name, const vpHomogeneousMatrix &cMo,
                            bool verbose = false, const vpHomogeneousMatrix &T = vpHomogeneousMatrix());
   virtual void reInitModel(const vpImage<vpRGBa> &I_color, const std::string &cad_name, const vpHomogeneousMatrix &cMo,
@@ -539,6 +549,7 @@ private:
 
     virtual ~TrackerWrapper();
 
+
     virtual inline vpColVector getError() const { return m_error; }
 
     virtual inline vpColVector getRobustWeights() const { return m_w; }
@@ -560,6 +571,10 @@ private:
     virtual void init(const vpImage<unsigned char> &I);
 
     virtual void loadConfigFile(const std::string &configFile, bool verbose = true);
+#ifdef VISP_HAVE_NLOHMANN_JSON
+  nlohmann::json asJson() const;
+  void fromJson(const nlohmann::json& j);
+#endif
 
     virtual void reInitModel(const vpImage<unsigned char> &I, const std::string &cad_name,
                              const vpHomogeneousMatrix &cMo, bool verbose = false,

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -758,7 +758,7 @@ inline void to_json(nlohmann::json& j, const vpMbGenericTracker::TrackerWrapper&
       {"scanline", t.useScanLine}
     }},
     {"clipping", {
-      {"useFOVClipping", (t.getClipping() == vpPolygon3D::FOV_CLIPPING)},
+      {"flags", clippingFlagsToJSON(t.getClipping())},
       {"near", t.getNearClippingDistance()},
       {"far", t.getFarClippingDistance()},
     }}
@@ -839,20 +839,15 @@ inline void from_json(const nlohmann::json& j, vpMbGenericTracker::TrackerWrappe
     t.setAngleDisappear(vpMath::rad(j.at("angleDisappear")));
   }
   if(j.contains("clipping")) {
-    nlohmann::json clipping = j["clipping"];
+    const nlohmann::json clipping = j["clipping"];
     t.setNearClippingDistance(clipping.value("near", t.getNearClippingDistance()));
     t.setFarClippingDistance(clipping.value("far", t.getFarClippingDistance()));
-    if(clipping.contains("useFOVClipping")) {
-      const bool useFovClipping = clipping.at("useFOVClipping").get<bool>();
-      if(useFovClipping) {
-        t.setClipping(t.getClipping() | vpPolygon3D::FOV_CLIPPING);
-      } else {
-        t.setClipping(t.getClipping() ^ vpPolygon3D::FOV_CLIPPING);
-      }
+    if(clipping.contains("flags")) {
+      t.setClipping(flagsFromJSON<vpPolygon3D::vpPolygon3DClippingType>(clipping.at("flags")));
     }
   }
   if(j.contains("lod")) {
-    nlohmann::json lod = j["lod"];
+    const nlohmann::json lod = j["lod"];
     t.useLodGeneral = lod.value("useLod", t.useLodGeneral);
     t.minLineLengthThresholdGeneral = lod.value("minLineLengthThresholdGeneral", t.minLineLengthThresholdGeneral);
     t.minPolygonAreaThresholdGeneral = lod.value("minPolygonAreaThresholdGeneral", t.minPolygonAreaThresholdGeneral);

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -716,6 +716,9 @@ protected:
 };
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
+
+#define MBT_JSON_SETTINGS_VERSION "1.0"
+
 // Serialize tracker type enumeration
 NLOHMANN_JSON_SERIALIZE_ENUM( vpMbGenericTracker::vpTrackerType, {
     {vpMbGenericTracker::EDGE_TRACKER, "edge"},
@@ -763,7 +766,7 @@ inline void to_json(nlohmann::json& j, const vpMbGenericTracker::TrackerWrapper&
   //Check tracker type: for each type, add settings to json if the tracker t does use the features
   //Edge tracker settings
   if(t.m_trackerType & vpMbGenericTracker::EDGE_TRACKER) {
-    j["edge_tracker"] = t.me;
+    j["edge"] = t.me;
   }
   //KLT tracker settings
   if(t.m_trackerType & vpMbGenericTracker::KLT_TRACKER) {
@@ -875,7 +878,7 @@ inline void from_json(const nlohmann::json& j, vpMbGenericTracker::TrackerWrappe
   //Check tracker type: for each type, load settings for this specific tracker type
   //Edge tracker settings
   if(t.m_trackerType & vpMbGenericTracker::EDGE_TRACKER) {
-    t.me = j.at("edge_tracker");
+    t.me = j.at("edge");
   }
   //KLT tracker settings
   if(t.m_trackerType & vpMbGenericTracker::KLT_TRACKER) {

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -746,6 +746,14 @@ inline void to_json(nlohmann::json& j, const vpMbGenericTracker::TrackerWrapper&
       {"minLineLengthThresholdGeneral", t.minLineLengthThresholdGeneral},
       {"minPolygonAreaThresholdGeneral", t.minPolygonAreaThresholdGeneral}
     }},
+    {"display", {
+      {"features", t.displayFeatures},
+      {"projectionError", t.m_projectionErrorDisplay}
+    }},
+    {"visibilityTest", {
+      {"ogre", t.useOgre},
+      {"scanline", t.useScanLine}
+    }},
     {"clipping", {
       {"useFOVClipping", (t.getClipping() == vpPolygon3D::FOV_CLIPPING)},
       {"near", t.getNearClippingDistance()},
@@ -788,7 +796,7 @@ inline void to_json(nlohmann::json& j, const vpMbGenericTracker::TrackerWrapper&
       }}
     };
   }
-
+  //Depth dense settings
   if(t.m_trackerType & vpMbGenericTracker::DEPTH_DENSE_TRACKER) {
     j["dense"] = {
       {"sampling", {
@@ -852,6 +860,16 @@ inline void from_json(const nlohmann::json& j, vpMbGenericTracker::TrackerWrappe
       t.setMinLineLengthThresh(t.minLineLengthThresholdGeneral);
       t.setMinPolygonAreaThresh(t.minPolygonAreaThresholdGeneral);
     }
+  }
+  if(j.contains("display")) {
+    const nlohmann::json displayJson = j["display"];
+    t.setDisplayFeatures(displayJson.value("features", t.displayFeatures));
+    t.setProjectionErrorDisplay(displayJson.value("projectionError", t.m_projectionErrorDisplay));
+  }
+  if(j.contains("visibilityTest")) {
+    const nlohmann::json visJson = j["visibilityTest"];
+    t.setOgreVisibilityTest(visJson.value("ogre", t.useOgre));
+    t.setScanLineVisibilityTest(visJson.value("scanline", t.useScanLine));
   }
 
   //Check tracker type: for each type, load settings for this specific tracker type

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
@@ -301,4 +301,16 @@ protected:
 
   bool samePoint(const vpPoint &P1, const vpPoint &P2) const;
 };
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include<nlohmann/json.hpp>
+NLOHMANN_JSON_SERIALIZE_ENUM( vpMbtFaceDepthNormal::vpFeatureEstimationType, {
+    {vpMbtFaceDepthNormal::ROBUST_FEATURE_ESTIMATION, "robust"},
+    {vpMbtFaceDepthNormal::ROBUST_SVD_PLANE_ESTIMATION, "robustSVD"},
+#ifdef VISP_HAVE_PCL
+    {vpMbtFaceDepthNormal::PCL_PLANE_ESTIMATION, "pcl"},
+#endif
+});
+#endif
+
 #endif

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -2910,16 +2910,16 @@ void vpMbGenericTracker::loadConfigFileJSON(const std::string& settingsFile, boo
   this->angleAppears = refTracker->getAngleAppear();
   this->angleDisappears = refTracker->getAngleDisappear();
   this->clippingFlag = refTracker->getClipping();
-  // Do this after all the trackers have been initialised so that changes are propagated
+  // These settings can be set in each tracker or globally. Global value overrides local ones.
   if(settings.contains("display")) {
     const json displayJson = settings["display"];
-    setDisplayFeatures(displayJson.value("features", false));
-    setProjectionErrorDisplay(displayJson.value("projectionError", false));
+    setDisplayFeatures(displayJson.value("features", displayFeatures));
+    setProjectionErrorDisplay(displayJson.value("projectionError", m_projectionErrorDisplay));
   }
   if(settings.contains("visibilityTest")) {
     const json visJson = settings["visibilityTest"];
-    setOgreVisibilityTest(visJson.value("ogre", false));
-    setScanLineVisibilityTest(visJson.value("scanline", false));
+    setOgreVisibilityTest(visJson.value("ogre", useOgre));
+    setScanLineVisibilityTest(visJson.value("scanline", useScanLine));
   }
   //If a 3D model is defined, load it
   if(settings.contains("model")) {
@@ -2948,7 +2948,6 @@ void vpMbGenericTracker::saveConfigFile(const std::string& settingsFile) const {
     }
   }
   j["trackers"] = trackers;
-
   std::ofstream f(settingsFile);
   if(f.good()) {
     const unsigned indentLevel = 4;

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -2872,6 +2872,12 @@ void vpMbGenericTracker::loadConfigFileJSON(const std::string& settingsFile, boo
   }
   jsonFile.close();
 
+  if(!settings.contains("version")) {
+    throw vpException(vpException::badValue, "JSON configuration does not contain versioning information");
+  } else if(settings["version"].get<std::string>() != MBT_JSON_SETTINGS_VERSION) {
+    throw vpException(vpException::badValue, "Trying to load an old configuration file");
+  }
+
   //Load Basic settings
   settings.at("referenceCameraName").get_to(m_referenceCameraName);
   json trackersJson;
@@ -2950,6 +2956,7 @@ void vpMbGenericTracker::loadConfigFileJSON(const std::string& settingsFile, boo
 void vpMbGenericTracker::saveConfigFile(const std::string& settingsFile) const {
   json j;
   j["referenceCameraName"] = m_referenceCameraName;
+  j["version"] = MBT_JSON_SETTINGS_VERSION;
   // j["thresholdOutlier"] = m_thresholdOutlier;
   json trackers;
   for(const auto& kv: m_mapOfTrackers) {

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -2935,6 +2935,9 @@ void vpMbGenericTracker::loadConfigFileJSON(const std::string& settingsFile, boo
   this->angleAppears = refTracker->getAngleAppear();
   this->angleDisappears = refTracker->getAngleDisappear();
   this->clippingFlag = refTracker->getClipping();
+  this->distNearClip = refTracker->getNearClippingDistance();
+  this->distFarClip = refTracker->getFarClippingDistance();
+  
   // These settings can be set in each tracker or globally. Global value overrides local ones.
   if(settings.contains("display")) {
     const json displayJson = settings["display"];

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -38,6 +38,7 @@
 #include <visp3/core/vpDisplay.h>
 #include <visp3/core/vpExponentialMap.h>
 #include <visp3/core/vpTrackingException.h>
+#include <visp3/core/vpIoTools.h>
 #include <visp3/mbt/vpMbtXmlGenericParser.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
@@ -184,7 +185,7 @@ vpMbGenericTracker::~vpMbGenericTracker()
 }
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-void vpMbGenericTracker::loadJSONSettings(const std::string& settingsFile) {
+void vpMbGenericTracker::loadConfigFileJSON(const std::string& settingsFile) {
   std::ifstream jsonFile(settingsFile);
   if(!jsonFile.good()) {
     throw vpException(vpException::generalExceptionEnum::ioError, "Could not read from settings file " + settingsFile + " to initialise the vpMbtGenericTracker");
@@ -194,21 +195,30 @@ void vpMbGenericTracker::loadJSONSettings(const std::string& settingsFile) {
 
   m_referenceCameraName = settings.at("referenceCameraName").get<std::string>();
   m_thresholdOutlier = settings.at("thresholdOutlier").get<double>();
-  std::map<std::string, vpHomogeneousMatrix> m = settings["mapOfCameraTransformationMatrix"];
-
 }
-void vpMbGenericTracker::saveJSONSettings(const std::string& settingsFile) {
+
+/*!
+  Save the tracker settings to a configuration file.
+  As of now, only saving to a JSON file is supported.
+
+  \param configFile : name of the file in which to save the tracker settings.
+*/
+void vpMbGenericTracker::saveConfigFile(const std::string& settingsFile) const {
   json j;
   j["referenceCameraName"] = m_referenceCameraName;
   j["thresholdOutlier"] = m_thresholdOutlier;
-
+  json trackers;
   for(const auto& kv: m_mapOfTrackers) {
-    j[kv.first] = kv.second->asJson();
-    j[kv.first]["cameraName"] = kv.first;
+    trackers[kv.first] = *(kv.second);
+    trackers[kv.first]["cameraName"] = kv.first;
+    const auto itTransformation = m_mapOfCameraTransformationMatrix.find(kv.first);
+    if(itTransformation != m_mapOfCameraTransformationMatrix.end()) {
+      trackers[kv.first]["camTref"] = itTransformation->second;
+    }
   }
+  j["trackers"] = trackers;
 
   std::ofstream f(settingsFile);
-
   f << j.dump(4); // indent level as parameter
   f.close();
 }
@@ -2818,6 +2828,36 @@ void vpMbGenericTracker::initFromPose(const std::map<std::string, const vpImage<
 }
 
 /*!
+  Load the configuration file. This file can be in XML format(.xml) or in JSON (.json) if ViSP is compiled with the JSON option.
+  From the configuration file initialize the parameters corresponding to the
+  objects: tracking parameters, camera intrinsic parameters.
+
+  \throw vpException::ioError if the file has not been properly parsed (file
+  not found), or if it is of an unknown extension (not .xml or .json).
+
+  \param configFile : full name of the xml or json file.
+  \param verbose : verbose flag. Ignored when parsing JSON
+*/
+void vpMbGenericTracker::loadConfigFile(const std::string &configFile, bool verbose)
+{
+  const std::string extension = vpIoTools::getFileExtension(configFile);
+  if(extension == ".xml") {
+    loadConfigFileXML(configFile, verbose);
+  }
+  #ifdef VISP_HAVE_NLOHMANN_JSON
+  else if(extension == ".json") {
+    if(verbose) {
+      std::cerr << "MBT config parsing does not support verbose option for JSON parsing" << std::endl;
+    }
+    loadConfigFileJSON(configFile);
+  }
+  #endif
+  else {
+    throw vpException(vpException::ioError, "MBT config parsing: File format " + extension + "for file " + configFile + " is not supported.");
+  }
+}
+
+/*!
   Load the xml configuration file.
   From the configuration file initialize the parameters corresponding to the
   objects: tracking parameters, camera intrinsic parameters.
@@ -2828,7 +2868,7 @@ void vpMbGenericTracker::initFromPose(const std::map<std::string, const vpImage<
   \param configFile : full name of the xml file.
   \param verbose : verbose flag.
 */
-void vpMbGenericTracker::loadConfigFile(const std::string &configFile, bool verbose)
+void vpMbGenericTracker::loadConfigFileXML(const std::string &configFile, bool verbose)
 {
   for (std::map<std::string, TrackerWrapper *>::const_iterator it = m_mapOfTrackers.begin();
        it != m_mapOfTrackers.end(); ++it) {
@@ -6237,72 +6277,6 @@ void vpMbGenericTracker::TrackerWrapper::initMbtTracking(const vpImage<unsigned 
     vpMbEdgeTracker::computeVVSFirstPhaseFactor(*ptr_I, 0);
   }
 }
-#ifdef VISP_HAVE_NLOHMANN_JSON
-json vpMbGenericTracker::TrackerWrapper::asJson() const {
-  json j;
-  j["camera"] = m_cam;
-  j["type"] = m_trackerType;
-  j["lod"] = json{
-    {"useLod", useLodGeneral},
-    {"minLineLengthThresholdGeneral", minLineLengthThresholdGeneral},
-    {"minPolygonAreaThresholdGeneral", minPolygonAreaThresholdGeneral}
-  };
-  j["clipping"] = json {
-    {"fov", getClipping()},
-    {"near", getNearClippingDistance()},
-    {"far", getFarClippingDistance()},
-  };
-  j["angleAppear"] = getAngleAppear();
-  j["angleDisappear"] = getAngleDisappear();
-  
-  if(m_trackerType & EDGE_TRACKER) {
-    j["edge_tracker"] = me;
-  }
-
-  if(m_trackerType & KLT_TRACKER) {
-    json klt;
-    klt["maxFeatures"] = tracker.getMaxFeatures();
-    klt["windowSize"] = tracker.getWindowSize();
-    klt["quality"] = tracker.getQuality();
-    klt["minDistance"] = tracker.getMinDistance();
-    klt["harris"] = tracker.getHarrisFreeParameter();
-    klt["blockSize"] = tracker.getBlockSize();
-    klt["pyramidLevels"] = tracker.getPyramidLevels();
-    #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
-    klt["maskBorder"] = maskBorder;
-    #endif
-    j["klt"] = klt;
-  }
-
-  if(m_trackerType & DEPTH_NORMAL_TRACKER) {
-    j["normals"] = json {
-      {"featureEstimationMethod", m_depthNormalFeatureEstimationMethod},
-      {"pcl", {
-        {"method", m_depthNormalPclPlaneEstimationMethod,
-        "ransacMaxIter", m_depthNormalPclPlaneEstimationRansacMaxIter,
-        "ransacThreshold", m_depthNormalPclPlaneEstimationRansacThreshold}
-      }},
-      {"sampling", {
-        {"x", m_depthNormalSamplingStepX},
-        {"y", m_depthNormalSamplingStepY}
-      }}
-    };
-  }
-
-  if(m_trackerType & DEPTH_DENSE_TRACKER) {
-    j["dense"] = {
-      {"sampling", {
-        {"x", m_depthDenseSamplingStepX},
-        {"y", m_depthDenseSamplingStepY}
-      }}
-    };
-  }
-  return j;
-}
-void vpMbGenericTracker::TrackerWrapper::fromJson(const json& j) {
-
-}
-#endif
 
 void vpMbGenericTracker::TrackerWrapper::loadConfigFile(const std::string &configFile, bool verbose)
 {

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -40,6 +40,11 @@
 #include <visp3/core/vpTrackingException.h>
 #include <visp3/mbt/vpMbtXmlGenericParser.h>
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+#endif
+
 vpMbGenericTracker::vpMbGenericTracker()
   : m_error(), m_L(), m_mapOfCameraTransformationMatrix(), m_mapOfFeatureFactors(), m_mapOfTrackers(),
     m_percentageGdPt(0.4), m_referenceCameraName("Camera"), m_thresholdOutlier(0.5), m_w(), m_weightedError(),
@@ -177,6 +182,41 @@ vpMbGenericTracker::~vpMbGenericTracker()
     it->second = NULL;
   }
 }
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+void vpMbGenericTracker::loadJSONSettings(const std::string& settingsFile) {
+  std::ifstream jsonFile(settingsFile);
+  if(!jsonFile.good()) {
+    throw vpException(vpException::generalExceptionEnum::ioError, "Could not read from settings file " + settingsFile + " to initialise the vpMbtGenericTracker");
+  }
+  json settings = json::parse(jsonFile);
+  jsonFile.close();
+
+
+  m_referenceCameraName = settings.at("referenceCameraName").get<std::string>();
+  m_thresholdOutlier = settings.at("thresholdOutlier").get<double>();
+  std::map<std::string, vpHomogeneousMatrix> m = settings["mapOfCameraTransformationMatrix"];
+
+}
+void vpMbGenericTracker::saveJSONSettings(const std::string& settingsFile) {
+  json j;
+  j["referenceCameraName"] = m_referenceCameraName;
+  j["thresholdOutlier"] = m_thresholdOutlier;
+
+  for(const auto& kv: m_mapOfTrackers) {
+    j[kv.first] = kv.second->asJson();
+    j[kv.first]["cameraName"] = kv.first;
+  }
+
+  std::ofstream f(settingsFile);
+
+  f << j.dump(4);
+  f.close();
+
+
+}
+
+#endif
 
 /*!
   Compute projection error given an input image and camera pose, parameters.
@@ -6200,6 +6240,74 @@ void vpMbGenericTracker::TrackerWrapper::initMbtTracking(const vpImage<unsigned 
     vpMbEdgeTracker::computeVVSFirstPhaseFactor(*ptr_I, 0);
   }
 }
+#ifdef VISP_HAVE_NLOHMANN_JSON
+json vpMbGenericTracker::TrackerWrapper::asJson() const {
+  json j;
+  j["camera"] = m_cam;
+  j["type"] = m_trackerType;
+  j["lod"] = json{
+    {"useLod", useLodGeneral},
+    {"minLineLengthThresholdGeneral", minLineLengthThresholdGeneral},
+    {"minPolygonAreaThresholdGeneral", minPolygonAreaThresholdGeneral}
+  };
+
+  j["clipping"] = json {
+    {"fov", getClipping()},
+    {"near", getNearClippingDistance()},
+    {"far", getFarClippingDistance()},
+  };
+  j["angleAppear"] = getAngleAppear();
+  j["angleDisappear"] = getAngleDisappear();
+  
+
+  if(m_trackerType & EDGE_TRACKER) {
+    j["edge_tracker"] = me;
+  }
+
+  if(m_trackerType & KLT_TRACKER) {
+    json klt;
+    klt["maxFeatures"] = tracker.getMaxFeatures();
+    klt["windowSize"] = tracker.getWindowSize();
+    klt["quality"] = tracker.getQuality();
+    klt["minDistance"] = tracker.getMinDistance();
+    klt["harris"] = tracker.getHarrisFreeParameter();
+    klt["blockSize"] = tracker.getBlockSize();
+    klt["pyramidLevels"] = tracker.getPyramidLevels();
+    #if defined(VISP_HAVE_MODULE_KLT) && (defined(VISP_HAVE_OPENCV) && (VISP_HAVE_OPENCV_VERSION >= 0x020100))
+    klt["maskBorder"] = maskBorder;
+    #endif
+    j["klt"] = klt;
+  }
+
+  if(m_trackerType & DEPTH_NORMAL_TRACKER) {
+    j["normals"] = json {
+      {"featureEstimationMethod", m_depthNormalFeatureEstimationMethod},
+      {"pcl", {
+        {"method", m_depthNormalPclPlaneEstimationMethod,
+        "ransacMaxIter", m_depthNormalPclPlaneEstimationRansacMaxIter,
+        "ransacThreshold", m_depthNormalPclPlaneEstimationRansacThreshold}
+      }},
+      {"sampling", {
+        {"x", m_depthNormalSamplingStepX},
+        {"y", m_depthNormalSamplingStepY}
+      }}
+    };
+  }
+
+  if(m_trackerType & DEPTH_DENSE_TRACKER) {
+    j["dense"] = {
+      {"sampling", {
+        {"x", m_depthDenseSamplingStepX},
+        {"y", m_depthDenseSamplingStepY}
+      }}
+    };
+  }
+  return j;
+}
+void vpMbGenericTracker::TrackerWrapper::fromJson(const json& j) {
+
+}
+#endif
 
 void vpMbGenericTracker::TrackerWrapper::loadConfigFile(const std::string &configFile, bool verbose)
 {

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -192,7 +192,6 @@ void vpMbGenericTracker::loadJSONSettings(const std::string& settingsFile) {
   json settings = json::parse(jsonFile);
   jsonFile.close();
 
-
   m_referenceCameraName = settings.at("referenceCameraName").get<std::string>();
   m_thresholdOutlier = settings.at("thresholdOutlier").get<double>();
   std::map<std::string, vpHomogeneousMatrix> m = settings["mapOfCameraTransformationMatrix"];
@@ -210,10 +209,8 @@ void vpMbGenericTracker::saveJSONSettings(const std::string& settingsFile) {
 
   std::ofstream f(settingsFile);
 
-  f << j.dump(4);
+  f << j.dump(4); // indent level as parameter
   f.close();
-
-
 }
 
 #endif
@@ -6250,7 +6247,6 @@ json vpMbGenericTracker::TrackerWrapper::asJson() const {
     {"minLineLengthThresholdGeneral", minLineLengthThresholdGeneral},
     {"minPolygonAreaThresholdGeneral", minPolygonAreaThresholdGeneral}
   };
-
   j["clipping"] = json {
     {"fov", getClipping()},
     {"near", getNearClippingDistance()},
@@ -6259,7 +6255,6 @@ json vpMbGenericTracker::TrackerWrapper::asJson() const {
   j["angleAppear"] = getAngleAppear();
   j["angleDisappear"] = getAngleDisappear();
   
-
   if(m_trackerType & EDGE_TRACKER) {
     j["edge_tracker"] = me;
   }

--- a/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
@@ -1,0 +1,156 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test vpMbGenericTracker JSON parse / save.
+ *
+ *****************************************************************************/
+
+/*!
+  \file testMbtJsonSettings.cpp
+
+  Test test saving and parsing JSON configuration for vpMbGenericTracker
+*/
+
+#include <visp3/core/vpIoTools.h>
+#include <visp3/mbt/vpMbGenericTracker.h>
+
+#if defined(VISP_HAVE_NLOHMANN_JSON)
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+bool test_json(const std::string& dir, const std::string& test_name, const std::function<vpMbGenericTracker()> setup, const std::function<void(json&)> modifyJson, const std::function<bool(const vpMbGenericTracker&, const vpMbGenericTracker&)> compare) {
+  const std::string json_path = dir + "/" + test_name + ".json";
+  vpMbGenericTracker t1 = setup();
+  t1.saveConfigFile(json_path);
+
+  std::ifstream json_file(json_path);
+  if(!json_file.good()) {
+    throw vpException(vpException::ioError, "Could not open JSON settings file");
+  }
+  json j = json::parse(json_file);
+  json_file.close();
+  modifyJson(j);
+  std::ofstream json_modif_file(json_path);
+  if(!json_modif_file.good()) {
+    throw vpException(vpException::ioError, "Could not open JSON settings file for writing modifications");
+  }
+  json_modif_file << j.dump();
+
+  vpMbGenericTracker t2;
+  t2.loadConfigFile(json_path);
+
+  return compare(t1, t2);
+}
+
+#endif
+
+
+int main()
+{
+#if defined(VISP_HAVE_NLOHMANN_JSON)
+
+#if defined(_WIN32)
+  std::string tmp_dir = "C:/temp/";
+#else
+  std::string tmp_dir = "/tmp/";
+#endif
+
+  // setup test dir
+  // Get the user login name
+  std::string username;
+  vpIoTools::getUserName(username);
+
+  tmp_dir += username + "/visp_test_json_parsing_mbt/";
+  vpIoTools::remove(tmp_dir);
+  std::cout << "Create: " << tmp_dir << std::endl;
+  vpIoTools::makeDirectory(tmp_dir);
+
+
+  const auto base_constructor = []() -> vpMbGenericTracker {
+    const std::vector<std::string> names = {"C1", "C2"};
+    const std::vector<int> featureTypes = {
+      vpMbGenericTracker::EDGE_TRACKER | vpMbGenericTracker::KLT_TRACKER,
+      vpMbGenericTracker::DEPTH_DENSE_TRACKER | vpMbGenericTracker::DEPTH_NORMAL_TRACKER
+    };
+    vpMbGenericTracker tracker(names, featureTypes);
+    return tracker;
+  };
+  const auto base_compare = [](const vpMbGenericTracker& t1, const vpMbGenericTracker& t2) -> bool {
+    const bool same_cameras = t1.getCameraNames() == t2.getCameraNames();
+    if(!same_cameras) {
+      return false;
+    }
+    const bool same_features = t1.getCameraTrackerTypes() == t2.getCameraTrackerTypes();
+    if(!same_features) {
+      return false;
+    }
+    return true;
+
+  };
+  const auto no_modif = [](json& j) -> void {
+
+  };
+  //! First test, check that a basic tracker can be saved and loaded
+  if(!test_json(tmp_dir, "basic_test", base_constructor, no_modif, base_compare)) {
+    std::cerr << "Basic JSON parsing test failed: not same camera names or camera features" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  //! Test on version field: should be present and the correct version
+  try {
+    test_json(tmp_dir, "throw_version_inexistant", base_constructor, [](json& j) -> void { j.erase("version"); }, base_compare);
+    return EXIT_FAILURE;
+  } catch(vpException& e) {
+    if(e.getCode() != vpException::badValue) {
+      return EXIT_FAILURE;
+    }
+  } catch(...) {
+    std::cerr << "Unexpected exception was caught" << std::endl;
+    return EXIT_FAILURE;
+  }
+  
+  try {
+    test_json(tmp_dir, "throw_wrong_version", base_constructor, [](json& j) -> void { j["version"] = "0.1"; }, base_compare);
+    return EXIT_FAILURE;
+  } catch(vpException& e) {
+    if(e.getCode() != vpException::badValue) {
+      return EXIT_FAILURE;
+    }
+  } catch(...) {
+    std::cerr << "Unexpected exception was caught" << std::endl;
+    return EXIT_FAILURE;
+  }
+  
+#else
+  std::cout << "Cannot run this example: install Lapack, Eigen3 or OpenCV" << std::endl;
+#endif
+
+  return EXIT_SUCCESS;
+}

--- a/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
@@ -66,13 +66,36 @@ vpMbGenericTracker baseTrackerConstructor() {
   cams[names[0]] = cam1;
   cams[names[1]] = cam2;
   t.setCameraParameters(cams);
+
+  t.setLod(false);
+
+  t.setAngleAppear(vpMath::rad(60));
+  t.setAngleDisappear(vpMath::rad(90));
+  
   return t;
 }
+
+
+template<typename T, typename C>
+void checkProperties(const T& t1, const T& t2, C fn, const std::string& message) {
+  THEN(message) {
+    REQUIRE( (t1.*fn)() == (t2.*fn)() );
+  }
+}
+
+
+template<typename T, typename C, typename... Fns>
+void checkProperties(const T& t1, const T& t2, C fn, const std::string& message, Fns... fns) {
+  checkProperties(t1, t2, fn, message);
+  checkProperties(t1, t2, fns...);
+}
+
 
 void compareNamesAndTypes(const vpMbGenericTracker& t1, const vpMbGenericTracker& t2) {
   REQUIRE( t1.getCameraNames() == t2.getCameraNames() );
   REQUIRE( t1.getCameraTrackerTypes() == t2.getCameraTrackerTypes() );
 }
+
 
 void compareCameraParameters(const vpMbGenericTracker& t1, const vpMbGenericTracker& t2) {
   std::map<std::string, vpCameraParameters> c1, c2;
@@ -92,7 +115,6 @@ json loadJson(const std::string& path) {
   return j;
 }
 
-
 void saveJson(const json& j, const std::string& path) {
   std::ofstream json_file(path);
   if(!json_file.good()) {
@@ -102,60 +124,12 @@ void saveJson(const json& j, const std::string& path) {
   json_file.close();
 }
 
-void test_json(const std::string& dir, const std::string& test_name, const std::function<vpMbGenericTracker()> setup, const std::function<void(json&)> modifyJson, const std::function<void(const vpMbGenericTracker&, const vpMbGenericTracker&)> compare) {
-  const std::string json_path = dir + "/" + test_name + ".json";
-  vpMbGenericTracker t1 = setup();
-  t1.saveConfigFile(json_path);
-
-  json j = loadJson(json_path);
-  modifyJson(j);
-  saveJson(j, json_path);
-  
-
-  vpMbGenericTracker t2;
-  t2.loadConfigFile(json_path);
-
-  compare(t1, t2);
-}
-
-
-//   // // Reference camera name not found
-//   // try {
-//   //   test_json(tmp_dir, "reference_cam_not_found", baseTrackerConstructor, [](json& j) -> void { j["referenceCameraName"] = "C3"; }, compareNamesAndTypes);
-//   //   return EXIT_FAILURE;
-//   // } catch(vpException& e) {
-//   //   if(e.getCode() != vpException::badValue) {
-//   //     return EXIT_FAILURE;
-//   //   }
-//   // } catch(...) {
-//   //   std::cerr << "Unexpected exception was caught" << std::endl;
-//   //   return EXIT_FAILURE;
-//   // }
-
-//   // // Camera to ref transformations test
-  
-//   // if(!test_json(tmp_dir, "camTref_removed_for_ref", baseTrackerConstructor, [](json& j) -> void { j["trackers"][j["referenceCameraName"].get<std::string>()].erase("camTref"); }, compareNamesAndTypes)) {
-//   //   std::cerr << "Removing the camera transformations should be allowed for the reference camera" << std::endl;
-//   //   return EXIT_FAILURE;
-//   // }
-
-SCENARIO("MBT JSON Parsing", "[json]") {
+SCENARIO("MBT JSON Serialization", "[json]") {
   // setup test dir
   // Get the user login name
-#if defined(_WIN32)
-  std::string tmp_dir = "C:/temp/";
-#else
-  std::string tmp_dir = "/tmp/";
-#endif
-  std::string username;
-  vpIoTools::getUserName(username);
 
-  tmp_dir += username + "/visp_test_json_parsing_mbt/";
-  vpIoTools::remove(tmp_dir);
-  std::cout << "Create: " << tmp_dir << std::endl;
-  vpIoTools::makeDirectory(tmp_dir);
-
-
+  std::string tmp_dir = vpIoTools::makeTempDirectory(vpIoTools::getTempPath() + vpIoTools::path("/") + "visp_test_json_parsing_mbt");
+  
 
   GIVEN("A generic tracker with two cameras, one with edge and KLT features, the other with depth features") {
     vpMbGenericTracker t1 = baseTrackerConstructor();
@@ -175,7 +149,87 @@ SCENARIO("MBT JSON Parsing", "[json]") {
         compareNamesAndTypes(t1, t2);
         compareCameraParameters(t1, t2);
       }
-      WHEN("Modifying JSON file") {
+
+      THEN("Reloading this tracker has the same basic properties") {
+        vpMbGenericTracker t2;
+        REQUIRE_NOTHROW(t2.loadConfigFile(jsonPath));
+        checkProperties(t1, t2,
+                &vpMbGenericTracker::getAngleAppear, "Angle appear should be the same",
+                &vpMbGenericTracker::getAngleDisappear, "Angle appear should be the same"
+        );
+      }
+
+      THEN("Reloaded edge tracker parameters should be the same") {
+        std::map<std::string, vpMe> oldvpMe, newvpMe;
+        t1.getMovingEdge(oldvpMe);
+        vpMbGenericTracker t2;
+        t2.loadConfigFile(jsonPath);
+        t2.getMovingEdge(newvpMe);
+        for(const auto& it: oldvpMe) {
+          vpMe o = it.second;
+          vpMe n;
+          REQUIRE_NOTHROW( n = newvpMe[it.first] );
+          checkProperties(o, n,
+            &vpMe::getAngleStep, "Angle step should be equal",
+            &vpMe::getMaskNumber, "Mask number should be equal",
+            &vpMe::getMaskSign, "Mask sign should be equal",
+            &vpMe::getMinSampleStep, "Min sample step should be equal",
+            &vpMe::getMu1, "Mu 1 should be equal",
+            &vpMe::getMu2, "Mu 2 should be equal",
+            &vpMe::getNbTotalSample, "Nb total sample should be equal",
+            &vpMe::getPointsToTrack, "Number of points to track should be equal",
+            &vpMe::getRange, "Range should be equal",
+            &vpMe::getStrip, "Strip should be equal"
+          );
+        }
+      }
+      
+      THEN("Reloaded KLT tracker parameters should be the same") {
+        std::map<std::string, vpKltOpencv> oldvpKlt, newvpKlt;
+        t1.getKltOpencv(oldvpKlt);
+        vpMbGenericTracker t2;
+        t2.loadConfigFile(jsonPath);
+        t2.getKltOpencv(newvpKlt);
+        for(const auto& it: oldvpKlt) {
+          vpKltOpencv o = it.second;
+          vpKltOpencv n;
+          REQUIRE_NOTHROW( n = newvpKlt[it.first] );
+          checkProperties(o, n,
+            &vpKltOpencv::getBlockSize, "Block size should be equal",
+            &vpKltOpencv::getHarrisFreeParameter, "Harris parameter should be equal",
+            &vpKltOpencv::getMaxFeatures, "Max number of features should be equal",
+            &vpKltOpencv::getMinDistance, "Minimum distance should be equal",
+            &vpKltOpencv::getPyramidLevels, "Pyramid levels should be equal",
+            &vpKltOpencv::getQuality, "Quality should be equal",
+            &vpKltOpencv::getWindowSize, "Window size should be equal"
+          );
+        }
+      }
+
+      THEN("Clipping properties should be the same") {
+        vpMbGenericTracker t2 = baseTrackerConstructor();
+        t2.setNearClippingDistance(0.1);
+        t2.setFarClippingDistance(2.0);
+        t2.setClipping(vpPolygon3D::ALL_CLIPPING);
+        t2.loadConfigFile(jsonPath);
+        std::map<std::string, unsigned int> oldFlags, newFlags;
+        t1.getClipping(oldFlags);
+        t2.getClipping(newFlags);
+        for(const auto it: oldFlags) {
+          unsigned int o = it.second;
+          unsigned int n;
+          REQUIRE_NOTHROW( n = newFlags[it.first] );
+          THEN("Clipping flags for camera " + it.first + " should be the same") {
+            REQUIRE( o == n );
+          }
+        }
+        checkProperties(t1, t2,
+          &vpMbGenericTracker::getNearClippingDistance, "Near clipping distance should be the same",
+          &vpMbGenericTracker::getFarClippingDistance, "Far clipping distance should be the same"
+        );
+      }
+
+      WHEN("Modifying JSON file/Using a custom JSON file") {
         THEN("Removing version from file generates an error on load") {
           modifyJson([](json& j) -> void {
             j.erase("version");
@@ -211,12 +265,71 @@ SCENARIO("MBT JSON Parsing", "[json]") {
           });
           REQUIRE_THROWS(t1.loadConfigFile(jsonPath));
         }
+
+        THEN("The full clipping config is optional") {
+          vpMbGenericTracker t2 = baseTrackerConstructor();
+          const double near = 0.21;
+          const double far = 5.2;
+          const int clipping = vpPolygon3D::LEFT_CLIPPING;
+          t2.setNearClippingDistance(near);
+          t2.setFarClippingDistance(far);
+          t2.setClipping(clipping);
+          modifyJson([&t1](json &j) -> void {
+            for(const auto& c: t1.getCameraNames()) {
+              j["trackers"][c].erase("clipping");
+            }
+          });
+          REQUIRE_NOTHROW(t2.loadConfigFile(jsonPath, false));
+          REQUIRE( t2.getClipping() == clipping);
+          REQUIRE( t2.getNearClippingDistance() == near );
+          REQUIRE( t2.getFarClippingDistance() == far );
+        }
+
+        THEN("Each clipping param is optional on its own") {
+          vpMbGenericTracker t2 = baseTrackerConstructor();
+          const double near = 0.21;
+          const double far = 5.2;
+          const int clipping = vpPolygon3D::LEFT_CLIPPING;
+          t2.setNearClippingDistance(near);
+          t2.setFarClippingDistance(far);
+          t2.setClipping(clipping);
+          THEN("Near clipping is optional") {
+            modifyJson([&t1](json &j) -> void {
+              for(const auto& c: t1.getCameraNames()) {
+                j["trackers"][c]["clipping"].erase("near");
+              }
+            });
+            t2.loadConfigFile(jsonPath);
+            REQUIRE(t2.getNearClippingDistance() == near);
+            REQUIRE(t2.getFarClippingDistance() == t1.getFarClippingDistance());
+            REQUIRE(t2.getClipping() == t1.getClipping());
+          }
+          THEN("Far clipping is optional") {
+            modifyJson([&t1](json &j) -> void {
+              for(const auto& c: t1.getCameraNames()) {
+                j["trackers"][c]["clipping"].erase("far");
+              }
+            });
+            t2.loadConfigFile(jsonPath);
+            REQUIRE(t2.getNearClippingDistance() == t1.getNearClippingDistance());
+            REQUIRE(t2.getFarClippingDistance() == far);
+            REQUIRE(t2.getClipping() == t1.getClipping());
+          }
+          THEN("Clipping flags are optional") {
+            modifyJson([&t1](json &j) -> void {
+              for(const auto& c: t1.getCameraNames()) {
+                j["trackers"][c]["clipping"].erase("flags");
+              }
+            });
+            t2.loadConfigFile(jsonPath);
+            REQUIRE(t2.getNearClippingDistance() == t1.getNearClippingDistance());
+            REQUIRE(t2.getFarClippingDistance() == t1.getFarClippingDistance());
+            REQUIRE(t2.getClipping() & clipping);
+          }
+        }
       }
     }
   }
-
-
-  
 }
 int main(int argc, char *argv[])
 {
@@ -227,7 +340,7 @@ int main(int argc, char *argv[])
   return numFailed;
 }
 
-#else 
+#else
 
 int main() {
   return EXIT_SUCCESS;

--- a/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
@@ -215,7 +215,7 @@ SCENARIO("MBT JSON Serialization", "[json]") {
         std::map<std::string, unsigned int> oldFlags, newFlags;
         t1.getClipping(oldFlags);
         t2.getClipping(newFlags);
-        for(const auto it: oldFlags) {
+        for(const auto& it: oldFlags) {
           unsigned int o = it.second;
           unsigned int n;
           REQUIRE_NOTHROW( n = newFlags[it.first] );

--- a/modules/tracker/me/CMakeLists.txt
+++ b/modules/tracker/me/CMakeLists.txt
@@ -48,3 +48,8 @@ if(USE_OPENCV)
   vp_set_source_file_compile_flag(src/moving-edges/vpMeNurbs.cpp -Wno-float-equal)
   vp_set_source_file_compile_flag(test/testNurbs.cpp -Wno-float-equal)
 endif()
+
+if(WITH_CATCH2)
+  # catch2 is private
+  include_directories(${CATCH2_INCLUDE_DIRS})
+endif()

--- a/modules/tracker/me/include/visp3/me/vpMe.h
+++ b/modules/tracker/me/include/visp3/me/vpMe.h
@@ -301,35 +301,31 @@ public:
     \sa getThreshold()
   */
   void setThreshold(const double &t) { threshold = t; }
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+  friend void to_json(nlohmann::json& j, const vpMe& me);
+  friend  void from_json(const nlohmann::json& j, vpMe& me);
+#endif
 };
 
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
 #include <nlohmann/json.hpp>
 
-/*
-double threshold; //! Likelihood ratio threshold
-  double mu1;       //! Contrast continuity parameter (left boundary)
-  double mu2;       //! Contrast continuity parameter (right boundary)
-  double min_samplestep;
-  unsigned int anglestep;
-  int mask_sign;
-  unsigned int range; //! Seek range - on both sides of the reference pixel
-  double sample_step; //! Distance between sampled points (in pixels)
-  int ntotal_sample;
-  int points_to_track;
-  unsigned int mask_size;
-  unsigned int n_mask;
-  int strip;*/
+/**
+ * @brief Convert a vpMe object to a JSON representation
+ * 
+ * @param j resulting json object
+ * @param me the object to convert
+ */
 inline void to_json(nlohmann::json& j, const vpMe& me) {
   j["threshold"] = me.getThreshold();
   j["mu"] = {me.getMu1(), me.getMu2()};
   j["minSampleStep"] = me.getMinSampleStep();
   j["angleStep"] = me.getAngleStep();
   j["sampleStep"] = me.getSampleStep();
-  
   j["range"] = me.getRange();
-  j["ntotal_sample"] = me.getNbTotalSample();
+  j["ntotalSample"] = me.getNbTotalSample();
   j["pointsToTrack"] = me.getPointsToTrack();
   j["maskSize"] = me.getMaskSize();
   j["nMask"] = me.getMaskNumber();
@@ -337,22 +333,67 @@ inline void to_json(nlohmann::json& j, const vpMe& me) {
   j["strip"] = me.getStrip();
 }
 
+/**
+ * @brief Retrieve a vpMe object from a JSON representation
+ * 
+ * JSON content (key: type):
+ *  - threshold: double, vpMe::setThreshold
+ *  - mu : [double, double], vpMe::setMu1, vpMe::setMu2
+ *  - minSampleStep: double, vpMe::setMinSampleStep
+ *  - angleStep: double, vpMe::setAngleStep
+ *  - sampleStep: double, vpMe::setSampleStep
+ *  - range: int, vpMe::setRange
+ *  - ntotal_sample: int, vpMe::setNbTotalSample
+ *  - pointsToTrack: int, vpMe::setPointsToTrack
+ *  - maskSize: int, vpMe::setMaskSize
+ *  - nMask: int, vpMe::setMaskNumber
+ *  - maskSign: int, vpMe::setMaskSign
+ *  - strip: int, vpMe::setStrip
+ * 
+ * Example:
+ * \code{.json}
+ * {
+ *  "angleStep": 1,
+    "maskSign": 0,
+    "maskSize": 5,
+    "minSampleStep": 4.0,
+    "mu": [
+        0.5,
+        0.5
+    ],
+    "nMask": 180,
+    "ntotal_sample": 0,
+    "pointsToTrack": 500,
+    "range": 7,
+    "sampleStep": 4.0,
+    "strip": 2,
+    "threshold": 5000.0
+  }
+ * \endcode
+ * 
+ * @param j JSON representation to convert
+ * @param me converted object
+ */
 inline void from_json(const nlohmann::json& j, vpMe& me) {
-  me.setThreshold(j.at("threshold").get<double>());
-  std::vector<double> mus = j.at("mu").get<std::vector<double>>();
-  assert((mus.size() == 2));
-  me.setMu1(mus[0]);
-  me.setMu2(mus[1]);
-  me.setMinSampleStep(j.at("minSampleStep").get<double>());
-  me.setAngleStep(j.at("angleStep").get<unsigned>());
-  me.setSampleStep(j.at("sampleStep").get<double>());
-  me.setRange(j.at("range").get<unsigned>());
-  me.setNbTotalSample(j.at("ntotal_sample").get<int>());
-  me.setPointsToTrack(j.at("pointsToTrack").get<int>());
-  me.setMaskSize(j.at("maskSize").get<unsigned>());
-  me.setMaskNumber(j.at("nMask").get<unsigned>());
-  me.setMaskSign(j.at("maskSign").get<int>());
-  me.setStrip(j.at("strip").get<int>());
+
+  me.threshold = j.value("threshold", me.threshold);
+  
+  if(j.contains("mu")) {
+    std::vector<double> mus = j.at("mu").get<std::vector<double>>();
+    assert((mus.size() == 2));
+    me.setMu1(mus[0]);
+    me.setMu2(mus[1]);
+  }
+  me.min_samplestep = j.value("minSampleStep", me.min_samplestep);
+  me.anglestep = j.value("angleStep", me.anglestep);
+  me.range = j.value("range", me.range);
+  me.ntotal_sample = j.value("ntotalSample", me.ntotal_sample);
+  me.points_to_track = j.value("pointsToTrack", me.points_to_track);
+  me.mask_size = j.value("maskSize", me.mask_size);
+  me.n_mask = j.value("nMask", me.n_mask);
+  me.mask_sign = j.value("maskSign", me.mask_sign);
+  me.strip = j.value("strip", me.strip);
+
   
   me.initMask();
 }

--- a/modules/tracker/me/include/visp3/me/vpMe.h
+++ b/modules/tracker/me/include/visp3/me/vpMe.h
@@ -59,8 +59,6 @@ public:
 #else
 private:
 #endif
-#ifdef VISP_HAVE_NLOHMANN_JSON
-#endif
   double threshold; //! Likelihood ratio threshold
   double mu1;       //! Contrast continuity parameter (left boundary)
   double mu2;       //! Contrast continuity parameter (right boundary)
@@ -319,18 +317,19 @@ public:
  * @param me the object to convert
  */
 inline void to_json(nlohmann::json& j, const vpMe& me) {
-  j["threshold"] = me.getThreshold();
-  j["mu"] = {me.getMu1(), me.getMu2()};
-  j["minSampleStep"] = me.getMinSampleStep();
-  j["angleStep"] = me.getAngleStep();
-  j["sampleStep"] = me.getSampleStep();
-  j["range"] = me.getRange();
-  j["ntotalSample"] = me.getNbTotalSample();
-  j["pointsToTrack"] = me.getPointsToTrack();
-  j["maskSize"] = me.getMaskSize();
-  j["nMask"] = me.getMaskNumber();
-  j["maskSign"] = me.getMaskSign();
-  j["strip"] = me.getStrip();
+  j = {
+    {"threshold", me.threshold},
+    {"mu", {me.mu1, me.mu2}},
+    {"minSampleStep", me.min_samplestep},
+    {"sampleStep", me.sample_step},
+    {"range", me.range},
+    {"ntotalSample", me.ntotal_sample},
+    {"pointsToTrack", me.points_to_track},
+    {"maskSize", me.mask_size},
+    {"nMask", me.n_mask},
+    {"maskSign", me.mask_sign},
+    {"strip", me.strip}
+  };
 }
 
 /**
@@ -375,7 +374,6 @@ inline void to_json(nlohmann::json& j, const vpMe& me) {
  * @param me converted object
  */
 inline void from_json(const nlohmann::json& j, vpMe& me) {
-
   me.threshold = j.value("threshold", me.threshold);
   
   if(j.contains("mu")) {
@@ -385,16 +383,21 @@ inline void from_json(const nlohmann::json& j, vpMe& me) {
     me.setMu2(mus[1]);
   }
   me.min_samplestep = j.value("minSampleStep", me.min_samplestep);
-  me.anglestep = j.value("angleStep", me.anglestep);
+  
   me.range = j.value("range", me.range);
   me.ntotal_sample = j.value("ntotalSample", me.ntotal_sample);
   me.points_to_track = j.value("pointsToTrack", me.points_to_track);
   me.mask_size = j.value("maskSize", me.mask_size);
-  me.n_mask = j.value("nMask", me.n_mask);
   me.mask_sign = j.value("maskSign", me.mask_sign);
   me.strip = j.value("strip", me.strip);
-
-  
+  if(j.contains("angleStep") && j.contains("nMask")) {
+    std::cerr << "both angle step and number of masks are defined, number of masks will take precedence" << std::endl;
+    me.setMaskNumber(j["nMask"]);
+  } else if(j.contains("angleStep")) {
+    me.setAngleStep(j["angleStep"]);
+  } else if (j.contains("nMask")) {
+    me.setMaskNumber(j["nMask"]);
+  }
   me.initMask();
 }
 

--- a/modules/tracker/me/include/visp3/me/vpMe.h
+++ b/modules/tracker/me/include/visp3/me/vpMe.h
@@ -59,6 +59,8 @@ public:
 #else
 private:
 #endif
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#endif
   double threshold; //! Likelihood ratio threshold
   double mu1;       //! Contrast continuity parameter (left boundary)
   double mu2;       //! Contrast continuity parameter (right boundary)
@@ -299,6 +301,69 @@ public:
     \sa getThreshold()
   */
   void setThreshold(const double &t) { threshold = t; }
+
+  
+
 };
+
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#include <nlohmann/json.hpp>
+
+/*
+double threshold; //! Likelihood ratio threshold
+  double mu1;       //! Contrast continuity parameter (left boundary)
+  double mu2;       //! Contrast continuity parameter (right boundary)
+  double min_samplestep;
+  unsigned int anglestep;
+  int mask_sign;
+  unsigned int range; //! Seek range - on both sides of the reference pixel
+  double sample_step; //! Distance between sampled points (in pixels)
+  int ntotal_sample;
+  int points_to_track;
+  unsigned int mask_size;
+  unsigned int n_mask;
+  int strip;*/
+inline void to_json(nlohmann::json& j, const vpMe& me) {
+  j["threshold"] = me.getThreshold();
+  j["mu"] = {me.getMu1(), me.getMu2()};
+  j["minSampleStep"] = me.getMinSampleStep();
+  j["angleStep"] = me.getAngleStep();
+  j["sampleStep"] = me.getSampleStep();
+  
+  j["range"] = me.getRange();
+  j["ntotal_sample"] = me.getNbTotalSample();
+  j["pointsToTrack"] = me.getPointsToTrack();
+  j["maskSize"] = me.getMaskSize();
+  j["nMask"] = me.getMaskNumber();
+  j["maskSign"] = me.getMaskSign();
+  j["strip"] = me.getStrip();
+
+  
+
+}
+
+inline void from_json(const nlohmann::json& j, vpMe& me) {
+  me.setThreshold(j.at("threshold").get<double>());
+  std::vector<double> mus = j.at("mu").get<std::vector<double>>();
+  assert((mus.size() == 2));
+  me.setMu1(mus[0]);
+  me.setMu2(mus[1]);
+  me.setMinSampleStep(j.at("minSampleStep").get<double>());
+  me.setAngleStep(j.at("angleStep").get<unsigned>());
+  me.setSampleStep(j.at("sampleStep").get<double>());
+  me.setRange(j.at("range").get<unsigned>());
+  me.setNbTotalSample(j.at("ntotal_sample").get<int>());
+  me.setPointsToTrack(j.at("pointsToTrack").get<int>());
+  me.setMaskSize(j.at("maskSize").get<unsigned>());
+  me.setMaskNumber(j.at("nMask").get<unsigned>());
+  me.setMaskSign(j.at("maskSign").get<int>());
+  me.setStrip(j.at("strip").get<int>());
+  
+  me.initMask();
+}
+
+
+#endif
 
 #endif

--- a/modules/tracker/me/include/visp3/me/vpMe.h
+++ b/modules/tracker/me/include/visp3/me/vpMe.h
@@ -301,9 +301,6 @@ public:
     \sa getThreshold()
   */
   void setThreshold(const double &t) { threshold = t; }
-
-  
-
 };
 
 
@@ -338,9 +335,6 @@ inline void to_json(nlohmann::json& j, const vpMe& me) {
   j["nMask"] = me.getMaskNumber();
   j["maskSign"] = me.getMaskSign();
   j["strip"] = me.getStrip();
-
-  
-
 }
 
 inline void from_json(const nlohmann::json& j, vpMe& me) {

--- a/modules/tracker/me/test/testJsonMe.cpp
+++ b/modules/tracker/me/test/testJsonMe.cpp
@@ -120,13 +120,17 @@ public:
     }
 };
 Catch::Generators::GeneratorWrapper<vpMe> randomMe() {
-    return Catch::Generators::GeneratorWrapper<vpMe>(std::unique_ptr<Catch::Generators::IGenerator<vpMe>>(new RandomMeGenerator()));
+    return Catch::Generators::GeneratorWrapper<vpMe>(
+      std::unique_ptr<Catch::Generators::IGenerator<vpMe>>(
+        new RandomMeGenerator()
+      )
+    );
 }
 }
 
 SCENARIO("Serializing and deserializing a single vpMe", "[json]") {
   GIVEN("Some random vpMe object") {
-    vpMe me = GENERATE(take(1000, randomMe()));        
+    vpMe me = GENERATE(take(100, randomMe()));        
     WHEN("Serializing and deserializing an object") {
         const json j = me;
         const vpMe otherMe = j;

--- a/modules/tracker/me/test/testJsonMe.cpp
+++ b/modules/tracker/me/test/testJsonMe.cpp
@@ -1,0 +1,219 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2019 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Test vpCameraParameters JSON parse / save.
+ *
+ *****************************************************************************/
+
+/*!
+  \file testJsonCamera.cpp
+
+  Test test saving and parsing JSON configuration for vpCameraParameters
+*/
+
+#include <random>
+#include <visp3/core/vpIoTools.h>
+#include <visp3/me/vpMe.h>
+
+#if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_CATCH2)
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#define CATCH_CONFIG_RUNNER
+#include <catch.hpp>
+
+template<typename T, typename C>
+void checkProperties(const T& t1, const T& t2, C fn, const std::string& message) {
+  THEN(message) {
+    REQUIRE( (t1.*fn)() == (t2.*fn)() );
+  }
+}
+
+
+template<typename T, typename C, typename... Fns>
+void checkProperties(const T& t1, const T& t2, C fn, const std::string& message, Fns... fns) {
+  checkProperties(t1, t2, fn, message);
+  checkProperties(t1, t2, fns...);
+}
+
+template<typename C>
+void testOptionalProperty(json& j, const std::vector<std::string>& keys, vpMe& me,
+std::function<void(vpMe*, C)> setter, std::function<C(vpMe*)> getter, std::function<C(C)> valueFn) {
+  THEN("Removing keys does not modify the value") {
+    const C v = valueFn(getter(&me));
+    setter(&me, v);
+    for(const std::string& k: keys) {
+      if(!j.contains(k)) {
+        FAIL();
+      }
+      j.erase(k);
+    }
+    from_json(j, me);
+    REQUIRE(getter(&me) == v);
+  }
+}
+
+
+
+namespace {
+class RandomMeGenerator : public Catch::Generators::IGenerator<vpMe> {
+private:
+    std::minstd_rand m_rand;
+    std::uniform_real_distribution<> m_dist;
+    std::uniform_int_distribution<> m_int_dist;
+    
+    
+    vpMe current;
+public:
+
+    RandomMeGenerator():
+        m_rand(std::random_device{}()),
+        m_dist(0.0, 1.0),
+        m_int_dist(1, 10)
+
+    {
+        static_cast<void>(next());
+    }
+
+    vpMe const& get() const override {
+        return current;
+    }
+    bool next() override {
+        current.setThreshold(m_dist(m_rand) * 1000.0);
+        current.setMaskNumber(m_int_dist(m_rand) * 10);
+        current.setMaskSign(m_int_dist(m_rand) > 5 ? 1 : 0);
+        current.setMu1(m_dist(m_rand));
+        current.setMu2(current.getMu1() + m_dist(m_rand));
+        current.setNbTotalSample(m_int_dist(m_rand) * 2);
+        current.setPointsToTrack(m_int_dist(m_rand));
+        current.setRange(m_int_dist(m_rand));
+        current.setStrip(m_int_dist(m_rand));
+        return true;
+    }
+};
+Catch::Generators::GeneratorWrapper<vpMe> randomMe() {
+    return Catch::Generators::GeneratorWrapper<vpMe>(std::unique_ptr<Catch::Generators::IGenerator<vpMe>>(new RandomMeGenerator()));
+}
+}
+
+SCENARIO("Serializing and deserializing a single vpMe", "[json]") {
+  GIVEN("Some random vpMe object") {
+    vpMe me = GENERATE(take(1000, randomMe()));        
+    WHEN("Serializing and deserializing an object") {
+        const json j = me;
+        const vpMe otherMe = j;
+        THEN("The object's properties are the same") {
+          checkProperties(me, otherMe,
+            &vpMe::getThreshold, "Threshold should be equal",
+            &vpMe::getAngleStep, "Angle step should be equal",
+            &vpMe::getMaskNumber, "Mask number should be equal",
+            &vpMe::getMaskSign, "Mask sign should be equal",
+            &vpMe::getMinSampleStep, "Min sample step should be equal",
+            &vpMe::getSampleStep, "Sample step should be equal",
+            &vpMe::getMu1, "Mu 1 should be equal",
+            &vpMe::getMu2, "Mu 2 should be equal",
+            &vpMe::getNbTotalSample, "Nb total sample should be equal",
+            &vpMe::getPointsToTrack, "Number of points to track should be equal",
+            &vpMe::getRange, "Range should be equal",
+            &vpMe::getStrip, "Strip should be equal"
+          );
+        }
+    }
+    WHEN("Removing optional properties in JSON object") {
+        json j = me;
+        const auto testInt = [&j, &me](const std::string& key,
+        std::function<void(vpMe*, int)> setter, std::function<int(vpMe*)> getter) -> void {
+          testOptionalProperty<int>(j, {key}, me, setter, getter, [](int v) -> int {return v - 1;});
+          
+        };
+        const auto testDouble = [&j, &me](const std::string& key, 
+        std::function<void(vpMe*, double)> setter, std::function<double(vpMe*)> getter) -> void {
+          testOptionalProperty<double>(j, {key}, me, setter, getter, [](double v) -> int {return v + 1.0;});
+        };
+        
+        WHEN("Removing threshold") {
+          testDouble("threshold", &vpMe::setThreshold, &vpMe::getThreshold);
+        }
+        WHEN("Removing mu1 and mu2") {
+          testDouble("mu", &vpMe::setMu1, &vpMe::getMu1);
+          testDouble("mu", &vpMe::setMu2, &vpMe::getMu2);
+          
+        }
+        
+        WHEN("Removing nMask") {
+          testInt("nMask", &vpMe::setMaskNumber, &vpMe::getMaskNumber);
+        }
+        WHEN("Removing maskSize") {
+          testInt("maskSize", &vpMe::setMaskSize, &vpMe::getMaskSize);
+        }
+        WHEN("Removing minSampleStep") {
+          testDouble("minSampleStep", &vpMe::setMinSampleStep, &vpMe::getMinSampleStep);
+        }
+        WHEN("Removing sampleStep") {
+          testDouble("sampleStep", &vpMe::setSampleStep, &vpMe::getSampleStep);
+        }
+        
+        WHEN("Removing maskSign") {
+          testInt("maskSign", &vpMe::setMaskSign, &vpMe::getMaskSign);
+        }
+        WHEN("Removing ntotalSample") {
+          testInt("ntotalSample", &vpMe::setNbTotalSample, &vpMe::getNbTotalSample);
+        }
+        WHEN("Removing pointsToTrack") {
+          testInt("pointsToTrack", &vpMe::setPointsToTrack, &vpMe::getPointsToTrack);
+        }
+        WHEN("Removing range") {
+          testInt("range", &vpMe::setRange, &vpMe::getRange);
+        }
+        WHEN("Removing strip") {
+          testInt("strip", &vpMe::setStrip, &vpMe::getStrip);
+        }
+    }
+  }
+}
+
+
+int main(int argc, char *argv[])
+{
+  Catch::Session session; // There must be exactly one instance
+  session.applyCommandLine(argc, argv);
+
+  int numFailed = session.run();
+  return numFailed;
+}
+
+#else
+
+int main() {
+  return EXIT_SUCCESS;
+}
+
+#endif

--- a/modules/tracker/me/test/testJsonMe.cpp
+++ b/modules/tracker/me/test/testJsonMe.cpp
@@ -130,7 +130,7 @@ Catch::Generators::GeneratorWrapper<vpMe> randomMe() {
 
 SCENARIO("Serializing and deserializing a single vpMe", "[json]") {
   GIVEN("Some random vpMe object") {
-    vpMe me = GENERATE(take(100, randomMe()));        
+    vpMe me = GENERATE(take(10, randomMe()));
     WHEN("Serializing and deserializing an object") {
         const json j = me;
         const vpMe otherMe = j;
@@ -153,25 +153,23 @@ SCENARIO("Serializing and deserializing a single vpMe", "[json]") {
     }
     WHEN("Removing optional properties in JSON object") {
         json j = me;
+
         const auto testInt = [&j, &me](const std::string& key,
         std::function<void(vpMe*, int)> setter, std::function<int(vpMe*)> getter) -> void {
           testOptionalProperty<int>(j, {key}, me, setter, getter, [](int v) -> int {return v - 1;});
-          
         };
         const auto testDouble = [&j, &me](const std::string& key, 
         std::function<void(vpMe*, double)> setter, std::function<double(vpMe*)> getter) -> void {
           testOptionalProperty<double>(j, {key}, me, setter, getter, [](double v) -> int {return v + 1.0;});
         };
-        
+
         WHEN("Removing threshold") {
           testDouble("threshold", &vpMe::setThreshold, &vpMe::getThreshold);
         }
         WHEN("Removing mu1 and mu2") {
           testDouble("mu", &vpMe::setMu1, &vpMe::getMu1);
           testDouble("mu", &vpMe::setMu2, &vpMe::getMu2);
-          
         }
-        
         WHEN("Removing nMask") {
           testInt("nMask", &vpMe::setMaskNumber, &vpMe::getMaskNumber);
         }
@@ -184,7 +182,6 @@ SCENARIO("Serializing and deserializing a single vpMe", "[json]") {
         WHEN("Removing sampleStep") {
           testDouble("sampleStep", &vpMe::setSampleStep, &vpMe::getSampleStep);
         }
-        
         WHEN("Removing maskSign") {
           testInt("maskSign", &vpMe::setMaskSign, &vpMe::getMaskSign);
         }

--- a/tutorial/tracking/model-based/generic-rgbd/CMakeLists.txt
+++ b/tutorial/tracking/model-based/generic-rgbd/CMakeLists.txt
@@ -8,7 +8,8 @@ find_package(VISP REQUIRED visp_core visp_mbt visp_io visp_gui visp_sensor)
 set(tutorial_cpp
   tutorial-mb-generic-tracker-rgbd.cpp
   tutorial-mb-generic-tracker-rgbd-realsense.cpp
-  tutorial-mb-generic-tracker-rgbd-structure-core.cpp)
+  tutorial-mb-generic-tracker-rgbd-structure-core.cpp
+  tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp)
 
 foreach(cpp ${tutorial_cpp})
   visp_add_target(${cpp})
@@ -62,3 +63,6 @@ endforeach()
 visp_copy_dir(tutorial-mb-generic-tracker-rgbd.cpp "${CMAKE_CURRENT_SOURCE_DIR}" data model)
 visp_copy_dir(tutorial-mb-generic-tracker-rgbd-realsense.cpp "${CMAKE_CURRENT_SOURCE_DIR}" model)
 visp_copy_dir(tutorial-mb-generic-tracker-rgbd-structure-core.cpp "${CMAKE_CURRENT_SOURCE_DIR}" model)
+visp_copy_dir(tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp "${CMAKE_CURRENT_SOURCE_DIR}" model)
+
+

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth-with-model-path.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth-with-model-path.json
@@ -1,5 +1,6 @@
 {
     "referenceCameraName": "Color",
+    "model": "model/cube/cube.cao",
     "trackers": {
         "Color": {
             "angleAppear": 65.0,
@@ -80,6 +81,82 @@
                 "edge",
                 "klt"
             ],
+            "visibilityTest": {
+                "ogre": false,
+                "scanline": true
+            }
+        },
+        "Depth": {
+            "angleAppear": 70.0,
+            "angleDisappear": 80.0,
+            "camTref": {
+                "cols": 4,
+                "data": [
+                    0.999972403049469,
+                    -0.006713358219712973,
+                    -0.003179509425535798,
+                    -0.01465611346065998,
+                    0.006699616555124521,
+                    0.9999682307243347,
+                    -0.004313052631914616,
+                    9.024870814755559e-05,
+                    0.003208363428711891,
+                    0.00429163221269846,
+                    0.9999856352806091,
+                    -0.0004482123476918787,
+                    0.0,
+                    0.0,
+                    0.0,
+                    1.0
+                ],
+                "rows": 4,
+                "type": "vpHomogeneousMatrix"
+            },
+            "camera": {
+                "model": "perspectiveWithoutDistortion",
+                "px": 381.7528076171875,
+                "py": 381.7528076171875,
+                "u0": 323.3261413574219,
+                "v0": 236.82505798339844
+            },
+            "clipping": {
+                "far": 2.0,
+                "flags": [
+                    "all"
+                ],
+                "near": 0.01
+            },
+            "dense": {
+                "sampling": {
+                    "x": 1,
+                    "y": 1
+                }
+            },
+            "normals": {
+                "featureEstimationMethod": "robust",
+                "pcl": {
+                    "method": 2,
+                    "ransacMaxIter": 200,
+                    "ransacThreshold": 0.001
+                },
+                "sampling": {
+                    "x": 2,
+                    "y": 2
+                }
+            },
+            "type": [
+                "depthDense",
+                "depthNormal"
+            ],
+            "display": {
+                "features": true,
+                "projectionError": true
+            },
+            "lod": {
+                "minLineLengthThresholdGeneral": 50.0,
+                "minPolygonAreaThresholdGeneral": 2500.0,
+                "useLod": false
+            },
             "visibilityTest": {
                 "ogre": false,
                 "scanline": true

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
@@ -1,0 +1,140 @@
+{
+    "referenceCameraName": "Color",
+    "trackers": {
+        "Color": {
+            "angleAppear": 65.0,
+            "angleDisappear": 75.00000000000001,
+            "camTref": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "camera": {
+                "model": "perspectiveWithoutDistortion",
+                "px": 605.146728515625,
+                "py": 604.79150390625,
+                "u0": 325.53253173828125,
+                "v0": 244.95083618164063
+            },
+            "clipping": {
+                "far": 0.9,
+                "near": 0.1,
+                "useFOVClipping": false
+            },
+            "display": {
+                "features": true,
+                "projectionError": true
+            },
+            "edge_tracker": {
+                "angleStep": 1,
+                "maskSign": 0,
+                "maskSize": 5,
+                "minSampleStep": 4.0,
+                "mu": [
+                    0.5,
+                    0.5
+                ],
+                "nMask": 180,
+                "ntotal_sample": 0,
+                "pointsToTrack": 500,
+                "range": 7,
+                "sampleStep": 4.0,
+                "strip": 2,
+                "threshold": 5000.0
+            },
+            "klt": {
+                "blockSize": 3,
+                "harris": 0.01,
+                "maskBorder": 5,
+                "maxFeatures": 300,
+                "minDistance": 5.0,
+                "pyramidLevels": 3,
+                "quality": 0.01,
+                "windowSize": 5
+            },
+            "lod": {
+                "minLineLengthThresholdGeneral": 50.0,
+                "minPolygonAreaThresholdGeneral": 2500.0,
+                "useLod": false
+            },
+            "type": [
+                "edge",
+                "klt"
+            ],
+            "visibilityTest": {
+                "ogre": false,
+                "scanline": true
+            }
+        },
+        "Depth": {
+            "angleAppear": 70.0,
+            "angleDisappear": 80.0,
+            "camTref": [
+                0.999972403049469,
+                -0.006713358219712973,
+                -0.003179509425535798,
+                -0.01465611346065998,
+                0.006699616555124521,
+                0.9999682307243347,
+                -0.004313052631914616,
+                9.024870814755559e-05,
+                0.003208363428711891,
+                0.00429163221269846,
+                0.9999856352806091,
+                -0.0004482123476918787,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "camera": {
+                "model": "perspectiveWithoutDistortion",
+                "px": 381.7528076171875,
+                "py": 381.7528076171875,
+                "u0": 323.3261413574219,
+                "v0": 236.82505798339844
+            },
+            "clipping": {
+                "far": 2.0,
+                "near": 0.001,
+                "useFOVClipping": true
+            },
+            "dense": {
+                "sampling": {
+                    "x": 4,
+                    "y": 4
+                }
+            },
+            
+            "display": {
+                "features": true,
+                "projectionError": true
+            },
+            "lod": {
+                "minLineLengthThresholdGeneral": 50.0,
+                "minPolygonAreaThresholdGeneral": 2500.0,
+                "useLod": true
+            },
+            "type": [
+                "depthDense"
+            ],
+            "visibilityTest": {
+                "ogre": false,
+                "scanline": false
+            }
+        }
+    }
+}

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
@@ -1,5 +1,6 @@
 {
     "referenceCameraName": "Color",
+    "version": "1.0",
     "trackers": {
         "Color": {
             "angleAppear": 65.0,
@@ -38,7 +39,7 @@
                 "features": true,
                 "projectionError": true
             },
-            "edge_tracker": {
+            "edge": {
                 "angleStep": 1,
                 "maskSign": 0,
                 "maskSize": 5,
@@ -48,7 +49,7 @@
                     0.5
                 ],
                 "nMask": 180,
-                "ntotal_sample": 0,
+                "ntotalSample": 0,
                 "pointsToTrack": 500,
                 "range": 7,
                 "sampleStep": 4.0,
@@ -118,7 +119,6 @@
                     "y": 4
                 }
             },
-            
             "display": {
                 "features": true,
                 "projectionError": true

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json.example
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json.example
@@ -1,9 +1,11 @@
 {
     "referenceCameraName": "Color",
     "trackers": {
+        //! [Color]
         "Color": {
             "angleAppear": 65.0,
             "angleDisappear": 75.00000000000001,
+            //! [Transformation]
             "camTref": {
                 "cols": 4,
                 "data": [
@@ -27,6 +29,8 @@
                 "rows": 4,
                 "type": "vpHomogeneousMatrix"
             },
+            //! [Transformation]
+            //! [Camera]
             "camera": {
                 "model": "perspectiveWithoutDistortion",
                 "px": 605.146728515625,
@@ -34,6 +38,7 @@
                 "u0": 325.53253173828125,
                 "v0": 244.95083618164063
             },
+            //! [Camera]
             "clipping": {
                 "far": 0.9,
                 "flags": [
@@ -45,6 +50,7 @@
                 "features": true,
                 "projectionError": true
             },
+            //! [Edge]
             "edge": {
                 "maskSign": 0,
                 "maskSize": 5,
@@ -61,6 +67,8 @@
                 "strip": 2,
                 "threshold": 5000.0
             },
+            //! [Edge]
+            //! [KLT]
             "klt": {
                 "blockSize": 3,
                 "harris": 0.01,
@@ -71,20 +79,24 @@
                 "quality": 0.01,
                 "windowSize": 5
             },
+            //! [KLT]
             "lod": {
                 "minLineLengthThresholdGeneral": 50.0,
                 "minPolygonAreaThresholdGeneral": 2500.0,
                 "useLod": false
             },
+            //! [Features]
             "type": [
                 "edge",
                 "klt"
             ],
+            //! [Features]
             "visibilityTest": {
                 "ogre": false,
                 "scanline": true
             }
         },
+        //! [Color]
         "Depth": {
             "angleAppear": 70.0,
             "angleDisappear": 80.0,
@@ -125,12 +137,15 @@
                 ],
                 "near": 0.01
             },
+            //! [DepthDense]
             "dense": {
                 "sampling": {
                     "x": 1,
                     "y": 1
                 }
             },
+            //! [DepthDense]
+            //! [DepthNormal]
             "normals": {
                 "featureEstimationMethod": "robust",
                 "pcl": {
@@ -143,6 +158,7 @@
                     "y": 2
                 }
             },
+            //! [DepthNormal]
             "type": [
                 "depthDense",
                 "depthNormal"

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
@@ -1,5 +1,6 @@
 {
     "referenceCameraName": "Color",
+    "version": "1.0",
     "trackers": {
         "Color": {
             "angleAppear": 65.0,
@@ -38,7 +39,7 @@
                 "features": true,
                 "projectionError": true
             },
-            "edge_tracker": {
+            "edge": {
                 "angleStep": 1,
                 "maskSign": 0,
                 "maskSize": 5,
@@ -48,7 +49,7 @@
                     0.5
                 ],
                 "nMask": 180,
-                "ntotal_sample": 0,
+                "ntotalSample": 0,
                 "pointsToTrack": 500,
                 "range": 7,
                 "sampleStep": 4.0,

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
@@ -1,0 +1,83 @@
+{
+    "referenceCameraName": "Color",
+    "trackers": {
+        "Color": {
+            "angleAppear": 65.0,
+            "angleDisappear": 75.00000000000001,
+            "camTref": [
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0
+            ],
+            "camera": {
+                "model": "perspectiveWithoutDistortion",
+                "px": 605.146728515625,
+                "py": 604.79150390625,
+                "u0": 325.53253173828125,
+                "v0": 244.95083618164063
+            },
+            "clipping": {
+                "far": 0.9,
+                "near": 0.1,
+                "useFOVClipping": false
+            },
+            "display": {
+                "features": true,
+                "projectionError": true
+            },
+            "edge_tracker": {
+                "angleStep": 1,
+                "maskSign": 0,
+                "maskSize": 5,
+                "minSampleStep": 4.0,
+                "mu": [
+                    0.5,
+                    0.5
+                ],
+                "nMask": 180,
+                "ntotal_sample": 0,
+                "pointsToTrack": 500,
+                "range": 7,
+                "sampleStep": 4.0,
+                "strip": 2,
+                "threshold": 5000.0
+            },
+            "klt": {
+                "blockSize": 3,
+                "harris": 0.01,
+                "maskBorder": 5,
+                "maxFeatures": 300,
+                "minDistance": 5.0,
+                "pyramidLevels": 3,
+                "quality": 0.01,
+                "windowSize": 5
+            },
+            "lod": {
+                "minLineLengthThresholdGeneral": 50.0,
+                "minPolygonAreaThresholdGeneral": 2500.0,
+                "useLod": false
+            },
+            "type": [
+                "edge",
+                "klt"
+            ],
+            "visibilityTest": {
+                "ogre": false,
+                "scanline": true
+            }
+        }
+    }
+}

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp
@@ -242,8 +242,6 @@ int main(int argc, char *argv[])
       // Get object pose
       cMo = tracker.getPose();
 
-      std::cout << "aaaa";
-
       // Check tracking errors
       double proj_error = 0;
       if (tracker.getTrackerType() & vpMbGenericTracker::EDGE_TRACKER) {

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense-json-settings.cpp
@@ -1,0 +1,347 @@
+//! \example tutorial-mb-generic-tracker-rgbd-realsense.cpp
+#include <iostream>
+
+#include <visp3/core/vpConfig.h>
+
+#if defined(VISP_HAVE_REALSENSE2) && defined(VISP_HAVE_OPENCV) && defined(VISP_HAVE_NLOHMANN_JSON)
+#include <visp3/core/vpDisplay.h>
+#include <visp3/core/vpIoTools.h>
+#include <visp3/gui/vpDisplayGDI.h>
+#include <visp3/gui/vpDisplayOpenCV.h>
+#include <visp3/gui/vpDisplayX.h>
+#include <visp3/mbt/vpMbGenericTracker.h>
+#include <visp3/sensor/vpRealSense2.h>
+
+int main(int argc, char *argv[])
+{
+  std::string config_file = "";
+  std::string model = "";
+  std::string init_file = "";
+  
+  double proj_error_threshold = 25;
+  bool display_projection_error = false;
+
+  for (int i = 1; i < argc; i++) {
+    if (std::string(argv[i]) == "--config" && i + 1 < argc) {
+      config_file = std::string(argv[i + 1]);
+    }
+    else if (std::string(argv[i]) == "--model" && i + 1 < argc) {
+      model = std::string(argv[i + 1]);
+    } else if (std::string(argv[i]) == "--init_file" && i + 1 < argc) {
+      init_file = std::string(argv[i + 1]);
+    } else if (std::string(argv[i]) == "--proj_error_threshold" && i + 1 < argc) {
+      proj_error_threshold = std::atof(argv[i + 1]);
+    } else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
+      std::cout << "Usage: \n"
+                << argv[0]
+                << "--config <settings.json>"
+                << " --model <object.cao>"
+                   " --init_file <object.init>"
+                   " [--proj_error_threshold <threshold between 0 and 90> (default: "
+                << proj_error_threshold
+                << ")]"
+                << std::endl;
+
+      std::cout << "\n** How to track a 4.2 cm width cube with manual initialization:\n"
+                << argv[0] << "--config model/cube/rgbd-tracker.json --model model/cube/cube.cao" << std::endl;
+      return EXIT_SUCCESS;
+    }
+  }
+
+  const std::string parentname = vpIoTools::getParent(model);
+  if (init_file.empty()) {
+    init_file = (parentname.empty() ? "" : (parentname + "/")) + vpIoTools::getNameWE(model) + ".init";
+  }
+  std::cout << "Config files: " << std::endl;
+  std::cout << "  JSON config: "
+            << "\"" << config_file << "\"" << std::endl;
+  std::cout << "  Model: "
+            << "\"" << model << "\"" << std::endl;
+  std::cout << "  Init file: "
+            << "\"" << init_file << "\"" << std::endl;
+  
+
+  if (config_file.empty()  || model.empty() || init_file.empty()) {
+    std::cout << "config_file.empty() || model.empty()  "
+                 "init_file.empty()"
+              << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  vpRealSense2 realsense;
+  int width = 640, height = 480;
+  int fps = 30;
+  rs2::config config;
+  config.enable_stream(RS2_STREAM_COLOR, width, height, RS2_FORMAT_RGBA8, fps);
+  config.enable_stream(RS2_STREAM_DEPTH, width, height, RS2_FORMAT_Z16, fps);
+
+  try {
+    realsense.open(config);
+  } catch (const vpException &e) {
+    std::cout << "Catch an exception: " << e.what() << std::endl;
+    std::cout << "Check if the Realsense camera is connected..." << std::endl;
+    return EXIT_SUCCESS;
+  }
+
+  vpCameraParameters cam_color =
+      realsense.getCameraParameters(RS2_STREAM_COLOR, vpCameraParameters::perspectiveProjWithoutDistortion);
+  vpCameraParameters cam_depth =
+      realsense.getCameraParameters(RS2_STREAM_DEPTH, vpCameraParameters::perspectiveProjWithoutDistortion);
+
+  std::cout << "Sensor internal camera parameters for color camera: " << cam_color << std::endl;
+  std::cout << "Sensor internal camera parameters for depth camera: " << cam_depth << std::endl;
+
+  vpImage<vpRGBa> I_color(height, width);
+  vpImage<unsigned char> I_gray(height, width);
+  vpImage<unsigned char> I_depth(height, width);
+  vpImage<uint16_t> I_depth_raw(height, width);
+
+  vpHomogeneousMatrix depth_M_color = realsense.getTransformation(RS2_STREAM_COLOR, RS2_STREAM_DEPTH);
+  std::map<std::string, vpHomogeneousMatrix> mapOfCameraTransformations;
+  std::map<std::string, const vpImage<unsigned char> *> mapOfImages;
+  std::map<std::string, std::string> mapOfInitFiles;
+  std::map<std::string, const std::vector<vpColVector> *> mapOfPointclouds;
+  std::map<std::string, unsigned int> mapOfWidths, mapOfHeights;
+  std::map<std::string, vpCameraParameters> mapOfCameraIntrinsics;
+
+  std::vector<vpColVector> pointcloud;
+
+  vpMbGenericTracker tracker;
+  tracker.loadConfigFile(config_file);
+  std::string color_key = "", depth_key = "";
+  for(const auto& tracker_type: tracker.getCameraTrackerTypes()) {
+    std::cout << "tracker key == " << tracker_type.first << std::endl;;
+    if(tracker_type.second & vpMbGenericTracker::EDGE_TRACKER || tracker_type.second & vpMbGenericTracker::KLT_TRACKER) {
+      color_key = tracker_type.first;
+      mapOfImages[color_key] = &I_gray;
+      mapOfInitFiles[color_key] = init_file;
+      mapOfWidths[color_key] = width;
+      mapOfHeights[color_key] = height;
+      mapOfCameraIntrinsics[color_key] = cam_color;
+    }
+    if(tracker_type.second & vpMbGenericTracker::DEPTH_DENSE_TRACKER || tracker_type.second & vpMbGenericTracker::DEPTH_NORMAL_TRACKER) {
+      depth_key = tracker_type.first;
+      mapOfImages[depth_key] = &I_depth;
+      mapOfWidths[depth_key] = width;
+      mapOfHeights[depth_key] = height;
+      mapOfCameraIntrinsics[depth_key] = cam_depth;
+      mapOfCameraTransformations[depth_key] = depth_M_color;
+      mapOfPointclouds[depth_key] = &pointcloud;
+    }
+  }
+  tracker.loadModel(model, model);
+
+  const bool use_depth = !depth_key.empty();
+  const bool use_color = !color_key.empty();
+
+  std::cout << "Updating configuration with parameters provided by RealSense SDK..." << std::endl;
+  tracker.setCameraParameters(mapOfCameraIntrinsics);
+  if(use_color && use_depth) {
+    tracker.setCameraTransformationMatrix(mapOfCameraTransformations);
+  }
+  std::cout << "Loading provided model" << std::endl;
+  
+
+  
+
+  unsigned int _posx = 100, _posy = 50;
+
+#ifdef VISP_HAVE_X11
+  vpDisplayX d1, d2;
+#elif defined(VISP_HAVE_GDI)
+  vpDisplayGDI d1, d2;
+#elif defined(VISP_HAVE_OPENCV)
+  vpDisplayOpenCV d1, d2;
+#endif
+  if (use_color)
+    d1.init(I_gray, _posx, _posy, "Color stream");
+  if (use_depth)
+    d2.init(I_depth, _posx + I_gray.getWidth() + 10, _posy, "Depth stream");
+
+  while (true) {
+    realsense.acquire((unsigned char *)I_color.bitmap, (unsigned char *)I_depth_raw.bitmap, NULL, NULL);
+
+    if (use_color) {
+      vpImageConvert::convert(I_color, I_gray);
+      vpDisplay::display(I_gray);
+      vpDisplay::displayText(I_gray, 20, 20, "Click when ready.", vpColor::red);
+      vpDisplay::flush(I_gray);
+
+      if (vpDisplay::getClick(I_gray, false)) {
+        break;
+      }
+    }
+    if (use_depth) {
+      vpImageConvert::createDepthHistogram(I_depth_raw, I_depth);
+
+      vpDisplay::display(I_depth);
+      vpDisplay::displayText(I_depth, 20, 20, "Click when ready.", vpColor::red);
+      vpDisplay::flush(I_depth);
+
+      if (vpDisplay::getClick(I_depth, false)) {
+        break;
+      }
+    }
+  }
+
+
+  
+  tracker.setProjectionErrorComputation(true);
+  tracker.initClick(mapOfImages, mapOfInitFiles, true);
+
+  
+  std::vector<double> times_vec;
+
+  try {
+    // To be able to display keypoints matching with test-detection-rs2
+    bool quit = false;
+    double loop_t = 0;
+    vpHomogeneousMatrix cMo;
+
+    while (!quit) {
+      double t = vpTime::measureTimeMs();
+      bool tracking_failed = false;
+
+      // Acquire images and update tracker input data
+      realsense.acquire((unsigned char *)I_color.bitmap, (unsigned char *)I_depth_raw.bitmap, &pointcloud, NULL, NULL);
+
+      if (use_color) {
+        vpImageConvert::convert(I_color, I_gray);
+        vpDisplay::display(I_gray);
+      }
+      if (use_depth) {
+        vpImageConvert::createDepthHistogram(I_depth_raw, I_depth);
+        vpDisplay::display(I_depth);
+      }
+
+      if (use_color && use_depth) {
+        mapOfImages[color_key] = &I_gray;
+        mapOfPointclouds[depth_key] = &pointcloud;
+        mapOfWidths[depth_key] = width;
+        mapOfHeights[depth_key] = height;
+      } else if (use_color) {
+        mapOfImages[color_key] = &I_gray;
+      } else if (use_depth) {
+        mapOfPointclouds[depth_key] = &pointcloud;
+      }
+
+      // Run the tracker
+      try {
+        if (use_color && use_depth) {
+          tracker.track(mapOfImages, mapOfPointclouds, mapOfWidths, mapOfHeights);
+        } else if (use_color) {
+          tracker.track(I_gray);
+        } else if (use_depth) {
+          tracker.track(mapOfImages, mapOfPointclouds, mapOfWidths, mapOfHeights);
+        }
+      } catch (const vpException &e) {
+        std::cout << "Tracker exception: " << e.getStringMessage() << std::endl;
+        tracking_failed = true;
+      }
+
+      // Get object pose
+      cMo = tracker.getPose();
+
+      std::cout << "aaaa";
+
+      // Check tracking errors
+      double proj_error = 0;
+      if (tracker.getTrackerType() & vpMbGenericTracker::EDGE_TRACKER) {
+        // Check tracking errors
+        proj_error = tracker.getProjectionError();
+      } else {
+        proj_error = tracker.computeCurrentProjectionError(I_gray, cMo, cam_color);
+      }
+
+      if (proj_error > proj_error_threshold) {
+        std::cout << "Tracker needs to restart (projection error detected: " << proj_error << ")" << std::endl;
+      }
+
+      // Display tracking results
+      if (!tracking_failed) {
+        // Turn display features on
+        tracker.setDisplayFeatures(true);
+
+        if ( use_color && use_depth) {
+          tracker.display(I_gray, I_depth, cMo, depth_M_color * cMo, cam_color, cam_depth, vpColor::red, 3);
+          vpDisplay::displayFrame(I_gray, cMo, cam_color, 0.05, vpColor::none, 3);
+          vpDisplay::displayFrame(I_depth, depth_M_color * cMo, cam_depth, 0.05, vpColor::none, 3);
+        } else if (use_color) {
+          tracker.display(I_gray, cMo, cam_color, vpColor::red, 3);
+          vpDisplay::displayFrame(I_gray, cMo, cam_color, 0.05, vpColor::none, 3);
+        } else if (use_depth) {
+          tracker.display(I_depth, cMo, cam_depth, vpColor::red, 3);
+          vpDisplay::displayFrame(I_depth, cMo, cam_depth, 0.05, vpColor::none, 3);
+        }
+
+        {
+          std::stringstream ss;
+          ss << "Nb features: " << tracker.getError().size();
+          vpDisplay::displayText(I_gray, I_gray.getHeight() - 50, 20, ss.str(), vpColor::red);
+        }
+        {
+          std::stringstream ss;
+          ss << "Features: edges " << tracker.getNbFeaturesEdge() << ", klt " << tracker.getNbFeaturesKlt()
+             << ", depth dense " << tracker.getNbFeaturesDepthDense() << ", depth normal" << tracker.getNbFeaturesDepthNormal();
+          vpDisplay::displayText(I_gray, I_gray.getHeight() - 30, 20, ss.str(), vpColor::red);
+        }
+      }
+
+      std::stringstream ss;
+      ss << "Loop time: " << loop_t << " ms";
+
+      vpMouseButton::vpMouseButtonType button;
+      if (use_color) {
+        vpDisplay::displayText(I_gray, 20, 20, ss.str(), vpColor::red);
+        vpDisplay::displayText(I_gray, 35, 20, "Right click: quit", vpColor::red);
+
+        vpDisplay::flush(I_gray);
+
+        if (vpDisplay::getClick(I_gray, button, false)) {
+          if (button == vpMouseButton::button3) {
+            quit = true;
+          }
+        }
+      }
+      if (use_depth) {
+        vpDisplay::displayText(I_depth, 20, 20, ss.str(), vpColor::red);
+        vpDisplay::displayText(I_depth, 40, 20, "Click to quit", vpColor::red);
+        vpDisplay::flush(I_depth);
+
+        if (vpDisplay::getClick(I_depth, false)) {
+          quit = true;
+        }
+      }
+
+    }
+  } catch (const vpException &e) {
+    std::cout << "Caught an exception: " << e.what() << std::endl;
+  }
+
+  if (!times_vec.empty()) {
+    std::cout << "\nProcessing time, Mean: " << vpMath::getMean(times_vec)
+              << " ms ; Median: " << vpMath::getMedian(times_vec) << " ; Std: " << vpMath::getStdev(times_vec) << " ms"
+              << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}
+#elif defined(VISP_HAVE_REALSENSE2) && defined(VISP_HAVE_OPENCV)
+int main()
+{
+  std::cout << "Install the JSON 3rd party library (Nlohmann JSON), reconfigure VISP and build again" << std::endl;
+  return EXIT_SUCCESS;
+}
+#elif defined(VISP_HAVE_REALSENSE2) && defined(VISP_HAVE_NLOHMANN_JSON)
+int main()
+{
+  std::cout << "Install OpenCV, reconfigure VISP and build again" << std::endl;
+  return EXIT_SUCCESS;
+}
+#else
+int main()
+{
+  std::cout << "Install librealsense2 3rd party, configure and build ViSP again to use this example" << std::endl;
+  return EXIT_SUCCESS;
+}
+#endif


### PR DESCRIPTION
This PR introduces JSON representations in ViSP, with a first use case for the loading and saving of the model-based tracker settings.

This allows to fully load a tracker with a single line, e.g:
```
vpMbGenericTracker tracker;
tracker.loadConfigFile("tracker-configuration.json");
```

To support this, the JSON conversion for multiple ViSP types has been written. For instance, it is now possible to convert vpColVector, vpHomogeneousMatrix or vpPoseVector to JSON.

This feature is optional, and to be activated, the ![nlohmann JSON](https://github.com/nlohmann/json) library must be installed before compiling ViSP.


This PR comes with a simple tutorial on how to use the JSON configuration file and a documentation on what each settings does.

