### PR TITLE
Set input encoding to UTF-8 to fix parsing issues.

### DIFF
--- a/modules/python/generator/visp_python_bindgen/generator.py
+++ b/modules/python/generator/visp_python_bindgen/generator.py
@@ -138,7 +138,7 @@ def generate_module(generate_path: Path, config_path: Path) -> None:
 
   # Step 3: write to main.cpp the call to the submodule binding implementations.
   main_path = generate_path / 'main.cpp'
-  with open(main_path, 'w') as main_file:
+  with open(main_path, 'w', encoding='utf-8') as main_file:
     submodule_fn_declarations = []
     submodule_fn_calls = []
     for submodule in submodules:

--- a/modules/python/generator/visp_python_bindgen/generator_config.py
+++ b/modules/python/generator/visp_python_bindgen/generator_config.py
@@ -69,6 +69,7 @@ class PreprocessorConfig(object):
       args += ['-I', v]
     args += self.other_args
     args.extend(['--passthru-includes', self.passthrough_includes_regex])
+    args.extend(['--output-encoding', 'utf-8'])
     if self.line_directive is not None:
       args.extend(['--line-directive', self.line_directive])
     else:

--- a/modules/python/generator/visp_python_bindgen/header.py
+++ b/modules/python/generator/visp_python_bindgen/header.py
@@ -153,7 +153,7 @@ class HeaderFile():
           # if 'visp3' in matches.group() or 'opencv' in matches.group():
           #   tmp_file_content.append(line)
 
-    with open(tmp_file_path.absolute(), 'w') as tmp_file:
+    with open(tmp_file_path.absolute(), 'w', encoding='utf-8') as tmp_file:
       tmp_file.write(''.join(tmp_file_content))
       tmp_file.flush()
 

--- a/modules/python/generator/visp_python_bindgen/header.py
+++ b/modules/python/generator/visp_python_bindgen/header.py
@@ -143,7 +143,7 @@ class HeaderFile():
       tmp_file_content.append(f'#include <{include}>\n')
 
     # Remove all includes: we only include configuration headers, defined above
-    with open(self.path.absolute(), 'r') as input_header_file:
+    with open(self.path.absolute(), 'r', encoding='utf-8') as input_header_file:
       include_regex = '#include\s*<(.*)>'
       for line in input_header_file.readlines():
         matches = re.search(include_regex, line)
@@ -167,7 +167,7 @@ class HeaderFile():
     preprocessed_header_content = None
 
     # Remove all #defines that could have been left by the preprocessor
-    with open(preprocessor_output_path, 'r') as header_file:
+    with open(preprocessor_output_path, 'r', encoding='utf-8') as header_file:
       preprocessed_header_lines = []
       for line in header_file.readlines():
         if not line.startswith('#define'):

--- a/modules/python/generator/visp_python_bindgen/submodule.py
+++ b/modules/python/generator/visp_python_bindgen/submodule.py
@@ -85,14 +85,14 @@ class Submodule():
         json.dump(default_config, config_file)
       return default_config
     else:
-      with open(path, 'r') as config_file:
+      with open(path, 'r', encoding='utf-8') as config_file:
         config = json.load(config_file)
       for included_config_filename in config.get('config_includes', []):
         included_config_path: Path = path.parent / included_config_filename
         if not included_config_path.exists():
           raise RuntimeError(f'Sub config file {included_config_path} does not exist')
         logging.info(f'Trying to load subconfig file: {included_config_path}')
-        with open(included_config_path, 'r') as additional_config_file:
+        with open(included_config_path, 'r', encoding='utf-8') as additional_config_file:
           additional_config = json.load(additional_config_file)
         self.add_subconfig_file(config, additional_config)
 

--- a/modules/python/generator/visp_python_bindgen/submodule.py
+++ b/modules/python/generator/visp_python_bindgen/submodule.py
@@ -81,7 +81,7 @@ class Submodule():
         'enums': {},
         'config_includes': []
       }
-      with open(path, 'w') as config_file:
+      with open(path, 'w', encoding='utf-8') as config_file:
         json.dump(default_config, config_file)
       return default_config
     else:
@@ -195,7 +195,7 @@ options.disable_enum_members_docstring();
 {bindings}
 }}
 '''
-    with open(self.submodule_file_path, 'w') as submodule_file:
+    with open(self.submodule_file_path, 'w', encoding='utf-8') as submodule_file:
       submodule_file.write(format_str)
 
     logs_path = self.submodule_file_path.parent.parent / 'logs'


### PR DESCRIPTION
This PR tries to  fix #1391, by forcing utf-8 decoding when reading headers before generating the bindings.

The issue can be seen in the generation log:
```
ERROR:root:Traceback (most recent call last):
  File "E:\user\visp-conda-ws\lib\site-packages\visp_python_bindgen\generator.py", line 54, in header_preprocess
    header.preprocess()
  File "E:\user\visp-conda-ws\lib\site-packages\visp_python_bindgen\header.py", line 110, in preprocess
    self.preprocessed_header_str = self.run_preprocessor() # Run preprocessor, get only code that can be compiled with current visp
  File "E:\uservisp-conda-ws\lib\site-packages\visp_python_bindgen\header.py", line 148, in run_preprocessor
    for line in input_header_file.readlines():
UnicodeDecodeError: 'gbk' codec can't decode byte 0x99 in position 4482: illegal multibyte sequence

ERROR:root:<class 'UnicodeDecodeError'>
```
