### PR TITLE
Fix compilation error related to GUI

### DIFF
--- a/modules/core/include/visp3/core/vpImageConvert.h
+++ b/modules/core/include/visp3/core/vpImageConvert.h
@@ -65,6 +65,7 @@
 #endif
 
 #if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_PCL_COMMON) && defined(VISP_HAVE_THREADS)
+#include <mutex>
 #include <visp3/core/vpColVector.h>
 #include <visp3/core/vpImageException.h>
 #include <visp3/core/vpPixelMeterConversion.h>

--- a/modules/gui/include/visp3/gui/vpDisplayFactory.h
+++ b/modules/gui/include/visp3/gui/vpDisplayFactory.h
@@ -30,8 +30,10 @@
  *
  * Description:
  * Display Factory
- *
-*****************************************************************************/
+ */
+
+#ifndef vpDisplayFactory_h
+#define vpDisplayFactory_h
 
 #include <visp3/core/vpConfig.h>
 #include <visp3/gui/vpDisplayD3D.h>
@@ -40,15 +42,18 @@
 #include <visp3/gui/vpDisplayOpenCV.h>
 #include <visp3/gui/vpDisplayX.h>
 
+/**
+ * \ingroup group_gui_display
+ */
 namespace vpDisplayFactory
 {
 /**
-* \brief Return a newly allocated vpDisplay specialisation
-* if a GUI library is available or nullptr otherwise.
-*
-* \return vpDisplay* A newly allocated vpDisplay specialisation
-* if a GUI library is available or nullptr otherwise.
-*/
+ * \brief Return a newly allocated vpDisplay specialization
+ * if a GUI library is available or nullptr otherwise.
+ *
+ * \return A newly allocated vpDisplay specialization
+ * if a GUI library is available or nullptr otherwise.
+ */
 vpDisplay *displayFactory()
 {
 #if defined(VISP_HAVE_DISPLAY)
@@ -69,32 +74,71 @@ vpDisplay *displayFactory()
 }
 
 /**
-* \brief Return a newly allocated vpDisplay specialisation initialized with \b I
-* if a GUI library is available or nullptr otherwise.
-*
-* \tparam T Any type that an image can handle and that can be displayed.
-* \param[in] I The image the display must be initialized with.
-*
-* \return vpDisplay* A newly allocated vpDisplay specialisation initialized with \b I
-* if a GUI library is available or nullptr otherwise.
-*/
+ * \brief Return a newly allocated vpDisplay specialization initialized with \b I
+ * if a GUI library is available or nullptr otherwise.
+ *
+ * \tparam T : Any type that an image can handle and that can be displayed.
+ * \param[in] I : The image the display must be initialized with.
+ *
+ * \return A newly allocated vpDisplay specialization initialized with \b I
+ * if a GUI library is available or nullptr otherwise.
+ */
 template<typename T>
 vpDisplay *displayFactory(vpImage<T> &I)
 {
 #if defined(VISP_HAVE_DISPLAY)
 #ifdef VISP_HAVE_X11
   return new vpDisplayX(I);
-#elif defined(VISP_HAVE_D3D9)
-  return new vpDisplayD3D(I);
 #elif defined(VISP_HAVE_GDI)
   return new vpDisplayGDI(I);
-#elif defined(VISP_HAVE_GTK)
-  return new vpDisplayGTK(I);
 #elif defined(HAVE_OPENCV_HIGHGUI)
   return new vpDisplayOpenCV(I);
+#elif defined(VISP_HAVE_GTK)
+  return new vpDisplayGTK(I);
+#elif defined(VISP_HAVE_D3D9)
+  return new vpDisplayD3D(I);
+#endif
+#else
+  return nullptr;
+#endif
+}
+
+/**
+ * \brief Return a newly allocated vpDisplay specialization initialized with \b I
+ * if a GUI library is available or nullptr otherwise.
+ *
+ * \tparam T : Any type that an image can handle and that can be displayed.
+ * \param[in] I : The image the display must be initialized with.
+ * \param[in] scale_type : If this parameter is set to:
+ * - vpDisplay::SCALE_AUTO, the display size is adapted to ensure the image is fully displayed in the screen;
+ * - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the same than the image size.
+ * - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines and the columns.
+ * - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines and the columns.
+ * - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines and the columns.
+ * - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines and the columns.
+ *
+ * \return A newly allocated vpDisplay specialization initialized with \b I
+ * if a GUI library is available or nullptr otherwise.
+ */
+template<typename T>
+vpDisplay *displayFactory(vpImage<T> &I, vpDisplay::vpScaleType scale_type)
+{
+#if defined(VISP_HAVE_DISPLAY)
+#ifdef VISP_HAVE_X11
+  return new vpDisplayX(I, scale_type);
+#elif defined(VISP_HAVE_GDI)
+  return new vpDisplayGDI(I, scale_type);
+#elif defined(HAVE_OPENCV_HIGHGUI)
+  return new vpDisplayOpenCV(I, scale_type);
+#elif defined(VISP_HAVE_GTK)
+  return new vpDisplayGTK(I, scale_type);
+#elif defined(VISP_HAVE_D3D9)
+  return new vpDisplayD3D(I, scale_type);
 #endif
 #else
   return nullptr;
 #endif
 }
 }
+
+#endif

--- a/modules/gui/include/visp3/gui/vpDisplayFactory.h
+++ b/modules/gui/include/visp3/gui/vpDisplayFactory.h
@@ -1,0 +1,100 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See https://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Display Factory
+ *
+*****************************************************************************/
+
+#include <visp3/core/vpConfig.h>
+#include <visp3/gui/vpDisplayD3D.h>
+#include <visp3/gui/vpDisplayGDI.h>
+#include <visp3/gui/vpDisplayGTK.h>
+#include <visp3/gui/vpDisplayOpenCV.h>
+#include <visp3/gui/vpDisplayX.h>
+
+namespace vpDisplayFactory
+{
+/**
+* \brief Return a newly allocated vpDisplay specialisation
+* if a GUI library is available or nullptr otherwise.
+*
+* \return vpDisplay* A newly allocated vpDisplay specialisation
+* if a GUI library is available or nullptr otherwise.
+*/
+vpDisplay *displayFactory()
+{
+#if defined(VISP_HAVE_DISPLAY)
+#ifdef VISP_HAVE_X11
+  return new vpDisplayX();
+#elif defined(VISP_HAVE_D3D9)
+  return new vpDisplayD3D();
+#elif defined(VISP_HAVE_GDI)
+  return new vpDisplayGDI();
+#elif defined(VISP_HAVE_GTK)
+  return new vpDisplayGTK();
+#elif defined(HAVE_OPENCV_HIGHGUI)
+  return new vpDisplayOpenCV();
+#endif
+#else
+  return nullptr;
+#endif
+}
+
+/**
+* \brief Return a newly allocated vpDisplay specialisation initialized with \b I
+* if a GUI library is available or nullptr otherwise.
+*
+* \tparam T Any type that an image can handle and that can be displayed.
+* \param[in] I The image the display must be initialized with.
+*
+* \return vpDisplay* A newly allocated vpDisplay specialisation initialized with \b I
+* if a GUI library is available or nullptr otherwise.
+*/
+template<typename T>
+vpDisplay *displayFactory(vpImage<T> &I)
+{
+#if defined(VISP_HAVE_DISPLAY)
+#ifdef VISP_HAVE_X11
+  return new vpDisplayX(I);
+#elif defined(VISP_HAVE_D3D9)
+  return new vpDisplayD3D(I);
+#elif defined(VISP_HAVE_GDI)
+  return new vpDisplayGDI(I);
+#elif defined(VISP_HAVE_GTK)
+  return new vpDisplayGTK(I);
+#elif defined(HAVE_OPENCV_HIGHGUI)
+  return new vpDisplayOpenCV(I);
+#endif
+#else
+  return nullptr;
+#endif
+}
+}

--- a/modules/gui/src/display/vpDisplayGTK.cpp
+++ b/modules/gui/src/display/vpDisplayGTK.cpp
@@ -568,13 +568,13 @@ private:
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -597,13 +597,13 @@ vpDisplayGTK::vpDisplayGTK(vpImage<unsigned char> &I, vpScaleType scaleType) : v
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -625,13 +625,13 @@ vpDisplayGTK::vpDisplayGTK(vpImage<unsigned char> &I, int win_x, int win_y, cons
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayGTK::vpDisplayGTK(vpImage<vpRGBa> &I, vpScaleType scaleType) : vpDisplay(), m_impl(new Impl())
@@ -652,13 +652,13 @@ vpDisplayGTK::vpDisplayGTK(vpImage<vpRGBa> &I, vpScaleType scaleType) : vpDispla
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayGTK::vpDisplayGTK(vpImage<vpRGBa> &I, int win_x, int win_y, const std::string &win_title,

--- a/modules/gui/src/display/vpDisplayOpenCV.cpp
+++ b/modules/gui/src/display/vpDisplayOpenCV.cpp
@@ -89,13 +89,13 @@ unsigned int vpDisplayOpenCV::m_nbWindows = 0;
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -124,13 +124,13 @@ vpDisplayOpenCV::vpDisplayOpenCV(vpImage<unsigned char> &I, vpScaleType scaleTyp
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -156,13 +156,13 @@ vpDisplayOpenCV::vpDisplayOpenCV(vpImage<unsigned char> &I, int x, int y, const 
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayOpenCV::vpDisplayOpenCV(vpImage<vpRGBa> &I, vpScaleType scaleType)
@@ -188,13 +188,13 @@ vpDisplayOpenCV::vpDisplayOpenCV(vpImage<vpRGBa> &I, vpScaleType scaleType)
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayOpenCV::vpDisplayOpenCV(vpImage<vpRGBa> &I, int x, int y, const std::string &title, vpScaleType scaleType)

--- a/modules/gui/src/display/vpDisplayX.cpp
+++ b/modules/gui/src/display/vpDisplayX.cpp
@@ -1632,13 +1632,13 @@ private:
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayX::vpDisplayX(vpImage<unsigned char> &I, vpScaleType scaleType) : vpDisplay(), m_impl(new Impl())
@@ -1660,13 +1660,13 @@ vpDisplayX::vpDisplayX(vpImage<unsigned char> &I, vpScaleType scaleType) : vpDis
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayX::vpDisplayX(vpImage<unsigned char> &I, int x, int y, const std::string &title, vpScaleType scaleType)
@@ -1686,13 +1686,13 @@ vpDisplayX::vpDisplayX(vpImage<unsigned char> &I, int x, int y, const std::strin
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayX::vpDisplayX(vpImage<vpRGBa> &I, vpScaleType scaleType) : vpDisplay(), m_impl(new Impl())
@@ -1713,13 +1713,13 @@ vpDisplayX::vpDisplayX(vpImage<vpRGBa> &I, vpScaleType scaleType) : vpDisplay(),
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 */
 vpDisplayX::vpDisplayX(vpImage<vpRGBa> &I, int x, int y, const std::string &title, vpScaleType scaleType)
@@ -2501,7 +2501,7 @@ bool vpDisplayX::getClickUp(vpImagePoint &ip, vpMouseButton::vpMouseButtonType &
 /*
   Gets the displayed image (including the overlay plane)
   and returns an RGBa image. If a scale factor is set using setScale(), the
-  size of the image is the size of the downscaled image.
+  size of the image is the size of the down scaled image.
 
   \param I : Image to get.
 */

--- a/modules/gui/src/display/windows/vpDisplayD3D.cpp
+++ b/modules/gui/src/display/windows/vpDisplayD3D.cpp
@@ -84,13 +84,13 @@ set to:
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
 same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
 and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
 and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
 and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
 and the columns.
 
 */
@@ -113,13 +113,13 @@ set to:
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
 same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
 and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
 and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
 and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
 and the columns.
 
 */
@@ -141,13 +141,13 @@ vpDisplayD3D::vpDisplayD3D(vpImage<vpRGBa> &I, int winx, int winy, const std::st
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
 same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
 and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
 and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
 and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
 and the columns.
 
 */
@@ -170,13 +170,13 @@ vpDisplayD3D::vpDisplayD3D(vpImage<unsigned char> &I, vpScaleType scaleType) : v
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
 same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
 and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
 and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
 and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
 and the columns.
 
 */

--- a/modules/gui/src/display/windows/vpDisplayGDI.cpp
+++ b/modules/gui/src/display/windows/vpDisplayGDI.cpp
@@ -84,13 +84,13 @@ vpDisplayGDI::vpDisplayGDI(int winx, int winy, const std::string &title) : vpDis
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -113,13 +113,13 @@ vpDisplayGDI::vpDisplayGDI(vpImage<vpRGBa> &I, vpScaleType scaleType) : vpDispla
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -141,13 +141,13 @@ vpDisplayGDI::vpDisplayGDI(vpImage<vpRGBa> &I, int winx, int winy, const std::st
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */
@@ -170,13 +170,13 @@ vpDisplayGDI::vpDisplayGDI(vpImage<unsigned char> &I, vpScaleType scaleType) : v
     is fully displayed in the screen;
   - vpDisplay::SCALE_DEFAULT or vpDisplay::SCALE_1, the display size is the
   same than the image size.
-  - vpDisplay::SCALE_2, the display size is downscaled by 2 along the lines
+  - vpDisplay::SCALE_2, the display size is down scaled by 2 along the lines
   and the columns.
-  - vpDisplay::SCALE_3, the display size is downscaled by 3 along the lines
+  - vpDisplay::SCALE_3, the display size is down scaled by 3 along the lines
   and the columns.
-  - vpDisplay::SCALE_4, the display size is downscaled by 4 along the lines
+  - vpDisplay::SCALE_4, the display size is down scaled by 4 along the lines
   and the columns.
-  - vpDisplay::SCALE_5, the display size is downscaled by 5 along the lines
+  - vpDisplay::SCALE_5, the display size is down scaled by 5 along the lines
   and the columns.
 
 */

--- a/tutorial/grabber/tutorial-grabber-1394-writer.cpp
+++ b/tutorial/grabber/tutorial-grabber-1394-writer.cpp
@@ -1,12 +1,17 @@
 /*! \example tutorial-grabber-1394-writer.cpp */
 #include <visp3/core/vpImage.h>
-#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayFactory.h>
 #include <visp3/io/vpVideoWriter.h>
 #include <visp3/sensor/vp1394TwoGrabber.h>
 
 int main(int argc, char **)
 {
 #ifdef VISP_HAVE_DC1394
+#ifdef VISP_HAVE_DISPLAY
+  vpDisplay *d = vpDisplayFactory::displayFactory();
+#else
+  std::cout << "No image viewer is available..." << std::endl;
+#endif
   try {
     bool save = false;
     if (argc == 2) {
@@ -23,36 +28,45 @@ int main(int argc, char **)
 
     std::cout << "Image size: " << I.getWidth() << " " << I.getHeight() << std::endl;
 
-#ifdef VISP_HAVE_X11
-    vpDisplayX d(I);
-#else
-    std::cout << "No image viewer is available..." << std::endl;
-#endif
-
     vpVideoWriter writer;
     writer.setFileName("./I%04d.pgm");
     if (save)
       writer.open(I);
 
-    while (1) {
+#ifdef VISP_HAVE_DISPLAY
+    d->init(I);
+    while (1)
+#else
+    // for loop when no display is available to avoid infinite while loop
+    for (unsigned int i = 0; i < 1000; ++i)
+#endif
+    {
       g.acquire(I);
 
       if (save)
         writer.saveFrame(I);
 
+#ifdef VISP_HAVE_DISPLAY
       vpDisplay::display(I);
       vpDisplay::flush(I);
 
       if (vpDisplay::getClick(I, false))
         break;
+#endif
     }
 
     if (save)
       writer.close();
 
-  } catch (const vpException &e) {
+  }
+  catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;
   }
+#ifdef VISP_HAVE_DISPLAY
+  if (d != nullptr) {
+    delete d;
+  }
+#endif
 #else
   (void)argc;
 #endif

--- a/tutorial/grabber/tutorial-grabber-1394-writer.cpp
+++ b/tutorial/grabber/tutorial-grabber-1394-writer.cpp
@@ -50,14 +50,15 @@ int main(int argc, char **)
       vpDisplay::display(I);
       vpDisplay::flush(I);
 
-      if (vpDisplay::getClick(I, false))
+      if (vpDisplay::getClick(I, false)) {
         break;
+      }
 #endif
     }
 
-    if (save)
+    if (save) {
       writer.close();
-
+    }
   }
   catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/tutorial/grabber/tutorial-grabber-v4l2-threaded.cpp
+++ b/tutorial/grabber/tutorial-grabber-v4l2-threaded.cpp
@@ -3,10 +3,10 @@
 #include <iostream>
 #include <visp3/core/vpImageConvert.h>
 #include <visp3/core/vpTime.h>
-#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayFactory.h>
 #include <visp3/sensor/vpV4l2Grabber.h>
 
-#if defined(VISP_HAVE_V4L2) && defined(VISP_HAVE_THREADS)
+#if defined(VISP_HAVE_V4L2) && defined(VISP_HAVE_THREADS) && defined(VISP_HAVE_DISPLAY)
 
 #include <thread>
 #include <mutex>
@@ -54,9 +54,7 @@ void displayFunction(std::mutex &mutex_capture, vpImage<unsigned char> &frame, t
 
   t_CaptureState capture_state_;
   bool display_initialized_ = false;
-#if defined(VISP_HAVE_X11)
-  vpDisplayX *d_ = nullptr;
-#endif
+  vpDisplay *d_ = vpDisplayFactory::displayFactory();
 
   do {
     mutex_capture.lock();
@@ -73,11 +71,9 @@ void displayFunction(std::mutex &mutex_capture, vpImage<unsigned char> &frame, t
 
       // Check if we need to initialize the display with the first frame
       if (!display_initialized_) {
-// Initialize the display
-#if defined(VISP_HAVE_X11)
-        d_ = new vpDisplayX(I_);
+      // Initialize the display
+        d_->init(I_);
         display_initialized_ = true;
-#endif
       }
 
       // Display the image
@@ -98,9 +94,7 @@ void displayFunction(std::mutex &mutex_capture, vpImage<unsigned char> &frame, t
     }
   } while (capture_state_ != capture_stopped);
 
-#if defined(VISP_HAVE_X11)
   delete d_;
-#endif
 
   std::cout << "End of display thread" << std::endl;
 }
@@ -157,6 +151,8 @@ int main()
   std::cout << "You should enable V4L2 to make this example working..." << std::endl;
 #elif !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) // UNIX
   std::cout << "You should enable pthread usage and rebuild ViSP..." << std::endl;
+#elif !defined(VISP_HAVE_DISPLAY)
+  std::cout << "You should have at least one GUI library installed to use this example." << std::endl;
 #else
   std::cout << "Multi-threading seems not supported on this platform" << std::endl;
 #endif

--- a/tutorial/grabber/tutorial-video-reader.cpp
+++ b/tutorial/grabber/tutorial-video-reader.cpp
@@ -1,7 +1,5 @@
 //! \example tutorial-video-reader.cpp
-#include <visp3/gui/vpDisplayGDI.h>
-#include <visp3/gui/vpDisplayOpenCV.h>
-#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayFactory.h>
 //! [Include]
 #include <visp3/core/vpTime.h>
 #include <visp3/io/vpVideoReader.h>
@@ -24,8 +22,8 @@ int main(int argc, char **argv)
         videoname = std::string(argv[i + 1]);
       else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
         std::cout << "\nUsage: " << argv[0] << " [--name <video name> (default: " << videoname << ")]"
-                  << " [--help] [-h]\n"
-                  << std::endl;
+          << " [--help] [-h]\n"
+          << std::endl;
         return EXIT_SUCCESS;
       }
     }
@@ -44,20 +42,17 @@ int main(int argc, char **argv)
     std::cout << "Video framerate: " << g.getFramerate() << "Hz" << std::endl;
     std::cout << "Video dimension: " << I.getWidth() << " " << I.getHeight() << std::endl;
 
-#ifdef VISP_HAVE_X11
-    vpDisplayX d(I);
-#elif defined(VISP_HAVE_GDI)
-    vpDisplayGDI d(I);
-#elif defined(HAVE_OPENCV_HIGHGUI)
-    vpDisplayOpenCV d(I);
+#ifdef VISP_HAVE_DISPLAY
+    vpDisplay *d = vpDisplayFactory::displayFactory(I);
 #else
     std::cout << "No image viewer is available..." << std::endl;
 #endif
     vpDisplay::setTitle(I, "Video reader");
 
     unsigned cpt = 1;
+    bool quit = false;
     //! [vpVideoReader while loop]
-    while (!g.end()) {
+    while ((!g.end()) && (!quit)) {
       //! [vpVideoReader while loop]
       //! [vpVideoReader loop start time]
       double t = vpTime::measureTimeMs();
@@ -68,17 +63,25 @@ int main(int argc, char **argv)
       vpDisplay::display(I);
       vpDisplay::displayText(I, 20, 20, "Click to quit", vpColor::red);
       std::stringstream ss;
-      ss << "Frame: " << cpt++;
+      ss << "Frame: " << ++cpt;
+      std::cout << "Read " << ss.str() << std::endl;
       vpDisplay::displayText(I, 40, 20, ss.str(), vpColor::red);
       vpDisplay::flush(I);
-      if (vpDisplay::getClick(I, false))
-        break;
+      if (vpDisplay::getClick(I, false)) {
+        quit = true;
+      }
       //! [vpVideoReader loop rate]
       vpTime::wait(t, 1000. / g.getFramerate());
       //! [vpVideoReader loop rate]
     }
-    std::cout << "End of video was reached" << std::endl;
-  } catch (const vpException &e) {
+    if (!quit) {
+      std::cout << "End of video was reached" << std::endl;
+    }
+#ifdef VISP_HAVE_DISPLAY
+    delete d;
+#endif
+  }
+  catch (const vpException &e) {
     std::cout << e.getMessage() << std::endl;
   }
 #else

--- a/tutorial/grabber/tutorial-video-recorder.cpp
+++ b/tutorial/grabber/tutorial-video-recorder.cpp
@@ -1,8 +1,6 @@
 /*! \example tutorial-video-recorder.cpp */
 #include <visp3/core/vpTime.h>
-#include <visp3/gui/vpDisplayGDI.h>
-#include <visp3/gui/vpDisplayGTK.h>
-#include <visp3/gui/vpDisplayOpenCV.h>
+#include <visp3/gui/vpDisplayFactory.h>
 #include <visp3/gui/vpDisplayX.h>
 #include <visp3/io/vpVideoWriter.h>
 #include <visp3/sensor/vpV4l2Grabber.h>
@@ -12,36 +10,36 @@
 #endif
 
 /*!
- This example allows to record a video from a camera.
- It only requires that ViSP is build with OpenCV.
+  This example allows to record a video from a camera.
+  It only requires that ViSP is build with OpenCV.
 
- Example to save an mpeg video:
+  Example to save an mpeg video:
 
     ./tutorial-video-recorder --device 0 --name myvideo.mp4
 
- Example to save a sequence of png images:
+  Example to save a sequence of png images:
 
     ./tutorial-video-recorder --device 0 --name image%04d.png
 
- Example to save one imags:
+  Example to save one image:
 
     ./tutorial-video-recorder --device 0 --name image.jpeg
 
  */
-int main(int argc, const char *argv [])
+int main(int argc, const char *argv[])
 {
-#if ((defined(VISP_HAVE_V4L2) || defined(HAVE_OPENCV_VIDEOIO)) &&                                            \
-     (defined(VISP_HAVE_X11) || defined(VISP_HAVE_GDI) || defined(HAVE_OPENCV_HIGHGUI) || defined(VISP_HAVE_GTK)))
+#if (defined(VISP_HAVE_V4L2) || defined(HAVE_OPENCV_VIDEOIO)) && defined(VISP_HAVE_DISPLAY)
   std::string opt_videoname = "video-recorded.mpg";
   int opt_device = 0;
 
   for (int i = 0; i < argc; i++) {
     if (std::string(argv[i]) == "--device")
       opt_device = atoi(argv[i + 1]);
-    else if (std::string(argv[i]) == "--name")
+    else if (std::string(argv[i]) == "--recorded-name")
       opt_videoname = std::string(argv[i + 1]);
     else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
-      std::cout << "\nUsage: " << argv[0] << " [--device <device number>] [--name <video name>] [--help][-h]\n"
+      std::cout << "\nUsage: " << argv[0]
+        << " [--device <device number>] [--recorded-name <video name>] [--help][-h]\n"
         << std::endl;
       return EXIT_SUCCESS;
     }
@@ -55,6 +53,7 @@ int main(int argc, const char *argv [])
     vpImage<unsigned char> I; // for gray images
 
 #if defined(VISP_HAVE_V4L2)
+    std::cout << "Use v4l2 grabber..." << std::endl;
     vpV4l2Grabber g;
     std::ostringstream device;
     device << "/dev/video" << opt_device;
@@ -63,6 +62,7 @@ int main(int argc, const char *argv [])
     g.open(I);
     g.acquire(I);
 #elif defined(HAVE_OPENCV_VIDEOIO)
+    std::cout << "Use OpenCV grabber..." << std::endl;
     cv::VideoCapture g(opt_device);
     if (!g.isOpened()) { // check if we succeeded
       std::cout << "Failed to open the camera" << std::endl;
@@ -75,16 +75,10 @@ int main(int argc, const char *argv [])
 
     std::cout << "Image size: " << I.getWidth() << " " << I.getHeight() << std::endl;
 
-#if defined(VISP_HAVE_X11)
-    vpDisplayX d;
-#elif defined(VISP_HAVE_GDI)
-    vpDisplayGDI d;
-#elif defined(HAVE_OPENCV_HIGHGUI)
-    vpDisplayOpenCV d;
-#elif defined(VISP_HAVE_GTK)
-    vpDisplayGTK d;
+#if defined(VISP_HAVE_DISPLAY)
+    vpDisplay *d = vpDisplayFactory::displayFactory();
+    d->init(I, 0, 0, "Camera view");
 #endif
-    d.init(I, 0, 0, "Camera view");
     vpVideoWriter writer;
 
 #if defined(HAVE_OPENCV_VIDEOIO)
@@ -121,6 +115,9 @@ int main(int argc, const char *argv [])
       vpDisplay::flush(I);
     }
     std::cout << "The video was recorded in \"" << opt_videoname << "\"" << std::endl;
+#ifdef VISP_HAVE_DISPLAY
+    delete d;
+#endif
   }
   catch (const vpException &e) {
     std::cout << "Catch an exception: " << e << std::endl;

--- a/tutorial/image/tutorial-draw-circle.cpp
+++ b/tutorial/image/tutorial-draw-circle.cpp
@@ -1,6 +1,5 @@
 //! \example tutorial-draw-circle.cpp
-#include <visp3/gui/vpDisplayGDI.h>
-#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayFactory.h>
 #include <visp3/core/vpImageCircle.h>
 #include <visp3/core/vpImageDraw.h>
 
@@ -11,10 +10,10 @@ int main()
 
   try {
     {
-#if defined(VISP_HAVE_X11)
-      vpDisplayX d(I, vpDisplay::SCALE_AUTO);
-#elif defined(VISP_HAVE_GDI)
-      vpDisplayGDI d(I, vpDisplay::SCALE_AUTO);
+#if defined(VISP_HAVE_DISPLAY)
+      vpDisplay *d = vpDisplayFactory::displayFactory(I, vpDisplay::SCALE_AUTO);
+#else
+      std::cout << "No gui available to display gray level image..." << std::endl;
 #endif
 
       vpDisplay::setTitle(I, "Gray image");
@@ -25,9 +24,9 @@ int main()
       // i.e. does not modify I
       vpDisplay::displayCircle(I, circle, vpColor::red, false, 2);
       //! [Circle display]
+      vpDisplay::setTitle(I, "Display a red circle on gray level image overlay");
       vpDisplay::flush(I);
-      vpDisplay::setTitle(I, "Overlay");
-      std::cout << "Result of displaying a red circle on overlay on the display..." << std::endl;
+      std::cout << "Result of displaying a red circle on a gray level image overlay..." << std::endl;
       std::cout << "A click to continue..." << std::endl;
       vpDisplay::getClick(I);
 
@@ -38,11 +37,17 @@ int main()
       vpImageDraw::drawCircle(I, circle2, 255, 2);
       //! [Circle draw uchar]
       vpDisplay::display(I);
-      vpDisplay::flush(I);
-      vpDisplay::setTitle(I, "Modification of a uchar image");
-      std::cout << "Result of the modification of a uchar image..." << std::endl;
+      vpDisplay::setTitle(I, "Display circle by modifying a gray level image");
+      std::cout << "Result of displaying a circle by modifying a gray level image..." << std::endl;
       std::cout << "A click to continue..." << std::endl;
+      vpDisplay::flush(I);
       vpDisplay::getClick(I);
+
+#if defined(VISP_HAVE_DISPLAY)
+      if (d) {
+        delete d;
+      }
+#endif
     }
 
     {
@@ -53,19 +58,23 @@ int main()
       vpImageDraw::drawCircle(I_rgb, circle3, vpColor::blue, 2);
       //! [Circle draw color]
 
-#if defined(VISP_HAVE_X11)
-      vpDisplayX d_rgb(I_rgb, vpDisplay::SCALE_AUTO);
-#elif defined(VISP_HAVE_GDI)
-      vpDisplayGDI d_rgb(I_rgb, vpDisplay::SCALE_AUTO);
+#if defined(VISP_HAVE_DISPLAY)
+      vpDisplay *d = vpDisplayFactory::displayFactory(I_rgb, vpDisplay::SCALE_AUTO);
+#else
+      std::cout << "No gui available to display color image..." << std::endl;
 #endif
 
-      vpDisplay::setTitle(I_rgb, "Color image");
       vpDisplay::display(I_rgb);
+      vpDisplay::setTitle(I_rgb, "Display blue circle on a modified color image");
       vpDisplay::flush(I_rgb);
-      vpDisplay::setTitle(I, "Modification of a vpRGBa image");
-      std::cout << "Result of the modification of a vpRGBa image..." << std::endl;
+      std::cout << "Result of displaying a blue circle on a modified color image..." << std::endl;
       std::cout << "A click to continue..." << std::endl;
       vpDisplay::getClick(I_rgb);
+#if defined(VISP_HAVE_DISPLAY)
+      if (d) {
+        delete d;
+      }
+#endif
     }
   }
   catch (const vpException &e) {

--- a/tutorial/image/tutorial-draw-cross.cpp
+++ b/tutorial/image/tutorial-draw-cross.cpp
@@ -1,13 +1,11 @@
 //! \example tutorial-draw-cross.cpp
-#include <visp3/gui/vpDisplayGDI.h>
-#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayFactory.h>
 
 int main()
 {
   vpImage<unsigned char> I(2160, 3840, 128);
 
   try {
-
 #if defined(VISP_HAVE_X11)
     vpDisplayX d(I, vpDisplay::SCALE_AUTO);
 #elif defined(VISP_HAVE_GDI)
@@ -22,7 +20,8 @@ int main()
     vpDisplay::flush(I);
     std::cout << "A click to quit..." << std::endl;
     vpDisplay::getClick(I);
-  } catch (const vpException &e) {
+  }
+  catch (const vpException &e) {
     std::cout << "Catch an exception: " << e.getMessage() << std::endl;
   }
   std::cout << std::endl;

--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-ibvs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-ibvs.cpp
@@ -37,13 +37,13 @@ int main(int argc, const char **argv)
 #endif
 
   for (int i = 1; i < argc; i++) {
-    if (std::string(argv[i]) == "--tag_size" && i + 1 < argc) {
+    if (std::string(argv[i]) == "--tag-size" && i + 1 < argc) {
       tagSize = std::atof(argv[i + 1]);
     }
     else if (std::string(argv[i]) == "--input" && i + 1 < argc) {
       device = std::atoi(argv[i + 1]);
     }
-    else if (std::string(argv[i]) == "--quad_decimate" && i + 1 < argc) {
+    else if (std::string(argv[i]) == "--quad-decimate" && i + 1 < argc) {
       quad_decimate = (float)atof(argv[i + 1]);
     }
     else if (std::string(argv[i]) == "--nthreads" && i + 1 < argc) {
@@ -52,39 +52,37 @@ int main(int argc, const char **argv)
     else if (std::string(argv[i]) == "--intrinsic" && i + 1 < argc) {
       intrinsic_file = std::string(argv[i + 1]);
     }
-    else if (std::string(argv[i]) == "--camera_name" && i + 1 < argc) {
+    else if (std::string(argv[i]) == "--camera-name" && i + 1 < argc) {
       camera_name = std::string(argv[i + 1]);
     }
 #if defined(VISP_HAVE_DISPLAY)
-    else if (std::string(argv[i]) == "--display_tag") {
+    else if (std::string(argv[i]) == "--display-tag") {
       display_tag = true;
     }
-    else if (std::string(argv[i]) == "--display_on") {
+    else if (std::string(argv[i]) == "--display-on") {
       display_on = true;
     }
-    else if (std::string(argv[i]) == "--save_image") {
+    else if (std::string(argv[i]) == "--save-image") {
       save_image = true;
     }
 #endif
-    else if (std::string(argv[i]) == "--serial_off") {
+    else if (std::string(argv[i]) == "--serial-off") {
       serial_off = true;
     }
-    else if (std::string(argv[i]) == "--tag_family" && i + 1 < argc) {
+    else if (std::string(argv[i]) == "--tag-family" && i + 1 < argc) {
       tagFamily = (vpDetectorAprilTag::vpAprilTagFamily)std::atoi(argv[i + 1]);
     }
     else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
       std::cout << "Usage: " << argv[0]
-        << " [--input <camera input>] [--tag_size <tag_size in m>]"
-        " [--quad_decimate <quad_decimate>] [--nthreads <nb>]"
-        " [--intrinsic <intrinsic file>] [--camera_name <camera name>]"
-        " [--tag_family <family> (0: TAG_36h11, 1: TAG_36h10, 2: "
-        "TAG_36ARTOOLKIT,"
-        " 3: TAG_25h9, 4: TAG_25h7, 5: TAG_16h5)]"
-        " [--display_tag]";
+        << " [--input <camera input>] [--tag-size <tag_size in m>]"
+        " [--quad-decimate <quad_decimate>] [--nthreads <nb>]"
+        " [--intrinsic <intrinsic file>] [--camera-name <camera name>]"
+        " [--tag-family <family> (0: TAG_36h11, 1: TAG_36h10, 2: TAG_36ARTOOLKIT, 3: TAG_25h9, 4: TAG_25h7, 5: TAG_16h5)]"
+        " [--display-tag]";
 #if defined(VISP_HAVE_DISPLAY)
-      std::cout << " [--display_on] [--save_image]";
+      std::cout << " [--display-on] [--save-image]";
 #endif
-      std::cout << " [--serial_off] [--help]" << std::endl;
+      std::cout << " [--serial-off] [--help]" << std::endl;
       return EXIT_SUCCESS;
     }
   }
@@ -285,7 +283,7 @@ int main(int argc, const char **argv)
         }
 
 #ifdef VISP_HAVE_DISPLAY
-// Display visual features
+        // Display visual features
         vpDisplay::displayPolygon(I, vec_ip, vpColor::green, 3); // Current polygon used to compure an moment
         vpDisplay::displayCross(I, detector.getCog(0), 15, vpColor::green,
                                 3); // Current polygon used to compure an moment
@@ -293,7 +291,7 @@ int main(int argc, const char **argv)
                                3); // Vertical line as desired x position
 #endif
 
-// Current moments
+        // Current moments
         m_obj.setType(vpMomentObject::DENSE_POLYGON); // Consider the AprilTag as a polygon
         m_obj.fromVector(vec_P);                      // Initialize the object with the points coordinates
 
@@ -342,7 +340,7 @@ int main(int argc, const char **argv)
         }
       }
       else {
-     // stop the robot
+        // stop the robot
         if (!serial_off) {
           serial->write("LED_RING=2,10,0,0\n"); // Switch on led 2 to red: tag not detected
           //          serial->write("LED_RING=3,0,0,0\n");  // Switch on led 3 to blue: motor left not servoed
@@ -375,8 +373,9 @@ int main(int argc, const char **argv)
       << " ; " << vpMath::getMedian(time_vec) << " ms"
       << " ; " << vpMath::getStdev(time_vec) << " ms" << std::endl;
 
-    if (display_on)
+    if (display_on) {
       delete d;
+    }
     if (!serial_off) {
       delete serial;
     }

--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-pbvs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-pbvs.cpp
@@ -26,13 +26,13 @@ int main(int argc, const char **argv)
   bool save_image = false; // Only possible if display_on = true
 
   for (int i = 1; i < argc; i++) {
-    if (std::string(argv[i]) == "--tag_size" && i + 1 < argc) {
+    if (std::string(argv[i]) == "--tag-size" && i + 1 < argc) {
       tagSize = std::atof(argv[i + 1]);
     }
     else if (std::string(argv[i]) == "--input" && i + 1 < argc) {
       device = std::atoi(argv[i + 1]);
     }
-    else if (std::string(argv[i]) == "--quad_decimate" && i + 1 < argc) {
+    else if (std::string(argv[i]) == "--quad-decimate" && i + 1 < argc) {
       quad_decimate = (float)atof(argv[i + 1]);
     }
     else if (std::string(argv[i]) == "--nthreads" && i + 1 < argc) {
@@ -41,38 +41,37 @@ int main(int argc, const char **argv)
     else if (std::string(argv[i]) == "--intrinsic" && i + 1 < argc) {
       intrinsic_file = std::string(argv[i + 1]);
     }
-    else if (std::string(argv[i]) == "--camera_name" && i + 1 < argc) {
+    else if (std::string(argv[i]) == "--camera-name" && i + 1 < argc) {
       camera_name = std::string(argv[i + 1]);
     }
-    else if (std::string(argv[i]) == "--display_tag") {
+    else if (std::string(argv[i]) == "--display-tag") {
       display_tag = true;
 #if defined(VISP_HAVE_DISPLAY)
     }
-    else if (std::string(argv[i]) == "--display_on") {
+    else if (std::string(argv[i]) == "--display-on") {
       display_on = true;
     }
-    else if (std::string(argv[i]) == "--save_image") {
+    else if (std::string(argv[i]) == "--save-image") {
       save_image = true;
 #endif
     }
-    else if (std::string(argv[i]) == "--serial_off") {
+    else if (std::string(argv[i]) == "--serial-off") {
       serial_off = true;
     }
-    else if (std::string(argv[i]) == "--tag_family" && i + 1 < argc) {
+    else if (std::string(argv[i]) == "--tag-family" && i + 1 < argc) {
       tagFamily = (vpDetectorAprilTag::vpAprilTagFamily)atoi(argv[i + 1]);
     }
     else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
       std::cout << "Usage: " << argv[0]
-        << " [--input <camera input>] [--tag_size <tag_size in m>]"
-        " [--quad_decimate <quad_decimate>] [--nthreads <nb>]"
-        " [--intrinsic <intrinsic file>] [--camera_name <camera name>]"
-        " [--tag_family <family> (0: TAG_36h11, 1: TAG_36h10, 2: TAG_36ARTOOLKIT,"
-        " 3: TAG_25h9, 4: TAG_25h7, 5: TAG_16h5)]"
-        " [--display_tag]";
+        << " [--input <camera input>] [--tag-size <tag size in m>]"
+        " [--quad-decimate <quad decimate>] [--nthreads <nb>]"
+        " [--intrinsic <intrinsic file>] [--camera-name <camera name>]"
+        " [--tag-family <family> (0: TAG_36h11, 1: TAG_36h10, 2: TAG_36ARTOOLKIT, 3: TAG_25h9, 4: TAG_25h7, 5: TAG_16h5)]"
+        " [--display-tag]";
 #if defined(VISP_HAVE_DISPLAY)
-      std::cout << " [--display_on] [--save_image]";
+      std::cout << " [--display-on] [--save-image]";
 #endif
-      std::cout << " [--serial_off] [--help]" << std::endl;
+      std::cout << " [--serial-off] [--help]" << std::endl;
       return EXIT_SUCCESS;
     }
   }
@@ -243,7 +242,7 @@ int main(int argc, const char **argv)
         }
       }
       else {
-     // stop the robot
+        // stop the robot
         if (!serial_off) {
           serial->write("LED_RING=2,10,0,0\n"); // Switch on led 2 to red: tag not detected
           //          serial->write("LED_RING=3,0,0,0\n");  // Switch on led 3 to blue: motor left not servoed
@@ -258,8 +257,9 @@ int main(int argc, const char **argv)
         vpDisplay::getImage(I, O);
         vpImageIo::write(O, "image.png");
       }
-      if (vpDisplay::getClick(I, false))
+      if (vpDisplay::getClick(I, false)) {
         break;
+      }
     }
 
     if (!serial_off) {
@@ -271,8 +271,9 @@ int main(int argc, const char **argv)
       << " ; " << vpMath::getMedian(time_vec) << " ms"
       << " ; " << vpMath::getStdev(time_vec) << " ms" << std::endl;
 
-    if (display_on)
+    if (display_on) {
       delete d;
+    }
     if (!serial_off) {
       delete serial;
     }

--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-pbvs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-pbvs.cpp
@@ -2,7 +2,7 @@
 #include <visp3/core/vpSerial.h>
 #include <visp3/core/vpXmlParserCamera.h>
 #include <visp3/detection/vpDetectorAprilTag.h>
-#include <visp3/gui/vpDisplayX.h>
+#include <visp3/gui/vpDisplayFactory.h>
 #include <visp3/io/vpImageIo.h>
 #include <visp3/robot/vpUnicycle.h>
 #include <visp3/sensor/vpV4l2Grabber.h>
@@ -46,7 +46,7 @@ int main(int argc, const char **argv)
     }
     else if (std::string(argv[i]) == "--display_tag") {
       display_tag = true;
-#if defined(VISP_HAVE_X11)
+#if defined(VISP_HAVE_DISPLAY)
     }
     else if (std::string(argv[i]) == "--display_on") {
       display_on = true;
@@ -69,7 +69,7 @@ int main(int argc, const char **argv)
         " [--tag_family <family> (0: TAG_36h11, 1: TAG_36h10, 2: TAG_36ARTOOLKIT,"
         " 3: TAG_25h9, 4: TAG_25h7, 5: TAG_16h5)]"
         " [--display_tag]";
-#if defined(VISP_HAVE_X11)
+#if defined(VISP_HAVE_DISPLAY)
       std::cout << " [--display_on] [--save_image]";
 #endif
       std::cout << " [--serial_off] [--help]" << std::endl;
@@ -104,9 +104,9 @@ int main(int argc, const char **argv)
 
     vpDisplay *d = nullptr;
     vpImage<vpRGBa> O;
-#ifdef VISP_HAVE_X11
+#ifdef VISP_HAVE_DISPLAY
     if (display_on) {
-      d = new vpDisplayX(I);
+      d = vpDisplayFactory::displayFactory(I);
     }
 #endif
 

--- a/tutorial/robot/mbot/raspberry/visp/test-serial-mbot.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/test-serial-mbot.cpp
@@ -15,22 +15,27 @@ int main(int argc, char *argv[])
   for (int i = 1; i < argc; i++) {
     if ((std::string(argv[i]) == "--t" || std::string(argv[i]) == "-t") && i + 1 < argc) {
       time = (double)atof(argv[i + 1]);
-    } else if ((std::string(argv[i]) == "--vx" || std::string(argv[i]) == "-vx") && i + 1 < argc) {
+    }
+    else if ((std::string(argv[i]) == "--vx" || std::string(argv[i]) == "-vx") && i + 1 < argc) {
       v_x = (double)atof(argv[i + 1]);
-    } else if ((std::string(argv[i]) == "--wz" || std::string(argv[i]) == "-wz") && i + 1 < argc) {
+    }
+    else if ((std::string(argv[i]) == "--wz" || std::string(argv[i]) == "-wz") && i + 1 < argc) {
       w_z = (double)atof(argv[i + 1]);
-    } else if ((std::string(argv[i]) == "--rpm_l" || std::string(argv[i]) == "-rpm_l") && i + 1 < argc) {
+    }
+    else if ((std::string(argv[i]) == "--rpm_l" || std::string(argv[i]) == "-rpm_l") && i + 1 < argc) {
       rpm_command = true;
       rpm_l = (double)atoi(argv[i + 1]);
-    } else if ((std::string(argv[i]) == "--rpm_r" || std::string(argv[i]) == "-rpm_r") && i + 1 < argc) {
+    }
+    else if ((std::string(argv[i]) == "--rpm_r" || std::string(argv[i]) == "-rpm_r") && i + 1 < argc) {
       rpm_command = true;
       rpm_r = (double)atoi(argv[i + 1]);
-    } else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
+    }
+    else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
       std::cout << "Usage: \n"
-                << argv[0]
-                << " --vx <linear velocity in m/s> --wz <rotational velocity in deg/s> --rpm_l <motor left RPM> "
-                   "--rpm_r <motor right RPM> --t <duration of the command in second> --help"
-                << std::endl;
+        << argv[0]
+        << " --vx <linear velocity in m/s> --wz <rotational velocity in deg/s> --rpm_l <motor left RPM> "
+        "--rpm_r <motor right RPM> --t <duration of the command in second> --help"
+        << std::endl;
       std::cout << "\nExample:\n" << argv[0] << " --vx 0.05 --wz 0 --t 4\n" << std::endl;
       return EXIT_SUCCESS;
     }
@@ -43,12 +48,13 @@ int main(int argc, char *argv[])
     if (rpm_command) {
       std::cout << "Apply rpm_l=" << rpm_l << " rpm_r=" << rpm_r << " during " << time << " seconds" << std::endl;
       ss << "MOTOR_RPM=" << rpm_l << "," << rpm_r << "\n";
-    } else {
+    }
+    else {
       vpColVector v(2);
       v[0] = v_x;
       v[1] = vpMath::rad(w_z);
       std::cout << "Apply v_x=" << v_x << " m/s "
-                << " w_z=" << w_z << " deg/s during " << time << " seconds" << std::endl;
+        << " w_z=" << w_z << " deg/s during " << time << " seconds" << std::endl;
       double radius = 0.0325;
       double L = 0.0725;
       double motor_left = -(v[0] + L * v[1]) / radius;


### PR DESCRIPTION
- Added a vpDisplayFactory namespace that permits to either get a newly allocated vpDisplay* if a GUI library is available or a nullptr otherwise. It permits to check only VISP_HAVE_DISPLAY instead of several macro in a software to get a new display.
- Fix compilation errors when no GUI library is available