### PR TITLE
Fix ROS2 build error

### DIFF
--- a/modules/core/test/image-with-dataset/testColorConversion.cpp
+++ b/modules/core/test/image-with-dataset/testColorConversion.cpp
@@ -931,6 +931,7 @@ static double computePSNR(const vpImage<vpRGBa> &I_RGBA_8U, const vpImage<vpRGBa
   return 10 * std::log10(255 * 255 / mse);
 }
 
+#if (VISP_HAVE_DATASET_VERSION >= 0x030500)
 static bool readBinaryFile(const std::string &filename, std::vector<uint16_t> &buffer)
 {
   std::FILE *f = std::fopen(filename.c_str(), "rb");
@@ -967,7 +968,6 @@ static bool readBinaryFile(const std::string &filename, std::vector<uint8_t> &bu
   return true;
 }
 
-#if (VISP_HAVE_DATASET_VERSION >= 0x030500)
 TEST_CASE("Bayer conversion", "[image_conversion]")
 {
   // Load original Klimt image

--- a/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-full.cpp
+++ b/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-full.cpp
@@ -10,6 +10,7 @@
 #include <visp3/io/vpVideoReader.h>
 #include <visp3/io/vpVideoWriter.h>
 
+#if defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_VIDEOIO) && defined(HAVE_OPENCV_HIGHGUI)
 namespace
 {
 std::vector<double> poseToVec(const vpHomogeneousMatrix &cMo)
@@ -21,6 +22,7 @@ std::vector<double> poseToVec(const vpHomogeneousMatrix &cMo)
   return vec;
 }
 }
+#endif
 
 int main(int argc, char **argv)
 {

--- a/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-read.cpp
+++ b/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-read.cpp
@@ -6,6 +6,7 @@
 #include <visp3/io/vpImageIo.h>
 #include <visp3/core/vpImageDraw.h>
 
+#if defined(VISP_HAVE_X11) || defined(VISP_HAVE_GDI) || defined(HAVE_OPENCV_HIGHGUI)
 namespace
 {
 // https://en.cppreference.com/w/cpp/io/c/fprintf
@@ -30,6 +31,7 @@ std::unique_ptr<T> make_unique_compat(Args&&... args)
 #endif
 }
 }
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -190,8 +192,10 @@ int main(int argc, char *argv[])
   vpDisplay::getClick(I_display, true);
 
 #else
-  std::cerr << "Error, a missing display library is needed (X11, GDI or OpenCV built with HighGUI module)."
+  (void)argc;
+  (void)argv;
+  std::cerr << "Error, a missing display library is needed (X11, GDI or OpenCV built with HighGUI module)." << std::endl;
 #endif
 
-    return EXIT_SUCCESS;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Fix build error on ROS2 and some others warnings, [cf](https://build.ros2.org/job/Rdev__visp__ubuntu_jammy_amd64/172/console):

```bash
:06:11 /tmp/ws/src/visp/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-read.cpp: In function ‘int main(int, char**)’:
17:06:11 /tmp/ws/src/visp/tutorial/tracking/model-based/generic/tutorial-mb-generic-tracker-read.cpp:193:108: error: expected ‘;’ before ‘return’
17:06:11   193 |   std::cerr << "Error, a missing display library is needed (X11, GDI or OpenCV built with HighGUI module)."
17:06:11       |                                                                                                            ^
17:06:11       |                                                                                                            ;
```

----

Would be interesting to add the ROS2 configuration for ViSP build into the [github workflows](https://github.com/lagadic/visp/blob/1d7a8096b755e8ae905457897012c7ac6a88d2a7/.github/workflows/ubuntu-dep-apt.yml#L18).

To reduce the number of workflows, I would vote to remove the C++14 runs with [ubuntu-dep-apt.yml](https://github.com/lagadic/visp/blob/master/.github/workflows/ubuntu-dep-apt.yml).
