### PR TITLE
Fix problems of roundings in the cvpImageCircle::omputeAngularCoverageInRoI 

### DIFF
--- a/modules/core/include/visp3/core/vpImageCircle.h
+++ b/modules/core/include/visp3/core/vpImageCircle.h
@@ -76,19 +76,21 @@ public:
   * Compute the angular coverage, in terms of radians, that is contained in the Region of Interest (RoI).
   * \sa computeArcLengthInRoI(), computeArcLengthInRoI(const vpRect &roi)
   * \param[in] roi The rectangular RoI in which we want to know the number of pixels of the circle that are contained.
+  * \param[in] roundingTolerance The tolerance on the angle when the angle is close to a negative multiple of 2 * M_PIf.
   * \return Returns angular coverage of a circle in a ROI as an angle value in radians.
   * More precisely, it returns 2.f * M_PI for a circle that is fully visible in the RoI, or the sum of the angles
   * of the arc(s) that is(are) visible in the RoI.
   */
-  float computeAngularCoverageInRoI(const vpRect &roi) const;
+  float computeAngularCoverageInRoI(const vpRect &roi, const float &roundingTolerance = 0.001f) const;
 
   /*!
   * Compute the arc length, in terms of number of pixels, that is contained in the Region of Interest (RoI).
   * \sa computeAngularCoverageInRoI(), computeAngularCoverageInRoI(const vpRect &roi)
   * \param[in] roi The rectangular RoI in which we want to know the number of pixels of the circle that are contained.
+  * \param[in] roundingTolerance The tolerance on the angle when the angle is close to 2.f * M_PIf .
   * \return The number of pixels of the circle that are contained in the RoI.
   */
-  float computeArcLengthInRoI(const vpRect &roi) const;
+  float computeArcLengthInRoI(const vpRect &roi, const float &roundingTolerance = 0.001f) const;
 
   /*!
    * Get the center of the image (2D) circle

--- a/modules/core/include/visp3/core/vpMath.h
+++ b/modules/core/include/visp3/core/vpMath.h
@@ -172,7 +172,7 @@ public:
    * \param[in] modulo The divider.
    * \return float The rest as in a modulo operation.
    */
-  static float moduloFloat(const float &value, const float &modulo)
+  static float modulo(const float &value, const float &modulo)
   {
     float quotient = std::floor(value / modulo);
     float rest = value - quotient * modulo;
@@ -187,7 +187,7 @@ public:
    * \param[in] modulo The divider.
    * \return double The rest as in a modulo operation.
    */
-  static double moduloDouble(const double &value, const double &modulo)
+  static double modulo(const double &value, const double &modulo)
   {
     double quotient = std::floor(value / modulo);
     double rest = value - quotient * modulo;

--- a/modules/core/include/visp3/core/vpMath.h
+++ b/modules/core/include/visp3/core/vpMath.h
@@ -140,7 +140,7 @@ public:
     if (theta1 > M_PIf) {
       theta1 -= 2.0f * M_PIf;
     }
-    else if (theta1 < -M_PIf) {
+    else if (theta1 <= -M_PIf) {
       theta1 += 2.0f * M_PIf;
     }
     return theta1;
@@ -162,6 +162,36 @@ public:
       theta1 += 2.0 * M_PI;
     }
     return theta1;
+  }
+
+  /**
+   * \brief Gives the rest of \b value divided by \b modulo when
+   * the quotient can only be an integer.
+   *
+   * \param[in] value The value we want to know the rest in the "modulo" operation.
+   * \param[in] modulo The divider.
+   * \return float The rest as in a modulo operation.
+   */
+  static float moduloFloat(const float &value, const float &modulo)
+  {
+    float quotient = std::floor(value / modulo);
+    float rest = value - quotient * modulo;
+    return rest;
+  }
+
+  /**
+   * \brief Gives the rest of \b value divided by \b modulo when
+   * the quotient can only be an integer.
+   *
+   * \param[in] value The value we want to know the rest in the "modulo" operation.
+   * \param[in] modulo The divider.
+   * \return double The rest as in a modulo operation.
+   */
+  static double moduloDouble(const double &value, const double &modulo)
+  {
+    double quotient = std::floor(value / modulo);
+    double rest = value - quotient * modulo;
+    return rest;
   }
 
   /*!
@@ -193,9 +223,9 @@ public:
     }
     return (v < lower) ? lower : (upper < v) ? upper : v;
 #endif
-    }
+  }
 
-    //   round x to the nearest integer
+  //   round x to the nearest integer
   static inline int round(double x);
 
   //   return the sign of x (+-1)
@@ -330,14 +360,14 @@ public:
 private:
   static const double ang_min_sinc;
   static const double ang_min_mc;
-  };
+};
 
-  // Begining of the inline functions definition
+// Begining of the inline functions definition
 
-  /*!
-    Computes and returns x!
-    \param x : parameter of factorial function.
-  */
+/*!
+  Computes and returns x!
+  \param x : parameter of factorial function.
+*/
 double vpMath::fact(unsigned int x)
 {
   if ((x == 1) || (x == 0))

--- a/modules/core/src/image/vpImageCircle.cpp
+++ b/modules/core/src/image/vpImageCircle.cpp
@@ -481,7 +481,7 @@ void computeIntersectionsTopLeftBottom(const float &u_c, const float &v_c, const
   std::pair<float, float> crossing_theta_u_min, crossing_theta_u_max;
   std::pair<float, float> crossing_theta_v_min, crossing_theta_v_max;
   float crossing_u_top = vmin_roi; // We cross the u-axis of the top axis of the RoI at the minimum v-coordinate of the RoI
-  float crossing_v = vmin_roi; // We cross the v-axis of the RoI at the minimum u-coordinate of the RoI
+  float crossing_v = umin_roi; // We cross the v-axis of the RoI at the minimum u-coordinate of the RoI
   computePerpendicularAxesIntersections(u_c, v_c, radius, crossing_u_top, crossing_v,
                                         crossing_theta_u_min, crossing_theta_u_max,
                                         crossing_theta_v_min, crossing_theta_v_max);
@@ -501,25 +501,63 @@ void computeIntersectionsTopLeftBottom(const float &u_c, const float &v_c, const
   float theta_u_max_bottom = crossing_theta_u_max.first;
   float u_umin_bottom = crossing_theta_u_min.second;
   float u_umax_bottom = crossing_theta_u_max.second;
+  int cas = -1;
   if (u_umin_top >= umin_roi && u_umin_bottom >= umin_roi && v_vmin >= vmin_roi && v_vmax <= vmax_roi) {
     // case intersection top + left + bottom twice
     delta_theta = (theta_v_min - theta_u_min_top) + (theta_u_max_top - theta_u_max_bottom) + (theta_u_min_bottom - theta_v_max);
+    cas = 0;
   }
   else if (u_umin_top <= umin_roi && v_vmin <= vmin_roi && u_umin_bottom <= umin_roi && v_vmax >= vmax_roi) {
     // case intersection top and bottom
     delta_theta = (theta_u_max_top - theta_u_max_bottom);
+    cas = 1;
   }
   else if (u_umax_top <= umin_roi && u_umax_bottom <= umin_roi && v_vmin >= vmin_roi && v_vmax <= vmax_roi) {
     // case left only
     computeIntersectionsLeftBorderOnly(u_c, umin_roi, radius, delta_theta);
+    cas = 2;
   }
   else if (u_umax_bottom > umin_roi && v_vmin >= vmin_roi) {
     // case bottom/left corner
     computeIntersectionsBottomLeft(u_c, v_c, umin_roi, vmax_roi, radius, delta_theta);
+    cas = 3;
   }
   else if (u_umax_top > umin_roi && v_vmax <= vmax_roi) {
     // case top/left corner
     computeIntersectionsTopLeft(u_c, v_c, umin_roi, vmin_roi, radius, delta_theta);
+    cas = 4;
+  }
+
+  if (delta_theta < 0.f) {
+    std::cout << "--- computeIntersectionsTopLeftBottom with negative result ---" << std::endl;
+    std::cout << "\tu_umin_top = " << u_umin_top << "\tu_umax_top = " << u_umax_top << std::endl;
+    std::cout << "\tu_umin_bot = " << u_umin_bottom << "\tu_umax_bot = " << u_umax_bottom << std::endl;
+    std::cout << "\tv_vmin = " << v_vmin << "\tv_vmax = " << v_vmax << std::endl;
+    std::cout << "\ttheta_u_min_top = " << theta_u_min_top << "\ttheta_u_max_top = " << theta_u_max_top << std::endl;
+    std::cout << "\ttheta_u_min_bot = " << theta_u_min_bottom << "\ttheta_u_max_bot = " << theta_u_max_bottom << std::endl;
+    std::cout << "\ttheta_v_min = " << theta_v_min << "\ttheta_v_max = " << theta_v_max << std::endl;
+    std::cout << "\tcas = ";
+    std::string nameCase;
+    switch (cas) {
+    case 0:
+      nameCase = "top + left + bottom twice";
+      break;
+    case 1:
+      nameCase = "top and bottom";
+      break;
+    case 2:
+      nameCase = "left only";
+      break;
+    case 3:
+      nameCase = "bottom/left corner";
+      break;
+    case 4:
+      nameCase = "top/left corner";
+      break;
+    default:
+      throw (vpException(vpException::fatalError, "Uncorrect case"));
+    }
+    std::cout << nameCase << std::endl;
   }
 }
 

--- a/modules/core/src/image/vpImageCircle.cpp
+++ b/modules/core/src/image/vpImageCircle.cpp
@@ -990,10 +990,10 @@ float vpImageCircle::computeAngularCoverageInRoI(const vpRect &roi, const float 
     throw(vpException(vpException::fatalError, "This case should never happen. Please contact Inria to make fix the problem"));
   }
 
-  if (delta_theta < 0) { // Needed since M_PIf is used
+  if (delta_theta < 0 || delta_theta > 2.f * M_PIf) { // Needed since M_PIf is used
     float quotient = std::floor(delta_theta / (2.f * M_PIf));
     float rest = delta_theta - quotient * 2.f * M_PIf;
-    if (rest < roundingTolerance && delta_theta < -M_PIf) {
+    if (rest < roundingTolerance && (delta_theta < -M_PIf || delta_theta > M_PIf)) {
       // If the angle is a negative multiple of 2.f * M_PIf we consider it to be 2.f * M_PIf
       delta_theta = 2.f * M_PIf;
     }

--- a/modules/core/src/image/vpImageCircle.cpp
+++ b/modules/core/src/image/vpImageCircle.cpp
@@ -1003,7 +1003,7 @@ float vpImageCircle::computeAngularCoverageInRoI(const vpRect &roi, const float 
   }
 
   if (delta_theta < 0 || delta_theta > 2.f * M_PIf) { // Needed since M_PIf is used
-    float rest = vpMath::moduloFloat(delta_theta, 2.f * M_PIf);
+    float rest = vpMath::modulo(delta_theta, 2.f * M_PIf);
     if (rest < roundingTolerance && (delta_theta < -M_PIf || delta_theta > M_PIf)) {
       // If the angle is a negative multiple of 2.f * M_PIf we consider it to be 2.f * M_PIf
       delta_theta = 2.f * M_PIf;

--- a/modules/core/src/image/vpImageCircle.cpp
+++ b/modules/core/src/image/vpImageCircle.cpp
@@ -77,6 +77,9 @@ void computeIntersectionsLeftBorderOnly(const float &u_c, const float &umin_roi,
   float theta_min = std::min(theta1, theta2);
   float theta_max = std::max(theta1, theta2);
   delta_theta = theta_max - theta_min;
+  if (u_c < umin_roi && std::abs(delta_theta - 2 * M_PIf) < 2.f * std::numeric_limits<float>::epsilon()) {
+    delta_theta = 0.f;
+  }
 }
 
 /*!
@@ -99,6 +102,9 @@ void computeIntersectionsRightBorderOnly(const float &u_c, const float &umax_roi
   float theta_min = std::min(theta1, theta2);
   float theta_max = std::max(theta1, theta2);
   delta_theta = 2.f * M_PIf - (theta_max - theta_min);
+  if (u_c > umax_roi && std::abs(delta_theta - 2 * M_PIf) < 2.f * std::numeric_limits<float>::epsilon()) {
+    delta_theta = 0.f;
+  }
 }
 
 /*!
@@ -138,6 +144,9 @@ void computeIntersectionsTopBorderOnly(const float &v_c, const float &vmin_roi, 
   else {
     delta_theta = theta_max - theta_min;
   }
+  if (v_c < vmin_roi && std::abs(delta_theta - 2 * M_PIf) < 2.f * std::numeric_limits<float>::epsilon()) {
+    delta_theta = 0.f;
+  }
 }
 
 /*!
@@ -176,6 +185,9 @@ void computeIntersectionsBottomBorderOnly(const float &v_c, const float &vmax_ro
   }
   else {
     delta_theta = 2.f * M_PIf - (theta_max - theta_min);
+  }
+  if (v_c > vmax_roi && std::abs(delta_theta - 2 * M_PIf) < 2.f * std::numeric_limits<float>::epsilon()) {
+    delta_theta = 0.f;
   }
 }
 
@@ -501,63 +513,25 @@ void computeIntersectionsTopLeftBottom(const float &u_c, const float &v_c, const
   float theta_u_max_bottom = crossing_theta_u_max.first;
   float u_umin_bottom = crossing_theta_u_min.second;
   float u_umax_bottom = crossing_theta_u_max.second;
-  int cas = -1;
   if (u_umin_top >= umin_roi && u_umin_bottom >= umin_roi && v_vmin >= vmin_roi && v_vmax <= vmax_roi) {
     // case intersection top + left + bottom twice
     delta_theta = (theta_v_min - theta_u_min_top) + (theta_u_max_top - theta_u_max_bottom) + (theta_u_min_bottom - theta_v_max);
-    cas = 0;
   }
   else if (u_umin_top <= umin_roi && v_vmin <= vmin_roi && u_umin_bottom <= umin_roi && v_vmax >= vmax_roi) {
     // case intersection top and bottom
     delta_theta = (theta_u_max_top - theta_u_max_bottom);
-    cas = 1;
   }
   else if (u_umax_top <= umin_roi && u_umax_bottom <= umin_roi && v_vmin >= vmin_roi && v_vmax <= vmax_roi) {
     // case left only
     computeIntersectionsLeftBorderOnly(u_c, umin_roi, radius, delta_theta);
-    cas = 2;
   }
   else if (u_umax_bottom > umin_roi && v_vmin >= vmin_roi) {
     // case bottom/left corner
     computeIntersectionsBottomLeft(u_c, v_c, umin_roi, vmax_roi, radius, delta_theta);
-    cas = 3;
   }
   else if (u_umax_top > umin_roi && v_vmax <= vmax_roi) {
     // case top/left corner
     computeIntersectionsTopLeft(u_c, v_c, umin_roi, vmin_roi, radius, delta_theta);
-    cas = 4;
-  }
-
-  if (delta_theta < 0.f) {
-    std::cout << "--- computeIntersectionsTopLeftBottom with negative result ---" << std::endl;
-    std::cout << "\tu_umin_top = " << u_umin_top << "\tu_umax_top = " << u_umax_top << std::endl;
-    std::cout << "\tu_umin_bot = " << u_umin_bottom << "\tu_umax_bot = " << u_umax_bottom << std::endl;
-    std::cout << "\tv_vmin = " << v_vmin << "\tv_vmax = " << v_vmax << std::endl;
-    std::cout << "\ttheta_u_min_top = " << theta_u_min_top << "\ttheta_u_max_top = " << theta_u_max_top << std::endl;
-    std::cout << "\ttheta_u_min_bot = " << theta_u_min_bottom << "\ttheta_u_max_bot = " << theta_u_max_bottom << std::endl;
-    std::cout << "\ttheta_v_min = " << theta_v_min << "\ttheta_v_max = " << theta_v_max << std::endl;
-    std::cout << "\tcas = ";
-    std::string nameCase;
-    switch (cas) {
-    case 0:
-      nameCase = "top + left + bottom twice";
-      break;
-    case 1:
-      nameCase = "top and bottom";
-      break;
-    case 2:
-      nameCase = "left only";
-      break;
-    case 3:
-      nameCase = "bottom/left corner";
-      break;
-    case 4:
-      nameCase = "top/left corner";
-      break;
-    default:
-      throw (vpException(vpException::fatalError, "Uncorrect case"));
-    }
-    std::cout << nameCase << std::endl;
   }
 }
 
@@ -1029,8 +1003,7 @@ float vpImageCircle::computeAngularCoverageInRoI(const vpRect &roi, const float 
   }
 
   if (delta_theta < 0 || delta_theta > 2.f * M_PIf) { // Needed since M_PIf is used
-    float quotient = std::floor(delta_theta / (2.f * M_PIf));
-    float rest = delta_theta - quotient * 2.f * M_PIf;
+    float rest = vpMath::moduloFloat(delta_theta, 2.f * M_PIf);
     if (rest < roundingTolerance && (delta_theta < -M_PIf || delta_theta > M_PIf)) {
       // If the angle is a negative multiple of 2.f * M_PIf we consider it to be 2.f * M_PIf
       delta_theta = 2.f * M_PIf;

--- a/modules/core/test/tools/geometry/testImageCircle.cpp
+++ b/modules/core/test/tools/geometry/testImageCircle.cpp
@@ -173,6 +173,31 @@ int main()
     hasSucceeded &= isValueOK;
   }
 
+  // Test with circle touching the left border, all the circle is hidden
+  {
+    // Formula: uc = OFFSET - RADIUS * cos(theta)
+    // theta := PI
+    float uc = OFFSET - RADIUS;
+    float vc = OFFSET - 100.f;
+    vpImageCircle circle(vpImagePoint(vc, uc), RADIUS);
+    float arcLengthCircle = circle.computeArcLengthInRoI(roi);
+    float theoreticalValue = 0.f;
+    bool isValueOK = equal(arcLengthCircle, theoreticalValue);
+    std::string statusTest;
+    if (isValueOK) {
+      statusTest = "SUCCESS";
+    }
+    else {
+      statusTest = "FAILED";
+    }
+    std::cout << "Test with circle touching the left border, all the circle is hidden." << std::endl;
+    std::cout << "\tarc length =" << arcLengthCircle << std::endl;
+    std::cout << "\ttheoretical length =" << theoreticalValue << std::endl;
+    std::cout << "\ttest status = " << statusTest << std::endl;
+
+    hasSucceeded &= isValueOK;
+  }
+
   // Test with intersections with the right border, more than half a circle visible
   {
     // Formula: uc = OFFSET + WIDTH - RADIUS * cos(theta)
@@ -241,6 +266,31 @@ int main()
       statusTest = "FAILED";
     }
     std::cout << "Test with circle touching the right border, all the circle is visible." << std::endl;
+    std::cout << "\tarc length =" << arcLengthCircle << std::endl;
+    std::cout << "\ttheoretical length =" << theoreticalValue << std::endl;
+    std::cout << "\ttest status = " << statusTest << std::endl;
+
+    hasSucceeded &= isValueOK;
+  }
+
+  // Test with circle touching the right border, all the circle is hidden
+  {
+    // Formula: uc = OFFSET + WIDTH - RADIUS * cos(theta)
+    // theta := 0
+    float uc = OFFSET + WIDTH + RADIUS;
+    float vc = OFFSET + 100.f;
+    vpImageCircle circle(vpImagePoint(vc, uc), RADIUS);
+    float arcLengthCircle = circle.computeArcLengthInRoI(roi);
+    float theoreticalValue = 0.f;
+    bool isValueOK = equal(arcLengthCircle, theoreticalValue);
+    std::string statusTest;
+    if (isValueOK) {
+      statusTest = "SUCCESS";
+    }
+    else {
+      statusTest = "FAILED";
+    }
+    std::cout << "Test with circle touching the right border, all the circle is hidden." << std::endl;
     std::cout << "\tarc length =" << arcLengthCircle << std::endl;
     std::cout << "\ttheoretical length =" << theoreticalValue << std::endl;
     std::cout << "\ttest status = " << statusTest << std::endl;
@@ -326,6 +376,32 @@ int main()
     hasSucceeded &= isValueOK;
   }
 
+  // Test with circle touching the top border, all the circle is hidden
+  {
+    // v = vc - r sin(theta)
+    // Formula: vc = OFFSET + RADIUS * sin(theta)
+    float theta = -M_PI_2f;
+    float uc = OFFSET + 100.f;
+    float vc = OFFSET + RADIUS * sin(theta);
+    vpImageCircle circle(vpImagePoint(vc, uc), RADIUS);
+    float arcLengthCircle = circle.computeArcLengthInRoI(roi);
+    float theoreticalValue = 0.f;
+    bool isValueOK = equal(arcLengthCircle, theoreticalValue);
+    std::string statusTest;
+    if (isValueOK) {
+      statusTest = "SUCCESS";
+    }
+    else {
+      statusTest = "FAILED";
+    }
+    std::cout << "Test with circle touching the top border, all the circle is hidden." << std::endl;
+    std::cout << "\tarc length =" << arcLengthCircle << std::endl;
+    std::cout << "\ttheoretical length =" << theoreticalValue << std::endl;
+    std::cout << "\ttest status = " << statusTest << std::endl;
+
+    hasSucceeded &= isValueOK;
+  }
+
   // Test with intersections with the bottom border, more than half a circle visible
   {
     // v = vc - r sin(theta)
@@ -395,6 +471,30 @@ int main()
       statusTest = "FAILED";
     }
     std::cout << "Test with circle touching the bottom border, all the circle is visible." << std::endl;
+    std::cout << "\tarc length =" << arcLengthCircle << std::endl;
+    std::cout << "\ttheoretical length =" << theoreticalValue << std::endl;
+    std::cout << "\ttest status = " << statusTest << std::endl;
+
+    hasSucceeded &= isValueOK;
+  }
+
+  // Test with circle touching the bottom border, all the circle is hidden
+  {
+    // Formula: vc = OFFSET + HEIGHT + RADIUS * sin(theta)
+    float uc = OFFSET + 100.f;
+    float vc = OFFSET + HEIGHT + RADIUS;
+    vpImageCircle circle(vpImagePoint(vc, uc), RADIUS);
+    float arcLengthCircle = circle.computeArcLengthInRoI(roi);
+    float theoreticalValue = 0.f;
+    bool isValueOK = equal(arcLengthCircle, theoreticalValue);
+    std::string statusTest;
+    if (isValueOK) {
+      statusTest = "SUCCESS";
+    }
+    else {
+      statusTest = "FAILED";
+    }
+    std::cout << "Test with circle touching the bottom border, all the circle is hidden." << std::endl;
     std::cout << "\tarc length =" << arcLengthCircle << std::endl;
     std::cout << "\ttheoretical length =" << theoreticalValue << std::endl;
     std::cout << "\ttest status = " << statusTest << std::endl;
@@ -2000,6 +2100,7 @@ int main()
     std::cout << "testImageCircle overall result: SUCCESS" << std::endl;
     return EXIT_SUCCESS;
   }
+
   std::cout << "testImageCircle overall result: FAILED" << std::endl;
   return EXIT_FAILURE;
 }


### PR DESCRIPTION
A rouding problem was introduced by the use of M_PIf .
The result of the method is now ensured to be between 0 and 2 Pi.