### PR TITLE
Add RISC-V architecture in GitHub CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-coverage:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -15,9 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-other-architectures:
+  build-other-architectures-isolated:
     # The host should always be linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }} ${{ matrix.endianness }}
 
     # Run steps on a matrix of different arch/distro combinations
@@ -29,19 +29,22 @@ jobs:
           #   distro: bullseye
           #   target: ARMV6
           - arch: armv7
-            distro: ubuntu22.04
+            distro: ubuntu_latest
             target: ARMV7
             endianness: (Little Endian)
           - arch: aarch64
-            distro: ubuntu22.04 #fedora_latest
-            target: ARMV8
+            distro: ubuntu_latest
+            endianness: (Little Endian)
+          - arch: riscv64
+            distro: ubuntu_latest
+            target: RISC-V
             endianness: (Little Endian)
           - arch: ppc64le
-            distro: ubuntu22.04
+            distro: ubuntu_latest
             target: POWER8
             endianness: (Little Endian)
           - arch: s390x
-            distro: ubuntu22.04
+            distro: ubuntu_latest
             target: Z13
             endianness: (Big Endian)
 
@@ -50,7 +53,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run on arch
-      uses: uraimo/run-on-arch-action@v2.2.1
+      uses: uraimo/run-on-arch-action@v2.7.2
       with:
         githubToken: ${{ github.token }}
         arch: ${{ matrix.arch }}

--- a/.github/workflows/other-arch.yml
+++ b/.github/workflows/other-arch.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-other-architectures:
     # The host should always be linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Build on ${{ matrix.distro }} ${{ matrix.arch }} ${{ matrix.endianness }}
 
     # Run steps on a matrix of 3 arch/distro combinations
@@ -32,14 +32,14 @@ jobs:
           #   distro: ubuntu20.04
           #   target: ARMV7
           - arch: aarch64
-            distro: ubuntu20.04 #fedora_latest
+            distro: ubuntu_latest
             target: ARMV8
             endianness: (Little Endian)
           # - arch: ppc64le
           #   distro: ubuntu20.04
           #   target: POWER8
           - arch: s390x
-            distro: ubuntu20.04
+            distro: ubuntu_latest
             target: Z13
             endianness: (Big Endian)
 
@@ -48,7 +48,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run on arch
-      uses: uraimo/run-on-arch-action@v2.1.1
+      uses: uraimo/run-on-arch-action@v2.7.2
       with:
         githubToken: ${{ github.token }}
         arch: ${{ matrix.arch }}
@@ -60,7 +60,7 @@ jobs:
           apt-get update && apt-get install -y  lsb-release git build-essential cmake
           lsb_release -a
 
-          apt-get update && apt-get install -y libx11-dev libdc1394-22-dev libv4l-dev gfortran liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev
+          apt-get update && apt-get install -y libx11-dev libdc1394-dev libv4l-dev gfortran liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev
           apt-get update && apt-get install -y libssl-dev libusb-1.0-0-dev pkg-config libgtk-3-dev libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev
 
           git clone --depth 1 https://github.com/lagadic/visp-images ${HOME}/visp-images

--- a/.github/workflows/ubuntu-3rdparty.yml
+++ b/.github/workflows/ubuntu-3rdparty.yml
@@ -14,12 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ubuntu-dep-apt:
+  build-ubuntu-dep-apt-3rdparty:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-latest]
         compiler: [ {CC: /usr/bin/gcc-10, CXX: /usr/bin/g++-10}, {CC: /usr/bin/clang, CXX: /usr/bin/clang++} ]
 
     steps:
@@ -35,12 +35,12 @@ jobs:
     - name: Print compiler information
       run: dpkg --list | grep compiler
 
-    - name: Install dependencies for ubuntu 18.04 and 20.04
-      if: matrix.os != 'ubuntu-22.04'
+    - name: Install dependencies for ubuntu 20.04
+      if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-22-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
-    - name: Install dependencies for ubuntu 22.04
-      if: matrix.os == 'ubuntu-22.04'
+    - name: Install dependencies for ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
     - name: Clone camera_localization

--- a/.github/workflows/ubuntu-contrib.yml
+++ b/.github/workflows/ubuntu-contrib.yml
@@ -14,12 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ubuntu-dep-apt:
+  build-ubuntu-dep-apt-contrib:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-latest]
         compiler: [ {CC: /usr/bin/gcc-10, CXX: /usr/bin/g++-10}, {CC: /usr/bin/clang, CXX: /usr/bin/clang++} ]
 
     steps:
@@ -36,11 +36,11 @@ jobs:
       run: dpkg --list | grep compiler
 
     - name: Install dependencies for ubuntu 20.04
-      if: matrix.os != 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-22-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
-    - name: Install dependencies for ubuntu 22.04
-      if: matrix.os == 'ubuntu-22.04'
+    - name: Install dependencies for ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
     - name: Clone visp_contrib

--- a/.github/workflows/ubuntu-dep-apt.yml
+++ b/.github/workflows/ubuntu-dep-apt.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-latest]
         compiler: [ {CC: /usr/bin/gcc-9, CXX: /usr/bin/g++-9}, {CC: /usr/bin/gcc-10, CXX: /usr/bin/g++-10}, {CC: /usr/bin/clang, CXX: /usr/bin/clang++} ]
         standard: [ 98, 11, 17 ]
 
@@ -37,11 +37,11 @@ jobs:
       run: dpkg --list | grep compiler
 
     - name: Install dependencies for ubuntu 20.04
-      if: matrix.os != 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-22-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
-    - name: Install dependencies for ubuntu 22.04
-      if: matrix.os == 'ubuntu-22.04'
+    - name: Install dependencies for ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
     - name: Clone visp-images

--- a/.github/workflows/ubuntu-dep-src.yml
+++ b/.github/workflows/ubuntu-dep-src.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-latest]
 
     steps:
     - name: Checkout repository
@@ -36,14 +36,9 @@ jobs:
       run: lsb_release -a
 
     - name: Install dependencies for ubuntu 20.04
-      if: matrix.os != 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update && sudo apt-get install -y libdc1394-22-dev
-
-    - name: Install dependencies for ubuntu 22.04
-      if: matrix.os == 'ubuntu-22.04'
-      run: |
-        sudo apt-get update && sudo apt-get install -y libdc1394-dev
 
     - name: Install common dependencies for ubuntu
       run: |
@@ -53,8 +48,8 @@ jobs:
         sudo apt-get install -y mesa-common-dev mesa-utils freeglut3-dev libflann-dev libboost-all-dev
         sudo apt-get install -y nlohmann-json3-dev
 
-    - name: Install dependencies for ubuntu 22.04
-      if: matrix.os == 'ubuntu-22.04'
+    - name: Install dependencies for ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-dev libv4l-dev gfortran liblapack-dev libeigen3-dev
         sudo apt-get update && sudo apt-get install -y libssl-dev libusb-1.0-0-dev pkg-config libgtk-3-dev libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev

--- a/.github/workflows/ubuntu-isolated.yml
+++ b/.github/workflows/ubuntu-isolated.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ubuntu-dep-apt:
+  build-ubuntu-dep-apt-isolated:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ubuntu-ustk.yml
+++ b/.github/workflows/ubuntu-ustk.yml
@@ -14,12 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ubuntu-dep-apt:
+  build-ubuntu-dep-apt-ustk:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04, ubuntu-latest]
 
     steps:
     - name: Checkout repository
@@ -35,11 +35,11 @@ jobs:
       run: dpkg --list | grep compiler
 
     - name: Install dependencies for ubuntu 20.04
-      if: matrix.os != 'ubuntu-22.04'
+      if: matrix.os == 'ubuntu-20.04'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-22-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
-    - name: Install dependencies for ubuntu 22.04
-      if: matrix.os == 'ubuntu-22.04'
+    - name: Install dependencies for ubuntu-latest
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install -y libx11-dev libdc1394-dev libv4l-dev liblapack-dev libopenblas-dev libeigen3-dev libopencv-dev nlohmann-json3-dev
 
     - name: Clone visp-images

--- a/.github/workflows/ubuntu-venv.yml
+++ b/.github/workflows/ubuntu-venv.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-ubuntu-dep-apt:
+  build-ubuntu-dep-apt-venv:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/windows-clang.yaml
+++ b/.github/workflows/windows-clang.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-windows-clang:
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/windows-conda.yml
+++ b/.github/workflows/windows-conda.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  visp-conda:
+  build-windows-conda:
     name: ${{ matrix.os }} ${{ matrix.compiler }} - Python ${{ matrix.python-version }} ${{ matrix.build_type }} ${{ matrix.cxx_options }}
     runs-on: ${{ matrix.os }}
 
@@ -85,7 +85,7 @@ jobs:
     name: check-windows-conda
 
     needs:
-    - visp-conda
+    - build-windows-conda
 
     runs-on: Ubuntu-latest
 

--- a/.github/workflows/windows-msvc.yaml
+++ b/.github/workflows/windows-msvc.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-windows-msvc:
     runs-on: ${{ matrix.os }}
     defaults:
       run:


### PR DESCRIPTION
Add RISC-V architecture. There should be more development in the future with this architecture, especially from China due to potentially licensing conflict with Arm, e.g.
- https://github.com/opencv/opencv/wiki/OpenCV-RISC-V

---

Suggestion to use `ubuntu-latest`.

Currently `ubuntu-latest` == `ubuntu-22.04`:
- [Available images](https://github.com/actions/runner-images)

![image](https://github.com/user-attachments/assets/3e3930a6-a5cb-4690-a353-300d10b98bf2)

- [Standard GitHub-hosted runners for public repositories](https://docs.github.com/fr/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

![image](https://github.com/user-attachments/assets/d8f682b1-f3a1-4d4a-a318-78f25234d0cb)
