### PR TITLE
Nix packaging

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,17 @@
+name: "Nix CI"
+
+on: [pull_request, push]
+
+jobs:
+  tests:
+    name: "Nix build on ${{ matrix.os }}"
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      matrix:
+        os: [ubuntu] # TODO: macos
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flake-checker-action@main
+      - run: nix build

--- a/.nixignore
+++ b/.nixignore
@@ -1,0 +1,12 @@
+*.nix
+.clang-format
+.git*
+.nixignore
+.vscode
+appveyor.yml
+ChangeLog.txt
+ci
+codecov.yml
+CONTRIBUTING.md
+INSTALL.txt
+README.md

--- a/cmake/VISPGenerateConfig.cmake
+++ b/cmake/VISPGenerateConfig.cmake
@@ -41,14 +41,19 @@
 # output: path_to_parent, the relative path to go from path_to_child to parent
 # example: if input =lib/x86_64-linux-gnu, then output=../..
 macro(get_path_to_parent path_to_child path_to_parent)
-  set(${path_to_parent} "")
-  set(input_ "${path_to_child}")
-  while(input_)
-    if(input_)
-      set(${path_to_parent} "${${path_to_parent}}../")
-    endif()
-    get_filename_component(input_ "${input_}" PATH)
-  endwhile(input_)
+  if(IS_ABSOLUTE ${path_to_child})
+    file(RELATIVE_PATH _path_to_parent "${path_to_child}" "${CMAKE_INSTALL_PREFIX}")
+    string(REGEX REPLACE "/$" "" ${path_to_parent} "${_path_to_parent}")
+  else()
+    set(${path_to_parent} "")
+    set(input_ "${path_to_child}")
+    while(input_)
+      if(input_)
+        set(${path_to_parent} "${${path_to_parent}}../")
+      endif()
+      get_filename_component(input_ "${input_}" PATH)
+    endwhile(input_)
+  endif()
 endmacro()
 
 # Here we determine the relative path from ./${VISP_LIB_INSTALL_PATH} to its parent folder

--- a/cmake/VISPGenerateConfigScript.cmake
+++ b/cmake/VISPGenerateConfigScript.cmake
@@ -343,8 +343,16 @@ else() # DEFINED CMAKE_HELPER_SCRIPT
     # Updates VISP_SCRIPT_PC_LIBS (for visp.pc used by pkg-config)
     #----------------------------------------------------------------------
     set(exec_prefix "\${prefix}")
-    set(includedir  "\${prefix}/${VISP_INC_INSTALL_PATH}")
-    set(libdir      "\${prefix}/${VISP_LIB_INSTALL_PATH}")
+    if(IS_ABSOLUTE ${VISP_INC_INSTALL_PATH})
+      set(includedir  "${VISP_INC_INSTALL_PATH}")
+    else()
+      set(includedir  "\${prefix}/${VISP_INC_INSTALL_PATH}")
+    endif()
+    if(IS_ABSOLUTE ${VISP_LIB_INSTALL_PATH})
+      set(libdir      "${VISP_LIB_INSTALL_PATH}")
+    else()
+      set(libdir      "\${prefix}/${VISP_LIB_INSTALL_PATH}")
+    endif()
 
     # prepend with ViSP own include dir
     set(VISP_SCRIPT_PC_CFLAGS
@@ -356,18 +364,33 @@ else() # DEFINED CMAKE_HELPER_SCRIPT
     vp_list_remove_separator(VISP_SCRIPT_PC_CFLAGS)
 
     # prepend with ViSP own modules first
-    set(VISP_SCRIPT_PC_LIBS
-      "-L\${exec_prefix}/${VISP_LIB_INSTALL_PATH}"
-      "${_modules}"
-    )
+    if(IS_ABSOLUTE ${VISP_LIB_INSTALL_PATH})
+      set(VISP_SCRIPT_PC_LIBS
+        "-L${VISP_LIB_INSTALL_PATH}"
+        "${_modules}"
+      )
+    else()
+      set(VISP_SCRIPT_PC_LIBS
+        "-L\${exec_prefix}/${VISP_LIB_INSTALL_PATH}"
+        "${_modules}"
+      )
+    endif()
     if(BUILD_SHARED_LIBS)
       set(VISP_SCRIPT_PC_LIBS_PRIVATE "${_extra_opt}")
     else()
-      set(VISP_SCRIPT_PC_LIBS_PRIVATE
-        "-L\${exec_prefix}/${VISP_3P_LIB_INSTALL_PATH}"
-        "${_3rdparty}"
-        "${_extra_opt}"
-      )
+      if(IS_ABSOLUTE ${VISP_3P_LIB_INSTALL_PATH})
+        set(VISP_SCRIPT_PC_LIBS_PRIVATE
+          "-L${VISP_3P_LIB_INSTALL_PATH}"
+          "${_3rdparty}"
+          "${_extra_opt}"
+        )
+      else()
+        set(VISP_SCRIPT_PC_LIBS_PRIVATE
+          "-L\${exec_prefix}/${VISP_3P_LIB_INSTALL_PATH}"
+          "${_3rdparty}"
+          "${_extra_opt}"
+        )
+      endif()
     endif()
 
     vp_list_remove_separator(VISP_SCRIPT_PC_LIBS)

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,87 @@
+# TODO:
+# visp> In file included from /nix/store/g6lpg2p890jn3hkv63jjkk2f7k66y6hk-ogre-14.2.5/include/OGRE/Ogre.h:52,
+# visp>                  from /build/source/modules/ar/include/visp3/ar/vpAROgre.h:66:
+# visp> /nix/store/g6lpg2p890jn3hkv63jjkk2f7k66y6hk-ogre-14.2.5/include/OGRE/OgreConfigFile.h:94:41: note: declared here
+# visp>    94 |         OGRE_DEPRECATED SectionIterator getSectionIterator(void);
+# visp>       |                                         ^~~~~~~~~~~~~~~~~~
+# visp> /build/source/modules/ar/src/ogre-simulator/vpAROgre.cpp:315:33: error: no matching function for call to 'Ogre::Root::showConfigDialog()'
+# visp>   315 |     if (!mRoot->showConfigDialog()) {
+# visp>       |          ~~~~~~~~~~~~~~~~~~~~~~~^~
+{
+  cmake,
+  coin3d,
+  doxygen,
+  eigen,
+  #fetchFromGitHub,
+  lapack,
+  lib,
+  libdc1394,
+  libdmtx,
+  libglvnd,
+  libpng,
+  libxml2,
+  libX11,
+  nix-gitignore,
+  nlohmann_json,
+  #ogre,
+  openblas,
+  opencv,
+  python3,
+  stdenv,
+  texliveSmall,
+  v4l-utils,
+  xorg,
+  zbar,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "visp";
+  version = "3.6.0";
+
+  /*
+  src = fetchFromGitHub {
+    owner = "lagadic";
+    repo = "visp";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-m5Tmr+cZab7eSjmbXb8HpJpFHb0UYFTyimY+CkfBIAo=";
+  };
+  */
+  src = nix-gitignore.gitignoreSource [ ./.nixignore ] ./.;
+
+  nativeBuildInputs = [
+    cmake
+    doxygen
+    texliveSmall
+  ];
+
+  doCheck = true;
+
+  buildInputs = [
+    coin3d
+    eigen
+    lapack
+    libdmtx
+    libxml2
+    libdc1394
+    libX11
+    libglvnd
+    libpng
+    nlohmann_json
+    #ogre
+    openblas
+    opencv
+    (python3.withPackages (p: [ p.numpy ]))
+    v4l-utils
+    xorg.libpthreadstubs
+    zbar
+    zlib
+  ];
+
+  meta = {
+    description = "Open Source Visual Servoing Platform";
+    homepage = "https://visp.inria.fr";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.nim65s ];
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1716715802,
+        "narHash": "sha256-usk0vE7VlxPX8jOavrtpOqphdfqEQpf9lgedlY/r66c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e2dd4e18cc1c7314e24154331bae07df76eb582f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Open Source Visual Servoing Platform";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { flake-utils, nixpkgs, ... }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        visp = pkgs.callPackage ./default.nix { };
+      in
+      {
+        packages.default = visp;
+      }
+    );
+}


### PR DESCRIPTION
Hello !

This PR includes:

1. a CMake fix for use cases where users (or package managers) set eg. `-DCMAKE_INSTALL_LIBDIR=/an/absolute/path`
2. a default.nix file which create a `visp` package in nix, and a flake.nix file to easily build and use this package. At some point, we will want to move this default.nix to https://github.com/NixOS/nixpkgs/, and just override the `src` attribute to use the local version instead.
3. a github action to test this nix setup.

I have a few questions:
- did I miss important dependencies / options ?
- visp do not compile correctly with ogre v14.2.5. Is this known ? What should we do about it ?
- contributing guidelines provide a "Copyright Assignment Agreement for an Individual Contributor". I am not in an individual position, but with CNRS. What should we do about that ?

Also, nix macos packaging is not done yet. I'll probably be able to find some time to deal with this, but not today, and maybe not this week.