### PR TITLE
Attempt to fix macos-13 ci issue when installing brew dependencies

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,11 +50,12 @@ jobs:
       #
       # To force the link and overwrite all conflicting files:
       #   brew link --overwrite python@3.12
+      #
+      # Fix proposed in https://github.com/actions/runner-images/issues/6817
       if: matrix.os == 'macos-13'
       run: |
         brew update
-        sudo rm /usr/local/bin/2to3-3.12
-        brew upgrade
+        brew upgrade || true
         brew install libpng libjpeg-turbo libdc1394 pcl librealsense zbar pkg-config nlohmann-json
         brew install opencv
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,8 +33,27 @@ jobs:
     - name: Print OS information
       run: system_profiler SPSoftwareDataType
 
-    - name: Install dependencies
-      run: brew install libpng libjpeg-turbo libdc1394 opencv pcl librealsense zbar pkg-config nlohmann-json
+    - name: Install dependencies on macos-12
+      if: matrix.os == 'macos-12'
+      run: |
+        brew install libpng libjpeg-turbo libdc1394 opencv pcl librealsense zbar pkg-config nlohmann-json
+
+    - name: Install dependencies on macos-13
+      # On macos-13 we need to do a specific action
+      # ==> Pouring python@3.12--3.12.1_1.ventura.bottle.tar.gz
+      # Error: The `brew link` step did not complete successfully
+      # The formula built, but is not symlinked into /usr/local
+      # Could not symlink bin/2to3-3.12
+      # Target /usr/local/bin/2to3-3.12
+      # already exists. You may want to remove it:
+      #   rm '/usr/local/bin/2to3-3.12'
+      #
+      # To force the link and overwrite all conflicting files:
+      #   brew link --overwrite python@3.12
+      if: matrix.os == 'macos-13'
+      run: |
+        brew install libpng libjpeg-turbo libdc1394 opencv pcl librealsense zbar pkg-config nlohmann-json
+        brew link --overwrite python@3.12
 
     - name: Install java dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,8 +52,10 @@ jobs:
       #   brew link --overwrite python@3.12
       if: matrix.os == 'macos-13'
       run: |
-        brew install libpng libjpeg-turbo libdc1394 opencv pcl librealsense zbar pkg-config nlohmann-json
-        brew link --overwrite python@3.12
+        brew update
+        brew upgrade
+        brew install libpng libjpeg-turbo libdc1394 pcl librealsense zbar pkg-config nlohmann-json
+        brew install opencv
 
     - name: Install java dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,6 +53,7 @@ jobs:
       if: matrix.os == 'macos-13'
       run: |
         brew update
+        sudo rm /usr/local/bin/2to3-3.12
         brew upgrade
         brew install libpng libjpeg-turbo libdc1394 pcl librealsense zbar pkg-config nlohmann-json
         brew install opencv


### PR DESCRIPTION
This issue is related to python installation using brew that is an opencv dependency

```
==> Installing opencv dependency: python@3.12
==> Downloading https://ghcr.io/v2/homebrew/core/python/3.12/manifests/3.12.1_1 Already downloaded: 
/Users/runner/Library/Caches/Homebrew/downloads/873ca0611888231c4efc2640b01a3d1db221765a1e4af903b95cfa
72f4b42e90--python@3.12-3.12.1_1.bottle_manifest.json ==> Pouring python@3.12--3.12.1_1.ventura.bottle.tar.gz 
Error: The `brew link` step did not complete successfully 
The formula built, but is not symlinked into /usr/local 
Could not symlink bin/2to3-3.12
Target /usr/local/bin/2to3-3.12
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3-3.12'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.12

Possible conflicting files are:
/usr/local/bin/2to3-3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3-3.12 
/usr/local/bin/idle3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3.12 
/usr/local/bin/pydoc3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3.12 
/usr/local/bin/python3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 
/usr/local/bin/python3.12-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12-config
```