### PR TITLE
Fixed typos in mbt stereo tutorial

### DIFF
--- a/doc/tutorial/tracking/tutorial-tracking-mb-generic-stereo.dox
+++ b/doc/tutorial/tracking/tutorial-tracking-mb-generic-stereo.dox
@@ -18,7 +18,7 @@ The mbt ViSP module allows the tracking of a markerless object using the knowled
 have to be modeled by segment, circle or cylinder primitives. The model of the object could be defined in vrml format
 (except for circles) or in cao (our own format).
 
-The visual features that could be considered by multiple cameras are the moving-edges, the keypoints (KLT features) of
+The visual features that could be considered by multiple cameras are the moving-edges, the keypoints (KLT features) or
 a combination of them in a hybrid scheme when the object is textured and has visible edges
 (see \ref mb_generic_intro_features_overview). They are the same than the one used for a single camera.
 
@@ -121,7 +121,7 @@ The tutorial-mb-generic-tracker-stereo.cpp example uses the following data as in
 
 As an output the tracker provides the two poses \f$^c {\bf M}_o \f$ corresponding to a 4 by 4 matrix that corresponds
 to the geometric transformation between the frame attached to the object (in our case the tea box) and the frame
-attached to the the left camera and the one attached to the right camera. The poses are returned as a
+attached to the left camera and the one attached to the right camera. The poses are returned as a
 vpHomogeneousMatrix container.
 
 \subsection mb_generic_stereo_example_code Example code
@@ -180,7 +180,7 @@ vpMbGenericTracker::vpTrackerType:
 \snippet tutorial-mb-generic-tracker-stereo.cpp Constructor
 
 All the configuration parameters for the tracker are stored in xml configuration files. To load the different files
-that contain also the the intrinsic camera parameters, we use:
+that contain also the intrinsic camera parameters, we use:
 
 \snippet tutorial-mb-generic-tracker-stereo.cpp Load config file
 
@@ -244,6 +244,6 @@ the object. The images were captured by cameras located in the Romeo eyes.
 \endhtmlonly
 
 \section mb_generic_stereo_next Next tutorial
-You are now ready to see the next \ref tutorial-tracking-mb-generic.
+You are now ready to see the next \ref tutorial-tracking-mb-generic-rgbd.
 
 */

--- a/tutorial/tracking/model-based/generic-stereo/tutorial-mb-generic-tracker-stereo.cpp
+++ b/tutorial/tracking/model-based/generic-stereo/tutorial-mb-generic-tracker-stereo.cpp
@@ -97,11 +97,14 @@ int main(int argc, char **argv)
     //! [Constructor]
 
 #if !defined(VISP_HAVE_MODULE_KLT)
-    if (opt_tracker >= 2) {
-      std::cout << "klt and hybrid model-based tracker are not available "
-        "since visp_klt module is missing"
-        << std::endl;
-      return EXIT_SUCCESS;
+    unsigned int nbTracker = trackerTypes.size();
+    for (unsigned int i = 0; i < nbTracker; ++i) {
+      if (trackerTypes[i] >= 2) {
+        std::cout << "klt and hybrid model-based tracker are not available "
+          "since visp_klt module is missing"
+          << std::endl;
+        return EXIT_SUCCESS;
+      }
     }
 #endif
 
@@ -166,7 +169,7 @@ int main(int argc, char **argv)
       }
     }
     vpDisplay::getClick(I_left);
-}
+  }
   catch (const vpException &e) {
     std::cerr << "Catch a ViSP exception: " << e.what() << std::endl;
   }


### PR DESCRIPTION
[TUTO][CLEAN] Fixed typos in mbt stereo tutorial:
- wrong link at the end of the dox
- "the the"
- "of a combination" instead of "or a combination"
- wrong test when VISP_HAVE_MODULE_KLT is not defined