### PR TITLE
Update macos-11 and macos-12 to macos-latest for Github runners

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-11]
+        os: [macos-latest]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -40,4 +40,6 @@ jobs:
       run: |
         mkdir build
         cd build
-        python ../platforms/ios/build_framework.py ios
+      # cf: doc\tutorial\ios\tutorial-install-iOS.dox
+        python ../platforms/ios/build_framework.py ios --iphoneos_deployment_target 12.0 --iphoneos_archs arm64 \
+                --build_only_specified_archs True

--- a/.github/workflows/macos-ustk.yml
+++ b/.github/workflows/macos-ustk.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12]
+        os: [macos-latest]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-13, macos-latest]
 
     steps:
     - name: Checkout repository
@@ -33,8 +33,8 @@ jobs:
     - name: Print OS information
       run: system_profiler SPSoftwareDataType
 
-    - name: Install dependencies on macos-12
-      if: matrix.os == 'macos-12'
+    - name: Install dependencies on macos-latest
+      if: matrix.os == 'macos-latest'
       run: |
         brew install libpng libjpeg-turbo libdc1394 opencv pcl librealsense zbar pkg-config nlohmann-json
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,12 @@ name: "Nix CI"
 
 on: [pull_request, push]
 
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre#comment133398800_72408109
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: "Nix build on ${{ matrix.os }}"


### PR DESCRIPTION
See:
- https://github.com/actions/runner-images/issues/9255
- https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

https://github.com/actions/runner-images/issues/9255

[![300882082-ac6ef1f1-8e18-4af1-a97f-d38cf82885df](https://github.com/lagadic/visp/assets/8035162/7cdcb151-d102-40de-bdb7-51c0a0ed2873)](https://github.com/actions/runner-images/issues/9255)