### PR TITLE
Fix parsing of the git tag with new ViSP tag naming

### DIFF
--- a/cmake/VISPUtils.cmake
+++ b/cmake/VISPUtils.cmake
@@ -2001,7 +2001,7 @@ macro(vp_git_describe var_name path)
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     if(NOT GIT_RESULT EQUAL 0)
-      execute_process(COMMAND "${GIT_EXECUTABLE}" describe --tags --always --dirty --match "[0-9].[0-9].[0-9]*"
+      execute_process(COMMAND "${GIT_EXECUTABLE}" describe --tags --always --dirty --match "v[0-9].[0-9].[0-9]*"
         WORKING_DIRECTORY "${path}"
         OUTPUT_VARIABLE ${var_name}
         RESULT_VARIABLE GIT_RESULT


### PR DESCRIPTION
Before:
```txt
more ViSP-third-party.txt 

==========================================================
General configuration information for ViSP 3.6.1

  Version control:               3.2.0-3608-gcef7d8d0e
```

Now:
```
more ViSP-third-party.txt 

==========================================================
General configuration information for ViSP 3.6.1

  Version control:               v3.6.0-789-g0a12cf235
```

---

```bash
git describe --tags --always --dirty
v3.6.0-788-gcef7d8d0e

git describe --tags --always --dirty --match "[0-9].[0-9].[0-9]*"
3.2.0-3608-gcef7d8d0e

git describe --tags --always --dirty --match "v[0-9].[0-9].[0-9]*"
v3.6.0-788-gcef7d8d0e
```