### PR TITLE
Fix canny

### DIFF
--- a/modules/core/include/visp3/core/vpCannyEdgeDetection.h
+++ b/modules/core/include/visp3/core/vpCannyEdgeDetection.h
@@ -116,8 +116,10 @@ private:
    * \brief Step 3: Edge thining.
    * \details Perform the edge thining step.
    * Perform a non-maximum suppression to keep only local maxima as edge candidates.
+   * \param[in] lowerThreshold Edge candidates that are below this threshold are definitely not
+   * edges.
    */
-  void performEdgeThining();
+  void performEdgeThinning(const float &lowerThreshold);
 
   /**
    * \brief Perform hysteresis thresholding.

--- a/tutorial/image/drawingHelpers.cpp
+++ b/tutorial/image/drawingHelpers.cpp
@@ -33,37 +33,67 @@
 #include <visp3/core/vpImageConvert.h>
 
 #if defined(VISP_HAVE_X11)
-vpDisplayX drawingHelpers::d;
+vpDisplayX drawingHelpers::d_Iinput;
+vpDisplayX drawingHelpers::d_dIx;
+vpDisplayX drawingHelpers::d_dIy;
+vpDisplayX drawingHelpers::d_IcannyVisp;
+vpDisplayX drawingHelpers::d_IcannyImgFilter;
 #elif defined(HAVE_OPENCV_HIGHGUI)
-vpDisplayOpenCV drawingHelpers::d;
+vpDisplayOpenCV drawingHelpers::d_Iinput;
+vpDisplayOpenCV drawingHelpers::d_dIx;
+vpDisplayOpenCV drawingHelpers::d_dIy;
+vpDisplayOpenCV drawingHelpers::d_IcannyVisp;
+vpDisplayOpenCV drawingHelpers::d_IcannyImgFilter;
 #elif defined(VISP_HAVE_GTK)
-vpDisplayGTK drawingHelpers::d;
+vpDisplayGTK drawingHelpers::d_Iinput;
+vpDisplayGTK drawingHelpers::d_dIx;
+vpDisplayGTK drawingHelpers::d_dIy;
+vpDisplayGTK drawingHelpers::d_IcannyVisp;
+vpDisplayGTK drawingHelpers::d_IcannyImgFilter;
 #elif defined(VISP_HAVE_GDI)
-vpDisplayGDI drawingHelpers::d;
+vpDisplayGDI drawingHelpers::d_Iinput;
+vpDisplayGDI drawingHelpers::d_dIx;
+vpDisplayGDI drawingHelpers::d_dIy;
+vpDisplayGDI drawingHelpers::d_IcannyVisp;
+vpDisplayGDI drawingHelpers::d_IcannyImgFilter;
 #elif defined(VISP_HAVE_D3D9)
-vpDisplayD3D drawingHelpers::d;
+vpDisplayD3D drawingHelpers::d_Iinput;
+vpDisplayD3D drawingHelpers::d_dIx;
+vpDisplayD3D drawingHelpers::d_dIy;
+vpDisplayD3D drawingHelpers::d_IcannyVisp;
+vpDisplayD3D drawingHelpers::d_IcannyImgFilter;
 #endif
 
-vpImage<vpRGBa> drawingHelpers::I_disp;
-
-bool drawingHelpers::display(vpImage<vpRGBa> &I, const std::string &title, const bool &blockingMode)
+void drawingHelpers::init(vpImage<unsigned char> &Iinput, vpImage<unsigned char> &IcannyVisp, vpImage<unsigned char> *p_dIx,
+            vpImage<unsigned char> *p_dIy, vpImage<unsigned char> *p_IcannyimgFilter)
 {
-  I_disp = I;
-#if defined(VISP_HAVE_DISPLAY)
-  if (!d.isInitialised()) {
-    d.init(I_disp);
-    vpDisplay::setTitle(I_disp, title);
+  d_Iinput.init(Iinput, 10, 10);
+  d_IcannyVisp.init(IcannyVisp, 10, Iinput.getHeight() + 10 * 2);
+  if (p_dIx != nullptr) {
+    d_dIx.init(*p_dIx, Iinput.getWidth() + 2 * 10, 10);
   }
-#else
-  (void)title;
-#endif
+  if (p_dIy != nullptr) {
+    d_dIy.init(*p_dIy, 2 * Iinput.getWidth() + 3 * 10, 10);
+  }
+  if (p_IcannyimgFilter != nullptr) {
+    d_IcannyImgFilter.init(*p_IcannyimgFilter, Iinput.getWidth() + 2 * 10, Iinput.getHeight() + 10 * 2);
+  }
+}
 
-  vpDisplay::display(I_disp);
-  vpDisplay::displayText(I_disp, 15, 15, "Left click to continue...", vpColor::red);
-  vpDisplay::displayText(I_disp, 35, 15, "Right click to stop...", vpColor::red);
-  vpDisplay::flush(I_disp);
+void drawingHelpers::display(vpImage<unsigned char> &I, const std::string &title)
+{
+  vpDisplay::display(I);
+  vpDisplay::setTitle(I, title);
+  vpDisplay::flush(I);
+}
+
+bool drawingHelpers::waitForClick(const vpImage<unsigned char> &I, const bool &blockingMode)
+{
+  vpDisplay::displayText(I, 15, 15, "Left click to continue...", vpColor::red);
+  vpDisplay::displayText(I, 35, 15, "Right click to stop...", vpColor::red);
+  vpDisplay::flush(I);
   vpMouseButton::vpMouseButtonType button;
-  vpDisplay::getClick(I_disp, button, blockingMode);
+  vpDisplay::getClick(I, button, blockingMode);
   bool hasToContinue = true;
   if (button == vpMouseButton::button3) {
     // Right click => stop the program
@@ -71,25 +101,4 @@ bool drawingHelpers::display(vpImage<vpRGBa> &I, const std::string &title, const
   }
 
   return hasToContinue;
-}
-
-bool drawingHelpers::display(vpImage<unsigned char> &D, const std::string &title, const bool &blockingMode)
-{
-  vpImage<vpRGBa> I; // Image to display
-  vpImageConvert::convert(D, I);
-  return display(I, title, blockingMode);
-}
-
-bool drawingHelpers::display(vpImage<double> &D, const std::string &title, const bool &blockingMode)
-{
-  vpImage<unsigned char> I; // Image to display
-  vpImageConvert::convert(D, I);
-  return display(I, title, blockingMode);
-}
-
-bool drawingHelpers::display(vpImage<float> &F, const std::string &title, const bool &blockingMode)
-{
-  vpImage<unsigned char> I; // Image to display
-  vpImageConvert::convert(F, I);
-  return display(I, title, blockingMode);
 }

--- a/tutorial/image/drawingHelpers.h
+++ b/tutorial/image/drawingHelpers.h
@@ -48,25 +48,25 @@ extern vpDisplayOpenCV d_Iinput;
 extern vpDisplayOpenCV d_dIx;
 extern vpDisplayOpenCV d_dIy;
 extern vpDisplayOpenCV d_IcannyVisp;
-extern vpDisplayOpenCV d_IcannyImgFilter
+extern vpDisplayOpenCV d_IcannyImgFilter;
 #elif defined(VISP_HAVE_GTK)
 extern vpDisplayGTK d_Iinput;
 extern vpDisplayGTK d_dIx;
 extern vpDisplayGTK d_dIy;
 extern vpDisplayGTK d_IcannyVisp;
-extern vpDisplayGTK d_IcannyImgFilter
+extern vpDisplayGTK d_IcannyImgFilter;
 #elif defined(VISP_HAVE_GDI)
 extern vpDisplayGDI d_Iinput;
 extern vpDisplayGDI d_dIx;
 extern vpDisplayGDI d_dIy;
 extern vpDisplayGDI d_IcannyVisp;
-extern vpDisplayGDI d_IcannyImgFilter
+extern vpDisplayGDI d_IcannyImgFilter;
 #elif defined(VISP_HAVE_D3D9)
 extern vpDisplayD3D d_Iinput;
 extern vpDisplayD3D d_dIx;
 extern vpDisplayD3D d_dIy;
 extern vpDisplayD3D d_IcannyVisp;
-extern vpDisplayD3D d_IcannyImgFilter
+extern vpDisplayD3D d_IcannyImgFilter;
 #endif
 
 /**
@@ -79,8 +79,8 @@ extern vpDisplayD3D d_IcannyImgFilter
  * \param[out] p_IcannyimgFilter If different from nullptr, pointer towards the result of the vpImageFilter::canny
  * method.
  */
-  void init(vpImage<unsigned char> &Iinput, vpImage<unsigned char> &IcannyVisp, vpImage<unsigned char> *p_dIx,
-            vpImage<unsigned char> *p_dIy, vpImage<unsigned char> *p_IcannyimgFilter);
+void init(vpImage<unsigned char> &Iinput, vpImage<unsigned char> &IcannyVisp, vpImage<unsigned char> *p_dIx,
+          vpImage<unsigned char> *p_dIy, vpImage<unsigned char> *p_IcannyimgFilter);
 
 /**
  * \brief Display a gray-scale image.

--- a/tutorial/image/drawingHelpers.h
+++ b/tutorial/image/drawingHelpers.h
@@ -38,66 +38,67 @@
 namespace drawingHelpers
 {
 #if defined(VISP_HAVE_X11)
-extern vpDisplayX d;
+extern vpDisplayX d_Iinput;
+extern vpDisplayX d_dIx;
+extern vpDisplayX d_dIy;
+extern vpDisplayX d_IcannyVisp;
+extern vpDisplayX d_IcannyImgFilter;
 #elif defined(HAVE_OPENCV_HIGHGUI)
-extern vpDisplayOpenCV d;
+extern vpDisplayOpenCV d_Iinput;
+extern vpDisplayOpenCV d_dIx;
+extern vpDisplayOpenCV d_dIy;
+extern vpDisplayOpenCV d_IcannyVisp;
+extern vpDisplayOpenCV d_IcannyImgFilter
 #elif defined(VISP_HAVE_GTK)
-extern vpDisplayGTK d;
+extern vpDisplayGTK d_Iinput;
+extern vpDisplayGTK d_dIx;
+extern vpDisplayGTK d_dIy;
+extern vpDisplayGTK d_IcannyVisp;
+extern vpDisplayGTK d_IcannyImgFilter
 #elif defined(VISP_HAVE_GDI)
-extern vpDisplayGDI d;
+extern vpDisplayGDI d_Iinput;
+extern vpDisplayGDI d_dIx;
+extern vpDisplayGDI d_dIy;
+extern vpDisplayGDI d_IcannyVisp;
+extern vpDisplayGDI d_IcannyImgFilter
 #elif defined(VISP_HAVE_D3D9)
-extern vpDisplayD3D d;
+extern vpDisplayD3D d_Iinput;
+extern vpDisplayD3D d_dIx;
+extern vpDisplayD3D d_dIy;
+extern vpDisplayD3D d_IcannyVisp;
+extern vpDisplayD3D d_IcannyImgFilter
 #endif
 
-extern vpImage<vpRGBa> I_disp; /*!< Displayed image.*/
-
 /**
- * \brief Display a RGB image and catch the user clicks to know if
- * the user wants to stop the program.
+ * \brief Initialize the different displays.
  *
- * \param[out] I The RGB image to display.
- * \param[in] title The title of the window.
- * \param[in] blockingMode If true, wait for a click to switch to the next image.
- * \return true The user wants to continue the application.
- * \return false The user wants to stop the application.
+ * \param[out] Iinput Input image of the program.
+ * \param[out] IcannyVisp Image resulting from the vpCannyEdgeDetection method.
+ * \param[out] p_dIx If different from nullptr, pointer towards the gradient along the horizontal axis.
+ * \param[out] p_dIy If different from nullptr, pointer towards the gradient along the vertical axis.
+ * \param[out] p_IcannyimgFilter If different from nullptr, pointer towards the result of the vpImageFilter::canny
+ * method.
  */
-bool display(vpImage<vpRGBa> &I, const std::string &title, const bool &blockingMode);
+  void init(vpImage<unsigned char> &Iinput, vpImage<unsigned char> &IcannyVisp, vpImage<unsigned char> *p_dIx,
+            vpImage<unsigned char> *p_dIy, vpImage<unsigned char> *p_IcannyimgFilter);
 
 /**
- * \brief Display a gray-scale image and catch the user clicks to know if
- * the user wants to stop the program.
+ * \brief Display a gray-scale image.
  *
  * \param[out] I The gray-scale image to display.
  * \param[in] title The title of the window.
- * \param[in] blockingMode If true, wait for a click to switch to the next image.
- * \return true The user wants to continue the application.
- * \return false The user wants to stop the application.
  */
-bool display(vpImage<unsigned char> &I, const std::string &title, const bool &blockingMode);
+void display(vpImage<unsigned char> &I, const std::string &title);
 
 /**
- * \brief Display a double precision image and catch the user clicks to know if
- * the user wants to stop the program.
+ * \brief Catch the user clicks to know if the user wants to stop the program.
  *
- * \param[out] D The double precision image to display.
- * \param[in] title The title of the window.
+ * \param[in] I The gray-scale image to display.
  * \param[in] blockingMode If true, wait for a click to switch to the next image.
  * \return true The user wants to continue the application.
  * \return false The user wants to stop the application.
  */
-bool display(vpImage<double> &D, const std::string &title, const bool &blockingMode);
-
-/**
- * \brief Display a floating-point precision image and catch the user clicks to know if
- * the user wants to stop the program.
- *
- * \param[out] F The floating-point precision image to display.
- * \param[in] title The title of the window.
- * \param[in] blockingMode If true, wait for a click to switch to the next image.
- * \return true The user wants to continue the application.
- * \return false The user wants to stop the application.
- */
-bool display(vpImage<float> &F, const std::string &title, const bool &blockingMode);
+bool waitForClick(const vpImage<unsigned char> &I, const bool &blockingMode);
 }
 
 #endif


### PR DESCRIPTION
Improved the ViSP Canny implementation by :
- changing the edge thinning algorithm
- considering only the gradient points having a value greater than the lower threshold

To test with the result of Canny by OpenCV beside the ViSP implementation result:
```
./tutorial-canny -t -1 -1 -r 0.4 0.95 -b opencv-backend --image
```

Here is a dataset that can be used to have a look at the capabilities of the new implementation:
[testCanny.zip](https://github.com/lagadic/visp/files/13424676/testCanny.zip)

