### PR TITLE
Fix invalid usage of OGRE_DIR in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ endif(WIN32)
 
 if(UNIX)
   list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/cmake")
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/Cmake")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/CMake")
   list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "/usr/local/lib/OGRE/cmake")
   list(APPEND CMAKE_MODULE_PATH "/usr/lib/OGRE/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,12 +329,13 @@ endif()
 
 # add the path to detect Ogre3D
 if(WIN32)
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/cmake")
   list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
 endif(WIN32)
 
 if(UNIX)
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/cmake")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/Cmake")
   list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "/usr/local/lib/OGRE/cmake")
   list(APPEND CMAKE_MODULE_PATH "/usr/lib/OGRE/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,13 +329,13 @@ endif()
 
 # add the path to detect Ogre3D
 if(WIN32)
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/cmake")
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/CMake")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
 endif(WIN32)
 
 if(UNIX)
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/cmake")
-  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}/CMake")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
+  list(APPEND CMAKE_MODULE_PATH "${OGRE_DIR}")
   list(APPEND CMAKE_MODULE_PATH "/usr/local/lib/OGRE/cmake")
   list(APPEND CMAKE_MODULE_PATH "/usr/lib/OGRE/cmake")
   list(APPEND CMAKE_MODULE_PATH "/usr/local/lib64/OGRE/cmake")


### PR DESCRIPTION
The `OGRE_DIR` cmake variable seems not correctly used here, as it will be set to the directory containing the configuration cmake file (as defined here: https://cmake.org/cmake/help/latest/command/find_package.html#full-signature ).
In other words, the `OGRE_DIR` variable typically already ends up with a `/cmake` directory, so the `CMAKE_MODULE_PATH` should not be appended by an extra `/cmake` directory.