### PR TITLE
Feat: MBT JSON improvements

### DIFF
--- a/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
+++ b/doc/tutorial/tracking/tutorial-tracking-mb-generic-json.dox
@@ -47,6 +47,7 @@ Let us first examine the global settings (located at the root of the JSON struct
 \endcode
 
 If they are defined globally, they will take precedence over the values defined per tracker.
+Some settings such as the "vvs" options, are only defined globally
 
 <table>
 <tr><th colspan="2">Key</th><th>Type</th><th>Description</th><th>Optional</th></tr>
@@ -96,6 +97,29 @@ If they are defined globally, they will take precedence over the values defined 
     <td colspan="2">visibilityTest:ogre</td>
     <td>boolean</td>
     <td>Whether to use ogre for visibility testing. OGRE must be installed, otherwise ignored. See vpMbGenericTracker::setOgreVisibilityTest()</td>
+    <td>Yes</td>
+</tr>
+<tr><th colspan="5">vvs (optional)</th></tr>
+<tr>
+    <td>lambda</td>
+    <td>float</td>
+    <td>Virtual visual servoing gain
+    </td>
+    <td>vpMbGenericTracker::setLambda()</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>maxIter</td>
+    <td>integer > 0</td>
+    <td>Number of iterations for virtual visual servoing</td>
+    <td>vpMbGenericTracker::setMaxIter()</td>
+    <td>Yes</td>
+</tr>
+<tr>
+    <td>initialMu</td>
+    <td>float</td>
+    <td>Initial Mu for levenberg marquardt optimization</td>
+    <td>vpMbGenericTracker::setInitialMu(</td>
     <td>Yes</td>
 </tr>
 </table>

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -175,7 +175,8 @@
  *               "range": 4,
  *               "sampleStep": 10.0,
  *               "strip": 2,
- *               "threshold": 1500.0
+*                "thresholdType": "normalized",
+ *               "threshold": 20.0
  *           },
  *           "lod": {
  *               "minLineLengthThresholdGeneral": 50.0,
@@ -1022,6 +1023,7 @@ inline void from_json(const nlohmann::json &j, vpMbGenericTracker::TrackerWrappe
   //Edge tracker settings
   if (t.m_trackerType & vpMbGenericTracker::EDGE_TRACKER) {
     from_json(j.at("edge"), t.me);
+    t.setMovingEdge(t.me);
   }
   //KLT tracker settings
 #if defined(VISP_HAVE_MODULE_KLT) && defined(VISP_HAVE_OPENCV) && defined(HAVE_OPENCV_IMGPROC) && defined(HAVE_OPENCV_VIDEO)

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -3019,6 +3019,15 @@ void vpMbGenericTracker::loadConfigFileJSON(const std::string &settingsFile, boo
     setOgreVisibilityTest(visJson.value("ogre", useOgre));
     setScanLineVisibilityTest(visJson.value("scanline", useScanLine));
   }
+
+  // VVS global settings
+  if (settings.contains("vvs")) {
+    const json vvsJson = settings["vvs"];
+    setLambda(vvsJson.value("lambda", this->m_lambda));
+    setMaxIter(vvsJson.value("maxIter", this->m_maxIter));
+    setInitialMu(vvsJson.value("initialMu", this->m_initialMu));
+  }
+
   //If a 3D model is defined, load it
   if (settings.contains("model")) {
     loadModel(settings.at("model").get<std::string>(), verbose);
@@ -3047,6 +3056,12 @@ void vpMbGenericTracker::saveConfigFile(const std::string &settingsFile) const
     }
   }
   j["trackers"] = trackers;
+  j["vvs"] = json {
+    {"lambda", m_lambda},
+    {"maxIter", m_maxIter},
+    {"initialMu", m_initialMu}
+  };
+
   std::ofstream f(settingsFile);
   if (f.good()) {
     const unsigned indentLevel = 4;

--- a/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
@@ -245,13 +245,29 @@ SCENARIO("MBT JSON Serialization", "[json]")
         );
       }
 
+      THEN("VVS properties should be the same")
+      {
+        vpMbGenericTracker t2 = baseTrackerConstructor();
+        t2.setMaxIter(4096);
+        t2.setLambda(5.0);
+        t2.setInitialMu(5.0);
+
+        t2.loadConfigFile(jsonPath);
+
+        checkProperties(t1, t2,
+          &vpMbGenericTracker::getMaxIter, "VVS m iterations be the same",
+          &vpMbGenericTracker::getLambda, "VVS lambda should be the same",
+          &vpMbGenericTracker::getInitialMu, "VVS initial mu be the same"
+        );
+      }
+
       WHEN("Modifying JSON file/Using a custom JSON file")
       {
         THEN("Removing version from file generates an error on load")
         {
           modifyJson([](json &j) -> void {
             j.erase("version");
-            });
+          });
           REQUIRE_THROWS(t1.loadConfigFile(jsonPath));
         }
 
@@ -259,7 +275,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
         {
           modifyJson([](json &j) -> void {
             j["version"] = "0.0.0";
-            });
+          });
           REQUIRE_THROWS(t1.loadConfigFile(jsonPath));
         }
 
@@ -267,7 +283,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
         {
           modifyJson([](json &j) -> void {
             j["referenceCameraName"] = "C3";
-            });
+          });
           REQUIRE_THROWS(t1.loadConfigFile(jsonPath));
         }
 
@@ -275,7 +291,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
         {
           modifyJson([&t1](json &j) -> void {
             j["trackers"][t1.getReferenceCameraName()].erase("camTref");
-            });
+          });
           REQUIRE_NOTHROW(t1.loadConfigFile(jsonPath));
         }
 
@@ -284,7 +300,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
           modifyJson([&t1](json &j) -> void {
             std::string otherCamName = t1.getReferenceCameraName() == "C1" ? "C2" : "C1";
             j["trackers"][otherCamName].erase("camTref");
-            });
+          });
           REQUIRE_THROWS(t1.loadConfigFile(jsonPath));
         }
 
@@ -301,7 +317,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
             for (const auto &c : t1.getCameraNames()) {
               j["trackers"][c].erase("clipping");
             }
-            });
+          });
           REQUIRE_NOTHROW(t2.loadConfigFile(jsonPath, false));
           REQUIRE(t2.getClipping() == clipping);
           REQUIRE(t2.getNearClippingDistance() == clipping_near);
@@ -323,7 +339,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
               for (const auto &c : t1.getCameraNames()) {
                 j["trackers"][c]["clipping"].erase("near");
               }
-              });
+            });
             t2.loadConfigFile(jsonPath);
             REQUIRE(t2.getNearClippingDistance() == clipping_near);
             REQUIRE(t2.getFarClippingDistance() == t1.getFarClippingDistance());
@@ -335,7 +351,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
               for (const auto &c : t1.getCameraNames()) {
                 j["trackers"][c]["clipping"].erase("far");
               }
-              });
+            });
             t2.loadConfigFile(jsonPath);
             REQUIRE(t2.getNearClippingDistance() == t1.getNearClippingDistance());
             REQUIRE(t2.getFarClippingDistance() == clipping_far);
@@ -347,7 +363,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
               for (const auto &c : t1.getCameraNames()) {
                 j["trackers"][c]["clipping"].erase("flags");
               }
-              });
+            });
             t2.loadConfigFile(jsonPath);
             REQUIRE(t2.getNearClippingDistance() == t1.getNearClippingDistance());
             REQUIRE(t2.getFarClippingDistance() == t1.getFarClippingDistance());
@@ -358,7 +374,7 @@ SCENARIO("MBT JSON Serialization", "[json]")
     }
   }
 }
-int main(int argc, char *argv [])
+int main(int argc, char *argv[])
 {
   Catch::Session session; // There must be exactly one instance
   session.applyCommandLine(argc, argv);

--- a/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/testMbtJsonSettings.cpp
@@ -75,6 +75,17 @@ vpMbGenericTracker baseTrackerConstructor()
 
   t.setAngleAppear(vpMath::rad(60));
   t.setAngleDisappear(vpMath::rad(90));
+  vpMe me;
+  me.setSampleStep(2.0);
+  me.setMaskSize(7);
+  me.setMaskNumber(160);
+  me.setRange(8);
+  me.setLikelihoodThresholdType(vpMe::NORMALIZED_THRESHOLD);
+  me.setThreshold(20);
+  me.setMu1(0.2);
+  me.setMu2(0.3);
+  me.setSampleStep(4);
+  t.setMovingEdge(me);
   return t;
 }
 
@@ -103,7 +114,6 @@ void compareNamesAndTypes(const vpMbGenericTracker &t1, const vpMbGenericTracker
 void compareCameraParameters(const vpMbGenericTracker &t1, const vpMbGenericTracker &t2)
 {
   std::map<std::string, vpCameraParameters> c1, c2;
-  vpCameraParameters c;
   t1.getCameraParameters(c1);
   t2.getCameraParameters(c2);
   REQUIRE(c1 == c2);
@@ -185,6 +195,8 @@ SCENARIO("MBT JSON Serialization", "[json]")
             &vpMe::getMaskNumber, "Mask number should be equal",
             &vpMe::getMaskSign, "Mask sign should be equal",
             &vpMe::getMinSampleStep, "Min sample step should be equal",
+            &vpMe::getSampleStep, "Min sample step should be equal",
+
             &vpMe::getMu1, "Mu 1 should be equal",
             &vpMe::getMu2, "Mu 2 should be equal",
             &vpMe::getNbTotalSample, "Nb total sample should be equal",

--- a/modules/tracker/me/include/visp3/me/vpMe.h
+++ b/modules/tracker/me/include/visp3/me/vpMe.h
@@ -117,7 +117,7 @@
  * \code{.unparsed}
  * $ cat me.json
  * {"maskSign":0,"maskSize":5,"minSampleStep":4.0,"mu":[0.5,0.5],"nMask":180,"ntotalSample":0,"pointsToTrack":200,
- *  "range":5,"sampleStep":10.0,"strip":2,"threshold":20.0,"thresholdMarginRatio":-1.0,"minThreshold":-1.0,"thresholdType":1}
+ *  "range":5,"sampleStep":10.0,"strip":2,"threshold":20.0,"thresholdMarginRatio":-1.0,"minThreshold":-1.0,"thresholdType":"normalized"}
  * \endcode
  */
 class VISP_EXPORT vpMe
@@ -531,7 +531,7 @@ public:
    * @brief Retrieve a vpMe object from a JSON representation
    *
    * JSON content (key: type):
-   *  - thresholdType: int, vpMe::getLikelihoodThresholdType()
+   *  - thresholdType: either "old" or "normalized", vpMe::getLikelihoodThresholdType()
    *  - threshold: double, vpMe::setThreshold()
    *  - thresholdMarginRatio: double, vpMe::setThresholdMarginRatio()
    *  - minThreshold: double, vpMe::setMinThreshold()
@@ -564,7 +564,7 @@ public:
    *   "range": 7,
    *   "sampleStep": 4.0,
    *   "strip": 2,
-   *   "thresholdType": 1,
+   *   "thresholdType": "normalized",
    *   "threshold": 20.0,
    *   "thresholdMarginRatio": 0.75,
    *   "minThreshold": 20.0,
@@ -579,6 +579,11 @@ public:
 };
 #ifdef VISP_HAVE_NLOHMANN_JSON
 #include <nlohmann/json.hpp>
+
+NLOHMANN_JSON_SERIALIZE_ENUM(vpMe::vpLikelihoodThresholdType, {
+  {vpMe::vpLikelihoodThresholdType::OLD_THRESHOLD, "old"},
+  {vpMe::vpLikelihoodThresholdType::NORMALIZED_THRESHOLD, "normalized"}
+});
 
 inline void to_json(nlohmann::json &j, const vpMe &me)
 {
@@ -616,7 +621,7 @@ inline void from_json(const nlohmann::json &j, vpMe &me)
     me.setMu2(mus[1]);
   }
   me.setMinSampleStep(j.value("minSampleStep", me.getMinSampleStep()));
-
+  me.setSampleStep(j.value("sampleStep", me.getSampleStep()));
   me.setRange(j.value("range", me.getRange()));
   me.setNbTotalSample(j.value("ntotalSample", me.getNbTotalSample()));
   me.setPointsToTrack(j.value("pointsToTrack", me.getPointsToTrack()));

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth-with-model-path.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth-with-model-path.json
@@ -60,6 +60,7 @@
                 "range": 7,
                 "sampleStep": 4.0,
                 "strip": 2,
+                "thresholdType": "old",
                 "threshold": 5000.0
             },
             "klt": {

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth-with-model-path.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth-with-model-path.json
@@ -164,5 +164,10 @@
             }
         }
     },
+    "vvs" :{
+      "lambda": 1.0,
+      "maxIter": 30,
+      "initialMu": 0.01
+    },
     "version": "1.0"
 }

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
@@ -163,5 +163,10 @@
             }
         }
     },
+    "vvs" :{
+      "lambda": 1.0,
+      "maxIter": 30,
+      "initialMu": 0.01
+    },
     "version": "1.0"
 }

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json
@@ -59,6 +59,7 @@
                 "range": 7,
                 "sampleStep": 4.0,
                 "strip": 2,
+                "thresholdType": "old",
                 "threshold": 5000.0
             },
             "klt": {

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json.example
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json.example
@@ -179,5 +179,12 @@
             }
         }
     },
+    //! [VVS]
+    "vvs" :{
+      "lambda": 1.0,
+      "maxIter": 30,
+      "initialMu": 0.01
+    },
+    //! [VVS]
     "version": "1.0"
 }

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json.example
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-and-depth.json.example
@@ -65,6 +65,7 @@
                 "range": 7,
                 "sampleStep": 4.0,
                 "strip": 2,
+                "thresholdType": "old",
                 "threshold": 5000.0
             },
             //! [Edge]

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
@@ -87,5 +87,10 @@
             }
         }
     },
+    "vvs" :{
+      "lambda": 1.0,
+      "maxIter": 30,
+      "initialMu": 0.01
+    },
     "version": "1.0"
 }

--- a/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
+++ b/tutorial/tracking/model-based/generic-rgbd/model/cube/realsense-color-only.json
@@ -59,6 +59,7 @@
                 "range": 7,
                 "sampleStep": 4.0,
                 "strip": 2,
+                "thresholdType": "old",
                 "threshold": 5000.0
             },
             "klt": {


### PR DESCRIPTION
This PR does the following:

- [x] Fix an issue with sampling step of vpMe having an incorrect serialization
- [x] Make vpMe threshold type representation a string instead of an int ("old"/"normalized" vs 0/1)
- [x] Introduce VVS parameters in JSON serialization: lambda, max iterations and initial mu
