### PR TITLE
Fix numpy test failing due to new vpArray2d constructor

### DIFF
--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -223,10 +223,22 @@ public:
       resize(r, c, false, false);
     }
     else if (c == 0) {
+      if (r != vec.size()) {
+        throw(vpException(vpException::dimensionError,
+                          "Cannot initialize vpArray(%d, %d) from std::vector(%d). Wrong dimension", r, c, vec.size()));
+      }
       resize(static_cast<unsigned int>(vec.size()), 1, false, false);
     }
     else if (r == 0) {
+      if (c != vec.size()) {
+        throw(vpException(vpException::dimensionError,
+                          "Cannot initialize vpArray(%d, %d) from std::vector(%d). Wrong dimension", r, c, vec.size()));
+      }
       resize(1, static_cast<unsigned int>(vec.size()), false, false);
+    }
+    else {
+      throw(vpException(vpException::dimensionError,
+                        "Cannot initialize vpArray(%d, %d) from std::vector(%d). Wrong dimension", r, c, vec.size()));
     }
 #if ((__cplusplus >= 201103L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))) // Check if cxx11 or higher
     std::copy(vec.begin(), vec.end(), data);

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -222,6 +222,10 @@ public:
       }
       resize(r, c, false, false);
     }
+    else if ((c == 0) && (r == 0)) {
+      throw(vpException(vpException::dimensionError,
+                        "Cannot initialize vpArray(%d, %d) from std::vector(%d). Using rows = 0 and cols = 0 is ambiguous", r, c, vec.size()));
+    }
     else if (c == 0) {
       if (r != vec.size()) {
         throw(vpException(vpException::dimensionError,
@@ -236,10 +240,7 @@ public:
       }
       resize(1, static_cast<unsigned int>(vec.size()), false, false);
     }
-    else {
-      throw(vpException(vpException::dimensionError,
-                        "Cannot initialize vpArray(%d, %d) from std::vector(%d). Wrong dimension", r, c, vec.size()));
-    }
+
 #if ((__cplusplus >= 201103L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))) // Check if cxx11 or higher
     std::copy(vec.begin(), vec.end(), data);
 #else

--- a/modules/core/test/math/testArray2D.cpp
+++ b/modules/core/test/math/testArray2D.cpp
@@ -140,11 +140,8 @@ TEST_CASE("Test constructors with double", "[constructors]")
     }
     SECTION("Keep default size (r=0, c=0)")
     {
-      vpArray2D<double> A(bench);
-      std::cout << "A with default size (r=0, c=0):\n" << A << std::endl;
-      CHECK(test("A", A, bench));
-      CHECK(A.getRows() == bench.size());
-      CHECK(A.getCols() == 1);
+      std::cout << "A with default size (r=0, c=0):\n" << std::endl;
+      REQUIRE_THROWS(vpArray2D<double>(bench));
     }
     SECTION("Keep row size to 0")
     {
@@ -221,11 +218,8 @@ TEST_CASE("Test constructors with float", "[constructors]")
     }
     SECTION("Keep default size (r=0, c=0)")
     {
-      vpArray2D<float> A(bench);
-      std::cout << "A with default size (r=0, c=0):\n" << A << std::endl;
-      CHECK(test("A", A, bench));
-      CHECK(A.getRows() == bench.size());
-      CHECK(A.getCols() == 1);
+      std::cout << "A with default size (r=0, c=0):\n" << std::endl;
+      REQUIRE_THROWS(vpArray2D<float>(bench));
     }
     SECTION("Keep row size to 0")
     {

--- a/modules/python/test/test_numpy_array.py
+++ b/modules/python/test/test_numpy_array.py
@@ -86,7 +86,6 @@ def test_numpy_constructor_interpreted_as_1d_vector():
   ac = ArrayDouble2D(n_1d, c=len(n_1d))
 
 
-
 def test_numpy_conversion_and_back():
   a = ArrayDouble2D(10, 10, 2.0)
   a_np = a.numpy().copy()

--- a/modules/python/test/test_numpy_array.py
+++ b/modules/python/test/test_numpy_array.py
@@ -76,8 +76,16 @@ def test_numpy_constructor():
     a = ArrayDouble2D(n_invalid)
   n_valid = np.array([[1, 2, 3], [4, 5, 6]])
   a = ArrayDouble2D(n_valid)
-
   assert np.all(np.equal(a.numpy(), n_valid))
+
+def test_numpy_constructor_interpreted_as_1d_vector():
+  n_1d = np.array([1, 2, 3])
+  with pytest.raises(RuntimeError):
+    a = ArrayDouble2D(n_1d) # R = 0, c = 0
+  ar = ArrayDouble2D(n_1d, r=len(n_1d))
+  ac = ArrayDouble2D(n_1d, c=len(n_1d))
+
+
 
 def test_numpy_conversion_and_back():
   a = ArrayDouble2D(10, 10, 2.0)


### PR DESCRIPTION
Fix for a python API test that was failing due to newly introduced constructor.