### PR TITLE
Fix cam parser

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -38,6 +38,7 @@ ViSP 3.x.x (Version in development)
     . [#1273] Build error in visp_java without deprecated functionalities
     . [#1274] Build issue no member named clamp in namespace std
     . [#1279] Issue in vpPoseVector json serialization
+    . [#1296] Unable to parse camera parameters with vpXmlParserCamera::parse() when camera name is empty
 ----------------------------------------------
 ViSP 3.6.0 (released September 22, 2023)
   - Contributors:

--- a/modules/core/src/camera/vpXmlParserCamera.cpp
+++ b/modules/core/src/camera/vpXmlParserCamera.cpp
@@ -554,7 +554,7 @@ public:
 
     camera = cam;
 
-    int nbCamera = count(node, cam_name, cam.get_projModel(), verbose, im_width, im_height);
+    int nbCamera = count(node, cam_name, cam.get_projModel(), im_width, im_height, verbose);
     if (nbCamera) {
       return SEQUENCE_ERROR;
     }

--- a/modules/core/src/camera/vpXmlParserCamera.cpp
+++ b/modules/core/src/camera/vpXmlParserCamera.cpp
@@ -310,7 +310,7 @@ public:
     }
     // if same name && same projection model && same image size camera already exists, we return SEQUENCE_OK
     // otherwise it is a new camera that need to be updated and we return SEQUENCE_OK
-    bool same_name = (!cam_name.empty() && (cam_name == camera_name_tmp));
+    bool same_name = (cam_name.empty() || (cam_name == camera_name_tmp));
     bool same_img_size = (abs((int)im_width - (int)image_width_tmp) < allowedPixelDiffOnImageSize || im_width == 0) &&
       (abs((int)im_height - (int)image_height_tmp) < allowedPixelDiffOnImageSize || im_height == 0) &&
       (test_subsampling_width) && (test_subsampling_height);

--- a/modules/core/test/camera/testXmlParserCamera.cpp
+++ b/modules/core/test/camera/testXmlParserCamera.cpp
@@ -267,6 +267,39 @@ int main()
     }
   }
 
+  {
+    std::cout << "-- Test to save/load one single camera with Kannala Brandt distortion in a single file wo name" << std::endl;
+    vpCameraParameters cam;
+    std::vector<double> distortion_coeffs;
+    distortion_coeffs.push_back(-0.00297341705299914);
+    distortion_coeffs.push_back(0.0352853797376156);
+    distortion_coeffs.push_back(-0.032205019146204);
+    distortion_coeffs.push_back(0.004446716979146);
+    distortion_coeffs.push_back(0);
+    cam.initProjWithKannalaBrandtDistortion(285.523895263672, 286.6708984375, 420.874114990234, 381.085388183594,
+                                            distortion_coeffs);
+    std::string filename = tmp_dir + "test_write_cam_with_KannalaBrandt_distortion.xml";
+    {
+      vpXmlParserCamera xml;
+      std::cout << "Write to: " << filename << std::endl;
+      if (xml.save(cam, filename, "Camera", 800, 848) != vpXmlParserCamera::SEQUENCE_OK) {
+        std::cerr << "Cannot save XML file: " << filename << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+
+    vpCameraParameters cam_read;
+    {
+      vpXmlParserCamera xml;
+      xml.parse(cam_read, filename, "", vpCameraParameters::ProjWithKannalaBrandtDistortion, 800, 848, false);
+      std::cout << "Cam write:\n" << cam << std::endl;
+      std::cout << "Cam read:\n" << cam_read << std::endl;
+      if (cam != cam_read) {
+        std::cerr << "Issue when parsing XML file: " << filename << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+  }
   vpIoTools::remove(tmp_dir);
 #endif
 

--- a/modules/core/test/camera/testXmlParserCamera.cpp
+++ b/modules/core/test/camera/testXmlParserCamera.cpp
@@ -278,7 +278,7 @@ int main()
     distortion_coeffs.push_back(0);
     cam.initProjWithKannalaBrandtDistortion(285.523895263672, 286.6708984375, 420.874114990234, 381.085388183594,
                                             distortion_coeffs);
-    std::string filename = tmp_dir + "test_write_cam_with_KannalaBrandt_distortion.xml";
+    std::string filename = tmp_dir + "test_write_cam_with_KannalaBrandt_distortion_wo_name.xml";
     {
       vpXmlParserCamera xml;
       std::cout << "Write to: " << filename << std::endl;
@@ -300,7 +300,72 @@ int main()
       }
     }
   }
+
+  {
+    std::cout << "-- Test to save 2 cameras and parse them wo name thanks they differ in distortion" << std::endl;
+    vpCameraParameters cam1;
+
+    std::string filename = tmp_dir + "test_write_2_cam_differ_in_distortion.xml";
+
+    {
+      vpXmlParserCamera xml;
+      std::cout << "Write to: " << filename << std::endl;
+      std::cout << "Cam write:\n" << cam1 << std::endl;
+      if (xml.save(cam1, filename, "Camera 1", 320, 240, "", false) != vpXmlParserCamera::SEQUENCE_OK) {
+        std::cerr << "Cannot save XML file: " << filename << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+
+    vpCameraParameters cam2;
+    std::vector<double> distortion_coeffs;
+    distortion_coeffs.push_back(-0.00297341705299914);
+    distortion_coeffs.push_back(0.0352853797376156);
+    distortion_coeffs.push_back(-0.032205019146204);
+    distortion_coeffs.push_back(0.004446716979146);
+    distortion_coeffs.push_back(0);
+    cam2.initProjWithKannalaBrandtDistortion(285.523895263672, 286.6708984375, 420.874114990234, 381.085388183594,
+                                            distortion_coeffs);
+    {
+      vpXmlParserCamera xml;
+      std::cout << "Write to: " << filename << std::endl;
+      std::cout << "Cam write:\n" << cam2 << std::endl;
+      if (xml.save(cam2, filename, "Camera 2", 800, 848, "", false) != vpXmlParserCamera::SEQUENCE_OK) {
+        std::cerr << "Cannot save XML file: " << filename << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+
+    {
+      std::cout << "Attempt to read camera with perspective projection without distortion and without name" << std::endl;
+      vpCameraParameters cam_read;
+      vpXmlParserCamera xml;
+      xml.parse(cam_read, filename, "", vpCameraParameters::perspectiveProjWithoutDistortion, 320, 240, false);
+
+      std::cout << "Cam read:\n" << cam_read << std::endl;
+      if (cam1 != cam_read) {
+        std::cerr << "Issue when parsing XML file: " << filename << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+
+    {
+      std::cout << "Attempt to read camera with Kannala Brandt distortion and without name" << std::endl;
+      vpCameraParameters cam_read;
+      vpXmlParserCamera xml;
+      xml.parse(cam_read, filename, "", vpCameraParameters::ProjWithKannalaBrandtDistortion, 800, 848, false);
+
+      std::cout << "Cam read:\n" << cam_read << std::endl;
+      if (cam2 != cam_read) {
+        std::cerr << "Issue when parsing XML file: " << filename << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+  }
+
   vpIoTools::remove(tmp_dir);
+
+  std::cout << "Test succeed" << std::endl;
 #endif
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
PR to solve Issue #1296

- Added a test in testXmlParserCamera to check if the parse method handles a file containing a single camera when no name is given to the camera
- FIx the problem: the test same_name was wrong.