### PR TITLE
Add mid-optimization normal filtering to MBT

### DIFF
--- a/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
@@ -1,6 +1,6 @@
 /*
  * ViSP, open source Visual Servoing Platform software.
- * Copyright (C) 2005 - 2023 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -31,8 +31,8 @@
  * Model-based tracker using depth normal features.
  */
 
-#ifndef _vpMbDepthNormalTracker_h_
-#define _vpMbDepthNormalTracker_h_
+#ifndef VP_MB_DEPTH_NORMAL_TRACKER_H
+#define VP_MB_DEPTH_NORMAL_TRACKER_H
 
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpPlane.h>
@@ -119,7 +119,6 @@ public:
   virtual void track(const pcl::PointCloud<pcl::PointXYZ>::ConstPtr &point_cloud);
 #endif
   virtual void track(const std::vector<vpColVector> &point_cloud, unsigned int width, unsigned int height);
-
 
 protected:
   //! Method to estimate the desired features

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbDepthNormalTracker.h
@@ -120,6 +120,7 @@ public:
 #endif
   virtual void track(const std::vector<vpColVector> &point_cloud, unsigned int width, unsigned int height);
 
+
 protected:
   //! Method to estimate the desired features
   vpMbtFaceDepthNormal::vpFeatureEstimationType m_depthNormalFeatureEstimationMethod;

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
@@ -133,6 +133,8 @@ public:
   void computeVisibility();
   void computeVisibilityDisplay();
 
+  bool planeIsDegenerate(const vpHomogeneousMatrix &cMo);
+
   void computeNormalVisibility(double nx, double ny, double nz, const vpColVector &centroid_point,
                                vpColVector &face_normal);
 #if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_PCL_COMMON) && defined(VISP_HAVE_PCL_SEGMENTATION) && defined(VISP_HAVE_PCL_FILTERS)

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
@@ -133,7 +133,7 @@ public:
   void computeVisibility();
   void computeVisibilityDisplay();
 
-  bool planeIsDegenerate(const vpHomogeneousMatrix &cMo);
+  bool planeIsInvalid(const vpHomogeneousMatrix &cMo, double maxAngle);
 
   void computeNormalVisibility(double nx, double ny, double nz, const vpColVector &centroid_point,
                                vpColVector &face_normal);

--- a/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
@@ -272,18 +272,11 @@ void vpMbDepthNormalTracker::computeVVSInteractionMatrixAndResidu()
 
     vpColVector face_error = features_face - m_depthNormalListOfDesiredFeatures[(size_t)cpt];
 
-    std::cout << "cpt = " << cpt << std::endl;
-    std::cout << "Current features = " << features_face.t() << std::endl;
-    std::cout << "Desired features = " << m_depthNormalListOfDesiredFeatures[(size_t)cpt].t() << std::endl;
-    std::cout << "error = " << face_error.t() << std::endl;
-
-    if (!(*it)->planeIsDegenerate(m_cMo)) {
+    if (!(*it)->planeIsInvalid(m_cMo, angleDisappears)) {
       m_error_depthNormal.insert(cpt * 3, face_error);
       m_L_depthNormal.insert(L_face, cpt * 3, 0);
     }
     else {
-      std::cout << "DEGENERATE PLANE" << std::endl;
-
       face_error = 0;
       L_face = 0;
       m_error_depthNormal.insert(cpt * 3, face_error);

--- a/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbDepthNormalTracker.cpp
@@ -267,12 +267,28 @@ void vpMbDepthNormalTracker::computeVVSInteractionMatrixAndResidu()
        it != m_depthNormalListOfActiveFaces.end(); ++it) {
     vpMatrix L_face;
     vpColVector features_face;
+
     (*it)->computeInteractionMatrix(m_cMo, L_face, features_face);
 
     vpColVector face_error = features_face - m_depthNormalListOfDesiredFeatures[(size_t)cpt];
 
-    m_error_depthNormal.insert(cpt * 3, face_error);
-    m_L_depthNormal.insert(L_face, cpt * 3, 0);
+    std::cout << "cpt = " << cpt << std::endl;
+    std::cout << "Current features = " << features_face.t() << std::endl;
+    std::cout << "Desired features = " << m_depthNormalListOfDesiredFeatures[(size_t)cpt].t() << std::endl;
+    std::cout << "error = " << face_error.t() << std::endl;
+
+    if (!(*it)->planeIsDegenerate(m_cMo)) {
+      m_error_depthNormal.insert(cpt * 3, face_error);
+      m_L_depthNormal.insert(L_face, cpt * 3, 0);
+    }
+    else {
+      std::cout << "DEGENERATE PLANE" << std::endl;
+
+      face_error = 0;
+      L_face = 0;
+      m_error_depthNormal.insert(cpt * 3, face_error);
+      m_L_depthNormal.insert(L_face, cpt * 3, 0);
+    }
 
     cpt++;
   }

--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
@@ -1055,7 +1055,7 @@ bool vpMbtFaceDepthNormal::planeIsInvalid(const vpHomogeneousMatrix &cMo, double
   computePolygonCentroid(polyPts, centroid);
   centroid.changeFrame(cMo);
   centroid.project();
-  const vpColVector c { centroid.get_X(), centroid.get_Y(), centroid.get_Z() };
+  const vpColVector c({ centroid.get_X(), centroid.get_Y(), centroid.get_Z() });
   const double L = c.frobeniusNorm();
   const double minD = L * cos(maxAngle);
   return fabs(D) <= minD;

--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
@@ -1055,7 +1055,10 @@ bool vpMbtFaceDepthNormal::planeIsInvalid(const vpHomogeneousMatrix &cMo, double
   computePolygonCentroid(polyPts, centroid);
   centroid.changeFrame(cMo);
   centroid.project();
-  const vpColVector c({ centroid.get_X(), centroid.get_Y(), centroid.get_Z() });
+  vpColVector c(3);
+  c[0] = centroid.get_X();
+  c[1] = centroid.get_Y();
+  c[2] = centroid.get_Z();
   const double L = c.frobeniusNorm();
   const double minD = L * cos(maxAngle);
   return fabs(D) <= minD;

--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthNormal.cpp
@@ -729,6 +729,9 @@ void vpMbtFaceDepthNormal::computeDesiredFeaturesRobustFeatures(const std::vecto
   centroid_point[0] /= den;
   centroid_point[1] /= den;
   centroid_point[2] /= den;
+  std::cout << "Centroid = " << centroid_point.t() << std::endl;
+  std::cout << "Desired features = " << desired_features.t() << std::endl;
+
 
   computeNormalVisibility(-desired_features[0], -desired_features[1], -desired_features[2], centroid_point,
                           desired_normal);
@@ -1038,6 +1041,17 @@ void vpMbtFaceDepthNormal::computeNormalVisibility(double nx, double ny, double 
   }
 }
 
+bool vpMbtFaceDepthNormal::planeIsDegenerate(const vpHomogeneousMatrix &cMo)
+{
+  m_planeCamera = m_planeObject;
+  m_planeCamera.changeFrame(cMo);
+  const vpTranslationVector t = cMo.getTranslationVector();
+  // const double D = -(t[0] * m_planeCamera.getA() + t[1] * m_planeCamera.getB() + t[2] * m_planeCamera.getC());
+  const double D = m_planeCamera.getD();
+  std::cout << "D = " << D << std::endl;
+  return fabs(D) < 5e-2;
+}
+
 void vpMbtFaceDepthNormal::computeInteractionMatrix(const vpHomogeneousMatrix &cMo, vpMatrix &L, vpColVector &features)
 {
   L.resize(3, 6, false, false);
@@ -1057,6 +1071,7 @@ void vpMbtFaceDepthNormal::computeInteractionMatrix(const vpHomogeneousMatrix &c
   features[0] = -ux / D;
   features[1] = -uy / D;
   features[2] = -uz / D;
+  std::cout << "Current features = " << features.t() << std::endl;
 
   // L_A
   L[0][0] = ux * ux / D2;

--- a/tutorial/tracking/model-based/generic-rgbd-blender/model/teabox/teabox_depth.xml
+++ b/tutorial/tracking/model-based/generic-rgbd-blender/model/teabox/teabox_depth.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <conf>
   <depth_normal>
-    <feature_estimation_method>2</feature_estimation_method>
+    <feature_estimation_method>0</feature_estimation_method>
     <PCL_plane_estimation>
       <method>2</method>
       <ransac_max_iter>200</ransac_max_iter>

--- a/tutorial/tracking/model-based/generic-rgbd-blender/tutorial-mb-generic-tracker-rgbd-blender.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd-blender/tutorial-mb-generic-tracker-rgbd-blender.cpp
@@ -410,7 +410,7 @@ int main(int argc, const char **argv)
         {
           std::stringstream ss;
           ss << "Features: edges " << tracker.getNbFeaturesEdge() << ", klt " << tracker.getNbFeaturesKlt()
-            << ", depth " << tracker.getNbFeaturesDepthDense();
+            << ", dense depth " << tracker.getNbFeaturesDepthDense() << ", depth normals " << tracker.getNbFeaturesDepthNormal();
           vpDisplay::displayText(I, I.getHeight() - 30, 20, ss.str(), vpColor::red);
         }
       }


### PR DESCRIPTION
This PR adds face rejection mid optimization for the MBT for the normal tracker. This is necessary, as filtering faces before VVS is not stringent enough: some faces that are close to being rejected before optimization have a strong adverse effect on VVS, leading to divergence. This is due to the fact that as the plane gets closer to being parallel to the camera axis and D gets to 0, the interaction matrix blows up.

This can observed in the Blender MBT tutorial, where turning on normals led to divergence before the fix.