### PR TITLE
Feat rework OpenCV includes

### DIFF
--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -167,7 +167,7 @@
 // OpenCV version in hexadecimal (for example 2.1.0 gives 0x020100).
 #ifdef VISP_HAVE_OPENCV
 #  define VISP_HAVE_OPENCV_VERSION ${VISP_HAVE_OPENCV_VERSION}
-#  include <opencv2/opencv.hpp>
+#  include <opencv2/opencv_modules.hpp>
 #endif
 
 // For compat with previous releases

--- a/modules/core/test/image-with-dataset/perfColorConversion.cpp
+++ b/modules/core/test/image-with-dataset/perfColorConversion.cpp
@@ -45,6 +45,11 @@
 #include <visp3/core/vpIoTools.h>
 #include <visp3/io/vpImageIo.h>
 
+#if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_IMGCODECS) && defined(HAVE_OPENCV_IMGPROC)
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
 static std::string ipath = vpIoTools::getViSPImagesDataPath();
 static std::string imagePathColor = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 static std::string imagePathGray = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
@@ -312,14 +317,14 @@ int main(int argc, char *argv[])
   // Build a new parser on top of Catch's
   using namespace Catch::clara;
   auto cli = session.cli()         // Get Catch's composite command line parser
-             | Opt(runBenchmark)   // bind variable to a new option, with a hint string
-                   ["--benchmark"] // the option names it will respond to
-             ("run benchmark?")    // description string for the help output
-             | Opt(imagePathColor, "imagePathColor")["--imagePathColor"]("Path to color image") |
-             Opt(imagePathGray, "imagePathColor")["--imagePathGray"]("Path to gray image") |
-             Opt(nThreads, "nThreads")["--nThreads"]("Number of threads");
+    | Opt(runBenchmark)   // bind variable to a new option, with a hint string
+    ["--benchmark"] // the option names it will respond to
+    ("run benchmark?")    // description string for the help output
+    | Opt(imagePathColor, "imagePathColor")["--imagePathColor"]("Path to color image") |
+    Opt(imagePathGray, "imagePathColor")["--imagePathGray"]("Path to gray image") |
+    Opt(nThreads, "nThreads")["--nThreads"]("Number of threads");
 
-  // Now pass the new composite back to Catch so it uses that
+// Now pass the new composite back to Catch so it uses that
   session.cli(cli);
 
   // Let Catch (using Clara) parse the command line
@@ -329,14 +334,14 @@ int main(int argc, char *argv[])
     vpImage<vpRGBa> I_color;
     vpImageIo::read(I_color, imagePathColor);
     std::cout << "imagePathColor:\n\t" << imagePathColor << "\n\t" << I_color.getWidth() << "x" << I_color.getHeight()
-              << std::endl;
+      << std::endl;
 
     vpImage<unsigned char> I_gray;
     vpImageIo::read(I_gray, imagePathGray);
     std::cout << "imagePathGray:\n\t" << imagePathGray << "\n\t" << I_gray.getWidth() << "x" << I_gray.getHeight()
-              << std::endl;
+      << std::endl;
     std::cout << "nThreads: " << nThreads << " / available threads: " << std::thread::hardware_concurrency()
-              << std::endl;
+      << std::endl;
 
     int numFailed = session.run();
 

--- a/modules/core/test/image-with-dataset/perfGaussianFilter.cpp
+++ b/modules/core/test/image-with-dataset/perfGaussianFilter.cpp
@@ -45,6 +45,11 @@
 #include <visp3/core/vpIoTools.h>
 #include <visp3/io/vpImageIo.h>
 
+#if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_IMGCODECS) && defined(HAVE_OPENCV_IMGPROC)
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
 static const std::string ipath = vpIoTools::getViSPImagesDataPath();
 static std::string imagePath = vpIoTools::createFilePath(ipath, "faces/1280px-Solvay_conference_1927.png");
 
@@ -166,12 +171,12 @@ int main(int argc, char *argv[])
   // Build a new parser on top of Catch's
   using namespace Catch::clara;
   auto cli = session.cli()         // Get Catch's composite command line parser
-             | Opt(runBenchmark)   // bind variable to a new option, with a hint string
-                   ["--benchmark"] // the option names it will respond to
-             ("run benchmark?")    // description string for the help output
-      ;
+    | Opt(runBenchmark)   // bind variable to a new option, with a hint string
+    ["--benchmark"] // the option names it will respond to
+    ("run benchmark?")    // description string for the help output
+    ;
 
-  // Now pass the new composite back to Catch so it uses that
+// Now pass the new composite back to Catch so it uses that
   session.cli(cli);
 
   // Let Catch (using Clara) parse the command line

--- a/modules/core/test/image-with-dataset/perfImageResize.cpp
+++ b/modules/core/test/image-with-dataset/perfImageResize.cpp
@@ -46,6 +46,11 @@
 #include <visp3/core/vpIoTools.h>
 #include <visp3/io/vpImageIo.h>
 
+#if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_IMGCODECS) && defined(HAVE_OPENCV_IMGPROC)
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
 static const std::string ipath = vpIoTools::getViSPImagesDataPath();
 static std::string imagePathColor = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
 static std::string imagePathGray = vpIoTools::createFilePath(ipath, "Klimt/Klimt.pgm");
@@ -368,15 +373,15 @@ int main(int argc, char *argv[])
   // Build a new parser on top of Catch's
   using namespace Catch::clara;
   auto cli = session.cli()         // Get Catch's composite command line parser
-             | Opt(runBenchmark)   // bind variable to a new option, with a hint string
-                   ["--benchmark"] // the option names it will respond to
-             ("run benchmark?")    // description string for the help output
-             | Opt(imagePathColor, "imagePathColor")["--imagePathColor"]("Path to color image") |
-             Opt(imagePathGray, "imagePathColor")["--imagePathGray"] |
-             Opt(g_resize_width, "g_resize_width")["--width"]("Resize width") |
-             Opt(g_resize_height, "g_resize_height")["--height"]("Resize height");
+    | Opt(runBenchmark)   // bind variable to a new option, with a hint string
+    ["--benchmark"] // the option names it will respond to
+    ("run benchmark?")    // description string for the help output
+    | Opt(imagePathColor, "imagePathColor")["--imagePathColor"]("Path to color image") |
+    Opt(imagePathGray, "imagePathColor")["--imagePathGray"] |
+    Opt(g_resize_width, "g_resize_width")["--width"]("Resize width") |
+    Opt(g_resize_height, "g_resize_height")["--height"]("Resize height");
 
-  // Now pass the new composite back to Catch so it uses that
+// Now pass the new composite back to Catch so it uses that
   session.cli(cli);
 
   // Let Catch (using Clara) parse the command line
@@ -386,12 +391,12 @@ int main(int argc, char *argv[])
     vpImage<vpRGBa> I_color;
     vpImageIo::read(I_color, imagePathColor);
     std::cout << "imagePathColor:\n\t" << imagePathColor << "\n\t" << I_color.getWidth() << "x" << I_color.getHeight()
-              << std::endl;
+      << std::endl;
 
     vpImage<unsigned char> I_gray;
     vpImageIo::read(I_gray, imagePathGray);
     std::cout << "imagePathGray:\n\t" << imagePathGray << "\n\t" << I_gray.getWidth() << "x" << I_gray.getHeight()
-              << std::endl;
+      << std::endl;
     std::cout << "Resize to: " << g_resize_width << "x" << g_resize_height << std::endl;
 
     int numFailed = session.run();

--- a/modules/core/test/image-with-dataset/testConversion.cpp
+++ b/modules/core/test/image-with-dataset/testConversion.cpp
@@ -45,6 +45,11 @@
 #include <visp3/io/vpImageIo.h>
 #include <visp3/io/vpParseArgv.h>
 
+#if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_IMGCODECS) && defined(HAVE_OPENCV_IMGPROC)
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
 /*!
   \example testConversion.cpp
 
@@ -74,7 +79,7 @@ SYNOPSIS\n\
   %s [-i <input image path>] [-o <output image path>] [-n <nb benchmark iterations>]\n\
      [-h]\n\
 ",
-          name);
+name);
 
   fprintf(stdout, "\n\
 OPTIONS:                                               Default\n\
@@ -208,7 +213,8 @@ int main(int argc, const char **argv)
       try {
         // Create the dirname
         vpIoTools::makeDirectory(opath);
-      } catch (...) {
+      }
+      catch (...) {
         usage(argv[0], NULL, ipath, opt_opath, username, nbIterations);
         std::cerr << std::endl << "ERROR:" << std::endl;
         std::cerr << "  Cannot create " << opath << std::endl;
@@ -223,8 +229,8 @@ int main(int argc, const char **argv)
       if (ipath != env_ipath) {
         std::cout << std::endl << "WARNING: " << std::endl;
         std::cout << "  Since -i <visp image path=" << ipath << "> "
-                  << "  is different from VISP_IMAGE_PATH=" << env_ipath << std::endl
-                  << "  we skip the environment variable." << std::endl;
+          << "  is different from VISP_IMAGE_PATH=" << env_ipath << std::endl
+          << "  we skip the environment variable." << std::endl;
       }
     }
 
@@ -233,9 +239,9 @@ int main(int argc, const char **argv)
       usage(argv[0], NULL, ipath, opt_opath, username, nbIterations);
       std::cerr << std::endl << "ERROR:" << std::endl;
       std::cerr << "  Use -i <visp image path> option or set VISP_INPUT_IMAGE_PATH " << std::endl
-                << "  environment variable to specify the location of the " << std::endl
-                << "  image path where test images are located." << std::endl
-                << std::endl;
+        << "  environment variable to specify the location of the " << std::endl
+        << "  image path where test images are located." << std::endl
+        << std::endl;
       return EXIT_FAILURE;
     }
 
@@ -278,7 +284,7 @@ int main(int argc, const char **argv)
     // Convert a YUV pixel value to a RGB value
     vpImageConvert::YUVToRGB(y, u, v, r, g, b);
     std::cout << "   y(" << (int)y << ") u(" << (int)u << ") v(" << (int)v << ") = r(" << (int)r << ") g(" << (int)g
-              << ") b(" << (int)b << ")" << std::endl;
+      << ") b(" << (int)b << ")" << std::endl;
 
     vpChrono chrono;
 
@@ -475,8 +481,8 @@ int main(int argc, const char **argv)
     // HSV color
     ////////////////////////////////////
     std::cout << "** Convert a vpImage<vpRGBa> in RGB color space to a "
-                 "vpImage<vpRGBa> in HSV color"
-              << std::endl;
+      "vpImage<vpRGBa> in HSV color"
+      << std::endl;
     unsigned int size = Ic.getSize();
     unsigned int w = Ic.getWidth(), h = Ic.getHeight();
     std::vector<unsigned char> hue(size);
@@ -512,11 +518,11 @@ int main(int argc, const char **argv)
       for (unsigned int j = 0; j < Ic.getWidth(); j++) {
         if (Ic[i][j].R != I_HSV2RGBa[i][j].R || Ic[i][j].G != I_HSV2RGBa[i][j].G || Ic[i][j].B != I_HSV2RGBa[i][j].B) {
           std::cerr << "Ic[i][j].R=" << static_cast<unsigned>(Ic[i][j].R)
-                    << " ; I_HSV2RGBa[i][j].R=" << static_cast<unsigned>(I_HSV2RGBa[i][j].R) << std::endl;
+            << " ; I_HSV2RGBa[i][j].R=" << static_cast<unsigned>(I_HSV2RGBa[i][j].R) << std::endl;
           std::cerr << "Ic[i][j].G=" << static_cast<unsigned>(Ic[i][j].G)
-                    << " ; I_HSV2RGBa[i][j].G=" << static_cast<unsigned>(I_HSV2RGBa[i][j].G) << std::endl;
+            << " ; I_HSV2RGBa[i][j].G=" << static_cast<unsigned>(I_HSV2RGBa[i][j].G) << std::endl;
           std::cerr << "Ic[i][j].B=" << static_cast<unsigned>(Ic[i][j].B)
-                    << " ; I_HSV2RGBa[i][j].B=" << static_cast<unsigned>(I_HSV2RGBa[i][j].B) << std::endl;
+            << " ; I_HSV2RGBa[i][j].B=" << static_cast<unsigned>(I_HSV2RGBa[i][j].B) << std::endl;
           throw vpException(vpException::fatalError, "Problem with conversion between RGB <==> HSV");
         }
       }
@@ -586,9 +592,9 @@ int main(int argc, const char **argv)
       cv::Mat colorMat_crop = colorMat(rect_roi);
       cv::Mat colorMat_crop_continuous = colorMat(rect_roi).clone();
       std::cout << "   colorMat_crop: " << colorMat_crop.cols << "x" << colorMat_crop.rows << " is continuous? "
-                << colorMat_crop.isContinuous() << std::endl;
+        << colorMat_crop.isContinuous() << std::endl;
       std::cout << "   colorMat_crop_continuous: " << colorMat_crop_continuous.cols << "x" << colorMat_crop_continuous.rows
-                << " is continuous? " << colorMat_crop_continuous.isContinuous() << std::endl;
+        << " is continuous? " << colorMat_crop_continuous.isContinuous() << std::endl;
 
       vpImage<vpRGBa> I_color_crop((unsigned int)(rect_roi.height - rect_roi.y),
                                    (unsigned int)(rect_roi.width - rect_roi.x));
@@ -636,7 +642,8 @@ int main(int argc, const char **argv)
     }
 
     return EXIT_SUCCESS;
-  } catch (const vpException &e) {
+  }
+  catch (const vpException &e) {
     std::cout << "Catch an exception: " << e.getMessage() << std::endl;
     return EXIT_FAILURE;
   }

--- a/modules/vision/test/keypoint-with-dataset/testKeyPoint-5.cpp
+++ b/modules/vision/test/keypoint-with-dataset/testKeyPoint-5.cpp
@@ -48,6 +48,15 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/vision/vpKeyPoint.h>
 
+#include <opencv2/core.hpp>
+#include <opencv2/features2d.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/video.hpp>
+#include <opencv2/xfeatures2d.hpp>
+
+
+
+
 // List of allowed command line options
 #define GETOPTARGS "cdh"
 
@@ -165,9 +174,9 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
   // features that are scale invariant to detect potential problem in ViSP.
   std::cout << "INFORMATION: " << std::endl;
   std::cout << "Here, we want to test feature detection on a pyramid of images  even for features "
-               "that are scale invariant to detect potential problem in ViSP."
-            << std::endl
-            << std::endl;
+    "that are scale invariant to detect potential problem in ViSP."
+    << std::endl
+    << std::endl;
   vpKeyPoint keyPoints;
 
   // Will test the different types of keypoints detection to see if there is
@@ -274,11 +283,11 @@ void run_test(const std::string &env_ipath, bool opt_click_allowed, bool opt_dis
 
     keyPoints.detect(I, kpts);
     std::cout << "Nb keypoints detected: " << kpts.size() << " for "
-              << mapOfDetectorNames[(vpKeyPoint::vpFeatureDetectorType)i] << " method." << std::endl;
+      << mapOfDetectorNames[(vpKeyPoint::vpFeatureDetectorType)i] << " method." << std::endl;
     if (kpts.empty()) {
       std::stringstream ss;
       ss << "No keypoints detected with " << mapOfDetectorNames[(vpKeyPoint::vpFeatureDetectorType)i]
-         << " method  and image: " << filename << "." << std::endl;
+        << " method  and image: " << filename << "." << std::endl;
       throw(vpException(vpException::fatalError, ss.str()));
     }
 
@@ -325,8 +334,8 @@ int main(int argc, const char **argv)
 
     if (env_ipath.empty()) {
       std::cerr << "Please set the VISP_INPUT_IMAGE_PATH environment "
-                   "variable value."
-                << std::endl;
+        "variable value."
+        << std::endl;
       return EXIT_FAILURE;
     }
 
@@ -344,7 +353,8 @@ int main(int argc, const char **argv)
       run_test(env_ipath, opt_click_allowed, opt_display, Iinput, I);
     }
 
-  } catch (const vpException &e) {
+  }
+  catch (const vpException &e) {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
   }

--- a/modules/vision/test/keypoint-with-dataset/testKeyPoint-5.cpp
+++ b/modules/vision/test/keypoint-with-dataset/testKeyPoint-5.cpp
@@ -48,11 +48,6 @@
 #include <visp3/io/vpParseArgv.h>
 #include <visp3/vision/vpKeyPoint.h>
 
-#include <opencv2/core.hpp>
-#include <opencv2/features2d.hpp>
-#include <opencv2/imgproc.hpp>
-#include <opencv2/video.hpp>
-#include <opencv2/xfeatures2d.hpp>
 
 
 

--- a/tutorial/image/tutorial-image-converter.cpp
+++ b/tutorial/image/tutorial-image-converter.cpp
@@ -2,6 +2,11 @@
 #include <visp3/core/vpImageConvert.h>
 #include <visp3/io/vpImageIo.h>
 
+#if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_IMGCODECS) && defined(HAVE_OPENCV_IMGPROC)
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/imgproc.hpp>
+#endif
+
 int main()
 {
 #if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_HIGHGUI) && defined(HAVE_OPENCV_IMGPROC) && defined(HAVE_OPENCV_IMGCODECS)
@@ -23,7 +28,8 @@ int main()
 #ifdef VISP_HAVE_PNG
     vpImageIo::write(I, "monkey.png"); // Gray
 #endif
-  } catch (const vpException &e) {
+  }
+  catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
   }
 #endif


### PR DESCRIPTION
This PR removes the inclusion of <opencv2/opencv.hpp> in vpConfig.h and replaces it with <opencv2/opencv_modules.hpp>.
This avoid unecessary includes and may be help reduce build time.

Before merging:
[ ] Another PR should be done to update visp_samples.
[ ] Check run issue for `testKeyPoint-5` and `testKeyPoint-6` when OpenCV is built with xfeatures2d but is not compiled with the `OPENCV_ENABLE_NONFREE`