### PR TITLE
Fixed vpCircleHoughTransform::detect(const vpImage<uchar> &, const int &)

### DIFF
--- a/modules/imgproc/src/vpCircleHoughTransform.cpp
+++ b/modules/imgproc/src/vpCircleHoughTransform.cpp
@@ -164,7 +164,7 @@ vpCircleHoughTransform::detect(const vpImage<unsigned char> &I, const int &nbCir
     }
   }
 
-  return m_finalCircles;
+  return bestCircles;
 }
 
 std::vector<vpImageCircle>


### PR DESCRIPTION
The wrong vector was returned  when the user asks to keep only the n best detections