### PR TITLE
Try to emulate the ROS2 Jenkins environment on Github runner

### DIFF
--- a/.github/workflows/ubuntu-isolated.yml
+++ b/.github/workflows/ubuntu-isolated.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
-        compiler: [ {CC: /usr/bin/clang, CXX: /usr/bin/clang++} ]
+        os: [ubuntu-latest]
+        compiler: [ {CC: /usr/bin/gcc, CXX: /usr/bin/g++} ]
         standard: [ 17 ]
 
     steps:
@@ -24,6 +24,24 @@ jobs:
       uses: styfle/cancel-workflow-action@0.9.1
       with:
         access_token: ${{ github.token }}
+
+      # Remove some packages to emulate the ROS2 Jenkins environment
+      # X11: https://raspberrypi.stackexchange.com/a/92334
+      # Java: https://askubuntu.com/a/185531
+      name: Remove packages
+      run: |
+        sudo apt-get install libomp-dev
+        sudo apt purge --auto-remove 'x11-*'
+        java -version
+        sudo dpkg --list | grep -i jdk
+        sudo dpkg --list | grep -i java
+        sudo apt-get purge --auto-remove openjdk*
+        sudo apt-get purge --auto-remove icedtea-* openjdk-*
+        sudo dpkg --list | grep -i jdk
+        sudo dpkg --list | grep -i java
+        sudo apt purge --auto-remove 'libjpeg*'
+        sudo apt purge --auto-remove 'libpng*'
+        sudo apt purge --auto-remove 'libxml*'
 
     - name: Checkout repository
       uses: actions/checkout@v3
@@ -47,7 +65,8 @@ jobs:
         echo "CC: $CC"
         echo "CXX: $CXX"
         echo "Standard: $CXX_STANDARD"
-        cmake .. -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/tmp/usr/local -DCMAKE_VERBOSE_MAKEFILE=ON -DUSE_CXX_STANDARD=$CXX_STANDARD
+        cmake .. -DCMAKE_C_COMPILER="${CC}" -DCMAKE_CXX_COMPILER="${CXX}" -DCMAKE_BUILD_TYPE=Release \
+                 -DCMAKE_INSTALL_PREFIX=/tmp/usr/local -DCMAKE_VERBOSE_MAKEFILE=ON -DUSE_CXX_STANDARD=$CXX_STANDARD
         cat ViSP-third-party.txt
 
     - name: Compile


### PR DESCRIPTION
- [build.ros2.org](https://build.ros2.org/job/Rdev__visp__ubuntu_jammy_amd64/172/consoleFull)

<details>
  <summary>log</summary>

  ```bash
17:06:11 -- ==========================================================
17:06:11 -- General configuration information for ViSP 3.6.1
17:06:11 -- 
17:06:11 --   Version control:               1d7a8096
17:06:11 -- 
17:06:11 --   Platform:
17:06:11 --     Timestamp:                   2024-01-29T15:43:48Z
17:06:11 --     Host:                        Linux 5.15.0-1047-aws x86_64
17:06:11 --     CMake:                       3.22.1
17:06:11 --     CMake generator:             Unix Makefiles
17:06:11 --     CMake build tool:            /usr/bin/gmake
17:06:11 --     Configuration:               Release
17:06:11 -- 
17:06:11 --   System information:
17:06:11 --     Number of CPU logical cores: 4
17:06:11 --     Number of CPU physical cores: 2
17:06:11 --     Total physical memory (in MiB): 7835
17:06:11 --     OS name:                     Linux
17:06:11 --     OS release:                  5.15.0-1047-aws
17:06:11 --     OS version:                  #52~20.04.1-Ubuntu SMP Thu Sep 21 10:05:54 UTC 2023
17:06:11 --     OS platform:                 x86_64
17:06:11 --     CPU name:                    Unknown AMD family
17:06:11 --     Is the CPU 64-bit?           yes
17:06:11 --     Does the CPU have FPU?       yes
17:06:11 --     CPU optimization:            SSE2 SSE3 SSSE3
17:06:11 -- 
17:06:11 --   C/C++:
17:06:11 --     Built as dynamic libs?:      yes
17:06:11 --     C++ Compiler:                /usr/lib/ccache/c++  (ver 11.4.0)
17:06:11 --     C++ flags (Release):         -Wall -Wextra -fopenmp -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -O3 -DNDEBUG
17:06:11 --     C++ flags (Debug):           -Wall -Wextra -fopenmp -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g
17:06:11 --     C Compiler:                  /usr/lib/ccache/cc
17:06:11 --     C flags (Release):           -Wall -Wextra -fopenmp -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -O3 -DNDEBUG
17:06:11 --     C flags (Debug):             -Wall -Wextra -fopenmp -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g
17:06:11 --     Linker flags (Release):
17:06:11 --     Linker flags (Debug):
17:06:11 --     Use cxx standard:            17
17:06:11 -- 
17:06:11 --   ViSP modules:
17:06:11 --     To be built:                 core gui imgproc io java_bindings_generator klt me sensor ar blob robot visual_features vs vision detection mbt tt tt_mi
17:06:11 --     Disabled:                    -
17:06:11 --     Disabled by dependency:      -
17:06:11 --     Unavailable:                 java
17:06:11 -- 
17:06:11 --   Python 3:
17:06:11 --     Interpreter:                 /usr/bin/python3.10 (ver 3.10.12)
17:06:11 -- 
17:06:11 --   Java:                          
17:06:11 --     ant:                         no
17:06:11 --     JNI:                         no
17:06:11 -- 
17:06:11 --   Python3 bindings:              no
17:06:11 -- 
17:06:11 --   Build options: 
17:06:11 --     Build deprecated:            yes
17:06:11 --     Build with moment combine:   no
17:06:11 -- 
17:06:11 --   OpenCV: 
17:06:11 --     Version:                     n/a
17:06:11 -- 
17:06:11 --   Mathematics: 
17:06:11 --     Blas/Lapack:                 yes
17:06:11 --     \- Use MKL:                  no
17:06:11 --     \- Use OpenBLAS:             no
17:06:11 --     \- Use Atlas:                no
17:06:11 --     \- Use Netlib:               no
17:06:11 --     \- Use GSL:                  no
17:06:11 --     \- Use Lapack (built-in):    yes (ver 3.2.1)
17:06:11 --     Use Eigen3:                  no
17:06:11 --     Use OpenCV:                  no
17:06:11 -- 
17:06:11 --   Simulator: 
17:06:11 --     Ogre simulator: 
17:06:11 --     \- Use Ogre3D:               no
17:06:11 --     \- Use OIS:                  no
17:06:11 --     Coin simulator: 
17:06:11 --     \- Use Coin3D:               no
17:06:11 --     \- Use SoWin:                no
17:06:11 --     \- Use SoXt:                 no
17:06:11 --     \- Use SoQt:                 no
17:06:11 --     \- Use Qt5:                  no
17:06:11 --     \- Use Qt4:                  no
17:06:11 --     \- Use Qt3:                  no
17:06:11 -- 
17:06:11 --   Media I/O: 
17:06:11 --     Use JPEG:                    no
17:06:11 --     Use PNG:                     no
17:06:11 --     \- Use ZLIB:                 yes (ver 1.2.11)
17:06:11 --     Use OpenCV:                  no
17:06:11 --     Use stb_image (built-in):    yes (ver 2.27.0)
17:06:11 --     Use TinyEXR (built-in):      yes (ver 1.0.2)
17:06:11 --     Use simdlib (built-in):      yes
17:06:11 -- 
17:06:11 --   Real robots: 
17:06:11 --     Use Afma4:                   no
17:06:11 --     Use Afma6:                   no
17:06:11 --     Use Franka:                  no
17:06:11 --     Use Viper650:                no
17:06:11 --     Use Viper850:                no
17:06:11 --     Use ur_rtde:                 no
17:06:11 --     Use Kinova Jaco:             no
17:06:11 --     Use aria (Pioneer):          no
17:06:11 --     Use PTU46:                   no
17:06:11 --     Use Biclops PTU:             no
17:06:11 --     Use Flir PTU SDK:            no
17:06:11 --     Use MAVSDK:                  no
17:06:11 --     Use Parrot ARSDK:            no
17:06:11 --     \-Use ffmpeg:                no
17:06:11 --     Use Virtuose:                no
17:06:11 --     Use qbdevice (built-in):     yes (ver 2.6.0)
17:06:11 --     Use takktile2 (built-in):    yes (ver 1.0.0)
17:06:11 --     Use pololu (built-in):       yes (ver 1.0.0)
17:06:11 -- 
17:06:11 --   GUI: 
17:06:11 --     Use X11:                     no
17:06:11 --     Use GTK:                     no
17:06:11 --     Use OpenCV:                  no
17:06:11 --     Use GDI:                     no
17:06:11 --     Use Direct3D:                no
17:06:11 -- 
17:06:11 --   Cameras: 
17:06:11 --     Use DC1394-2.x:              no
17:06:11 --     Use CMU 1394:                no
17:06:11 --     Use V4L2:                    no
17:06:11 --     Use directshow:              no
17:06:11 --     Use OpenCV:                  no
17:06:11 --     Use FLIR Flycapture:         no
17:06:11 --     Use Basler Pylon:            no
17:06:11 --     Use IDS uEye:                no
17:06:11 -- 
17:06:11 --   RGB-D sensors: 
17:06:11 --     Use Realsense:               no
17:06:11 --     Use Realsense2:              no
17:06:11 --     Use Occipital Structure:     no
17:06:11 --     Use Kinect:                  no
17:06:11 --     \- Use libfreenect:          no
17:06:11 --     \- Use libusb-1:             no
17:06:11 --     \- Use std::thread:          yes
17:06:11 --     Use PCL:                     no
17:06:11 --     \- Use VTK:                  no
17:06:11 -- 
17:06:11 --   F/T sensors: 
17:06:11 --     Use atidaq (built-in):       no
17:06:11 --     Use comedi:                  no
17:06:11 --     Use IIT SDK:                 no
17:06:11 -- 
17:06:11 --   Mocap: 
17:06:11 --     Use Qualisys:                no
17:06:11 --     Use Vicon:                   no
17:06:11 -- 
17:06:11 --   Detection: 
17:06:11 --     Use zbar:                    no
17:06:11 --     Use dmtx:                    no
17:06:11 --     Use AprilTag (built-in):     yes (ver 3.1.1)
17:06:11 --     \- Use AprilTag big family:  no
17:06:11 -- 
17:06:11 --   Misc: 
17:06:11 --     Use Clipper (built-in):      no
17:06:11 --     Use pugixml (built-in):      yes (ver 1.9.0)
17:06:11 --     Use libxml2:                 no
17:06:11 --     Use json (nlohmann):         no
17:06:11 -- 
17:06:11 --   Optimization: 
17:06:11 --     Use OpenMP:                  yes
17:06:11 --     Use std::thread:             yes
17:06:11 --     Use pthread (built-in):      no
17:06:11 --     Use simdlib (built-in):      yes
17:06:11 -- 
17:06:11 --   DNN: 
17:06:11 --     Use CUDA Toolkit:            no
17:06:11 --     Use TensorRT:                no
17:06:11 -- 
17:06:11 --   Documentation: 
17:06:11 --     Use doxygen:                 no
17:06:11 --     \- Use mathjax:              no
17:06:11 -- 
17:06:11 --   Tests and samples:
17:06:11 --     Use catch2 (built-in):       yes (ver 2.13.7)
17:06:11 --     Tests:                       yes
17:06:11 --     Apps:                        yes
17:06:11 --     Demos:                       yes
17:06:11 --     Examples:                    yes
17:06:11 --     Tutorials:                   yes
17:06:11 --     Dataset found:               no
17:06:11 -- 
17:06:11 --   Library dirs:
17:06:11 -- 
17:06:11 --   Install path:                  /tmp/ws/install_isolated/VISP
17:06:11 -- 
17:06:11 -- ==========================================================
17:06:11 -- Configuring done
17:06:11 -- Generating done
17:06:11 -- Build files have been written to: /tmp/ws/build_isolated/VISP
  ```
</details>

- [github](https://github.com/lagadic/visp/actions/runs/7701612658/job/20988054534)

<details>
  <summary>log</summary>

  ```bash
2024-01-30T07:00:41.0806877Z -- ==========================================================
2024-01-30T07:00:41.0808281Z -- General configuration information for ViSP 3.6.1
2024-01-30T07:00:41.0811152Z -- 
2024-01-30T07:00:41.0811886Z --   Version control:               91205a5
2024-01-30T07:00:41.0812626Z -- 
2024-01-30T07:00:41.0813231Z --   Platform:
2024-01-30T07:00:41.0813873Z --     Timestamp:                   2024-01-30T07:00:41Z
2024-01-30T07:00:41.0815054Z --     Host:                        Linux 6.2.0-1018-azure x86_64
2024-01-30T07:00:41.0816041Z --     CMake:                       3.28.1
2024-01-30T07:00:41.0816794Z --     CMake generator:             Unix Makefiles
2024-01-30T07:00:41.0817654Z --     CMake build tool:            /usr/bin/gmake
2024-01-30T07:00:41.0818552Z --     Configuration:               Release
2024-01-30T07:00:41.0819183Z -- 
2024-01-30T07:00:41.0819706Z --   System information:
2024-01-30T07:00:41.0820451Z --     Number of CPU logical cores: 4
2024-01-30T07:00:41.0821146Z --     Number of CPU physical cores: 2
2024-01-30T07:00:41.0821957Z --     Total physical memory (in MiB): 15981
2024-01-30T07:00:41.0822826Z --     OS name:                     Linux
2024-01-30T07:00:41.0823637Z --     OS release:                  6.2.0-1018-azure
2024-01-30T07:00:41.0824611Z --     OS version:                  #18~22.04.1-Ubuntu SMP Tue Nov 21 19:25:02 UTC 2023
2024-01-30T07:00:41.0825668Z --     OS platform:                 x86_64
2024-01-30T07:00:41.0826836Z --     CPU name:                    Unknown AMD family
2024-01-30T07:00:41.0827603Z --     Is the CPU 64-bit?           yes
2024-01-30T07:00:41.0828622Z --     Does the CPU have FPU?       yes
2024-01-30T07:00:41.0829507Z --     CPU optimization:            SSE2 SSE3 SSSE3
2024-01-30T07:00:41.0830180Z -- 
2024-01-30T07:00:41.0830747Z --   C/C++:
2024-01-30T07:00:41.0831967Z --     Built as dynamic libs?:      yes
2024-01-30T07:00:41.0833059Z --     C++ Compiler:                /usr/bin/clang++  (ver 14.0.0)
2024-01-30T07:00:41.0834585Z --     C++ flags (Release):         -Wall -Wextra -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -O3 -DNDEBUG
2024-01-30T07:00:41.0836297Z --     C++ flags (Debug):           -Wall -Wextra -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g
2024-01-30T07:00:41.0837463Z --     C Compiler:                  /usr/bin/clang
2024-01-30T07:00:41.0838875Z --     C flags (Release):           -Wall -Wextra -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -O3 -DNDEBUG
2024-01-30T07:00:41.0840522Z --     C flags (Debug):             -Wall -Wextra -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g
2024-01-30T07:00:41.0841639Z --     Linker flags (Release):
2024-01-30T07:00:41.0842339Z --     Linker flags (Debug):
2024-01-30T07:00:41.0843258Z --     Use cxx standard:            17
2024-01-30T07:00:41.0843913Z -- 
2024-01-30T07:00:41.0844452Z --   ViSP modules:
2024-01-30T07:00:41.0845918Z --     To be built:                 core gui imgproc io java_bindings_generator klt me sensor ar blob robot visual_features vs vision detection mbt tt tt_mi java
2024-01-30T07:00:41.0847367Z --     Disabled:                    -
2024-01-30T07:00:41.0848133Z --     Disabled by dependency:      -
2024-01-30T07:00:41.0848872Z --     Unavailable:                 -
2024-01-30T07:00:41.0849485Z -- 
2024-01-30T07:00:41.0850022Z --   Python 3:
2024-01-30T07:00:41.0850778Z --     Interpreter:                 /usr/bin/python (ver 3.10.12)
2024-01-30T07:00:41.0851620Z -- 
2024-01-30T07:00:41.0852255Z --   Java:                          
2024-01-30T07:00:41.0853008Z --     ant:                         /usr/bin/ant (ver 1.10.12)
2024-01-30T07:00:41.0855366Z --     JNI:                         /usr/lib/jvm/temurin-11-jdk-amd64/include /usr/lib/jvm/temurin-11-jdk-amd64/include/linux /usr/lib/jvm/temurin-11-jdk-amd64/include
2024-01-30T07:00:41.0856973Z -- 
2024-01-30T07:00:41.0857472Z --   Python3 bindings:              no
2024-01-30T07:00:41.0858111Z -- 
2024-01-30T07:00:41.0858729Z --   Build options: 
2024-01-30T07:00:41.0859306Z --     Build deprecated:            yes
2024-01-30T07:00:41.0860054Z --     Build with moment combine:   no
2024-01-30T07:00:41.0860825Z -- 
2024-01-30T07:00:41.0861250Z --   OpenCV: 
2024-01-30T07:00:41.0861903Z --     Version:                     n/a
2024-01-30T07:00:41.0862686Z -- 
2024-01-30T07:00:41.0863176Z --   Mathematics: 
2024-01-30T07:00:41.0864419Z --     Blas/Lapack:                 yes
2024-01-30T07:00:41.0865638Z --     \- Use MKL:                  no
2024-01-30T07:00:41.0866897Z --     \- Use OpenBLAS:             no
2024-01-30T07:00:41.0867953Z --     \- Use Atlas:                no
2024-01-30T07:00:41.0869115Z --     \- Use Netlib:               no
2024-01-30T07:00:41.0870341Z --     \- Use GSL:                  yes (ver 2.7.1)
2024-01-30T07:00:41.0871521Z --     \- Use Lapack (built-in):    no
2024-01-30T07:00:41.0872507Z --     Use Eigen3:                  no
2024-01-30T07:00:41.0873577Z --     Use OpenCV:                  no
2024-01-30T07:00:41.0874568Z -- 
2024-01-30T07:00:41.0875150Z --   Simulator: 
2024-01-30T07:00:41.0875706Z --     Ogre simulator: 
2024-01-30T07:00:41.0876566Z --     \- Use Ogre3D:               no
2024-01-30T07:00:41.0877521Z --     \- Use OIS:                  no
2024-01-30T07:00:41.0878989Z --     Coin simulator: 
2024-01-30T07:00:41.0879971Z --     \- Use Coin3D:               no
2024-01-30T07:00:41.0880916Z --     \- Use SoWin:                no
2024-01-30T07:00:41.0882012Z --     \- Use SoXt:                 no
2024-01-30T07:00:41.0883326Z --     \- Use SoQt:                 no
2024-01-30T07:00:41.0884542Z --     \- Use Qt5:                  no
2024-01-30T07:00:41.0886147Z --     \- Use Qt4:                  no
2024-01-30T07:00:41.0887486Z --     \- Use Qt3:                  no
2024-01-30T07:00:41.0888929Z -- 
2024-01-30T07:00:41.0889560Z --   Media I/O: 
2024-01-30T07:00:41.0890380Z --     Use JPEG:                    yes (ver 80)
2024-01-30T07:00:41.0891369Z --     Use PNG:                     yes (ver 1.6.37)
2024-01-30T07:00:41.0892464Z --     \- Use ZLIB:                 yes (ver 1.2.11)
2024-01-30T07:00:41.0893524Z --     Use OpenCV:                  no
2024-01-30T07:00:41.0894914Z --     Use stb_image (built-in):    yes (ver 2.27.0)
2024-01-30T07:00:41.0896256Z --     Use TinyEXR (built-in):      yes (ver 1.0.2)
2024-01-30T07:00:41.0897360Z --     Use simdlib (built-in):      yes
2024-01-30T07:00:41.0898200Z -- 
2024-01-30T07:00:41.0898683Z --   Real robots: 
2024-01-30T07:00:41.0899612Z --     Use Afma4:                   no
2024-01-30T07:00:41.0900629Z --     Use Afma6:                   no
2024-01-30T07:00:41.0901748Z --     Use Franka:                  no
2024-01-30T07:00:41.0902958Z --     Use Viper650:                no
2024-01-30T07:00:41.0903997Z --     Use Viper850:                no
2024-01-30T07:00:41.0905448Z --     Use ur_rtde:                 no
2024-01-30T07:00:41.0906440Z --     Use Kinova Jaco:             no
2024-01-30T07:00:41.0907338Z --     Use aria (Pioneer):          no
2024-01-30T07:00:41.0908579Z --     Use PTU46:                   no
2024-01-30T07:00:41.0909662Z --     Use Biclops PTU:             no
2024-01-30T07:00:41.0910718Z --     Use Flir PTU SDK:            no
2024-01-30T07:00:41.0911862Z --     Use MAVSDK:                  no
2024-01-30T07:00:41.0912928Z --     Use Parrot ARSDK:            no
2024-01-30T07:00:41.0913997Z --     \-Use ffmpeg:                no
2024-01-30T07:00:41.0915316Z --     Use Virtuose:                no
2024-01-30T07:00:41.0916436Z --     Use qbdevice (built-in):     yes (ver 2.6.0)
2024-01-30T07:00:41.0917503Z --     Use takktile2 (built-in):    yes (ver 1.0.0)
2024-01-30T07:00:41.0918631Z --     Use pololu (built-in):       yes (ver 1.0.0)
2024-01-30T07:00:41.0919712Z -- 
2024-01-30T07:00:41.0920122Z --   GUI: 
2024-01-30T07:00:41.0920775Z --     Use X11:                     yes
2024-01-30T07:00:41.0921940Z --     Use GTK:                     no
2024-01-30T07:00:41.0923013Z --     Use OpenCV:                  no
2024-01-30T07:00:41.0924098Z --     Use GDI:                     no
2024-01-30T07:00:41.0925215Z --     Use Direct3D:                no
2024-01-30T07:00:41.0926000Z -- 
2024-01-30T07:00:41.0926526Z --   Cameras: 
2024-01-30T07:00:41.0927462Z --     Use DC1394-2.x:              no
2024-01-30T07:00:41.0928642Z --     Use CMU 1394:                no
2024-01-30T07:00:41.0929656Z --     Use V4L2:                    no
2024-01-30T07:00:41.0930795Z --     Use directshow:              no
2024-01-30T07:00:41.0931928Z --     Use OpenCV:                  no
2024-01-30T07:00:41.0933149Z --     Use FLIR Flycapture:         no
2024-01-30T07:00:41.0934126Z --     Use Basler Pylon:            no
2024-01-30T07:00:41.0935580Z --     Use IDS uEye:                no
2024-01-30T07:00:41.0937208Z -- 
2024-01-30T07:00:41.0937639Z --   RGB-D sensors: 
2024-01-30T07:00:41.0938210Z --     Use Realsense:               no
2024-01-30T07:00:41.0938963Z --     Use Realsense2:              no
2024-01-30T07:00:41.0940117Z --     Use Occipital Structure:     no
2024-01-30T07:00:41.0941484Z --     Use Kinect:                  no
2024-01-30T07:00:41.0942614Z --     \- Use libfreenect:          no
2024-01-30T07:00:41.0943709Z --     \- Use libusb-1:             no
2024-01-30T07:00:41.0961272Z --     \- Use std::thread:          yes
2024-01-30T07:00:41.0962120Z --     Use PCL:                     no
2024-01-30T07:00:41.0962808Z --     \- Use VTK:                  no
2024-01-30T07:00:41.0963372Z -- 
2024-01-30T07:00:41.0964270Z --   F/T sensors: 
2024-01-30T07:00:41.0964742Z --     Use atidaq (built-in):       no
2024-01-30T07:00:41.0965477Z --     Use comedi:                  no
2024-01-30T07:00:41.0966201Z --     Use IIT SDK:                 no
2024-01-30T07:00:41.0966783Z -- 
2024-01-30T07:00:41.0967220Z --   Mocap: 
2024-01-30T07:00:41.0967717Z --     Use Qualisys:                no
2024-01-30T07:00:41.0968427Z --     Use Vicon:                   no
2024-01-30T07:00:41.0968976Z -- 
2024-01-30T07:00:41.0969503Z --   Detection: 
2024-01-30T07:00:41.0969997Z --     Use zbar:                    no
2024-01-30T07:00:41.0970678Z --     Use dmtx:                    no
2024-01-30T07:00:41.0971477Z --     Use AprilTag (built-in):     yes (ver 3.1.1)
2024-01-30T07:00:41.0972304Z --     \- Use AprilTag big family:  no
2024-01-30T07:00:41.0972920Z -- 
2024-01-30T07:00:41.0973315Z --   Misc: 
2024-01-30T07:00:41.0973873Z --     Use Clipper (built-in):      no
2024-01-30T07:00:41.0974582Z --     Use pugixml (built-in):      yes (ver 1.9.0)
2024-01-30T07:00:41.0975957Z --     Use libxml2:                 yes (ver 2.9.13)
2024-01-30T07:00:41.0976685Z --     Use json (nlohmann):         no
2024-01-30T07:00:41.0977197Z -- 
2024-01-30T07:00:41.0977788Z --   Optimization: 
2024-01-30T07:00:41.0978271Z --     Use OpenMP:                  no
2024-01-30T07:00:41.0979053Z --     Use std::thread:             yes
2024-01-30T07:00:41.0980126Z --     Use pthread (built-in):      no
2024-01-30T07:00:41.0980713Z --     Use simdlib (built-in):      yes
2024-01-30T07:00:41.0981464Z -- 
2024-01-30T07:00:41.0981905Z --   DNN: 
2024-01-30T07:00:41.0982391Z --     Use CUDA Toolkit:            no
2024-01-30T07:00:41.0983156Z --     Use TensorRT:                no
2024-01-30T07:00:41.0983717Z -- 
2024-01-30T07:00:41.0984137Z --   Documentation: 
2024-01-30T07:00:41.0984830Z --     Use doxygen:                 no
2024-01-30T07:00:41.0985471Z --     \- Use mathjax:              no
2024-01-30T07:00:41.0985991Z -- 
2024-01-30T07:00:41.0986667Z --   Tests and samples:
2024-01-30T07:00:41.0987243Z --     Use catch2 (built-in):       yes (ver 2.13.7)
2024-01-30T07:00:41.0987945Z --     Tests:                       yes
2024-01-30T07:00:41.0988746Z --     Apps:                        yes
2024-01-30T07:00:41.0989423Z --     Demos:                       yes
2024-01-30T07:00:41.0990113Z --     Examples:                    yes
2024-01-30T07:00:41.0990899Z --     Tutorials:                   yes
2024-01-30T07:00:41.0991576Z --     Dataset found:               no
2024-01-30T07:00:41.0992015Z -- 
2024-01-30T07:00:41.0992387Z --   Library dirs:
2024-01-30T07:00:41.0992710Z -- 
2024-01-30T07:00:41.0993062Z --   Install path:                  /tmp/usr/local
2024-01-30T07:00:41.0993587Z -- 
2024-01-30T07:00:41.0993953Z -- ==========================================================
2024-01-30T07:00:41.1129386Z -- Configuring done (26.0s)
2024-01-30T07:00:42.8168415Z -- Generating done (1.5s)
2024-01-30T07:00:42.8896751Z -- Build files have been written to: /home/runner/work/visp/visp/build
  ```
</details>