### PR TITLE
Introduce a workaround to consider nlohmann_json installed on system …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,17 @@ if(USE_PCL)
   set(PCL_REQUIRED_COMPONENTS "common;filters;io;visualization;segmentation")
   # Create cmake vars corresponding to pcl components used by ViSP like VISP_HAVE_PCL_COMMON...
   vp_detect_required_pcl_components(PCL_REQUIRED_COMPONENTS)
+
+  # USE_NLOHMANN_JSON is set to ON if nlohmann_json is installed and found thanks to nlohmann_jsonConfig.cmake.
+  # VTK that is a PCL 3rd party embbed also a built in version of nlohmann_json.
+  # Here we add a specific case to consider the nlohmann version coming from VTK when the system version is not found
+  if(NOT USE_NLOHMANN_JSON)
+    if(VISP_HAVE_NLOHMANN_JSON_FROM_VTK)
+      message(WARNING "json 3rd party is detected and used as a VTK 3rd party which is itself a PCL 3rd party. Thus we enable nlohmann json usage turning USE_NLOHMANN_JSON=ON.")
+      unset(USE_NLOHMANN_JSON)
+      set(USE_NLOHMANN_JSON ON CACHE BOOL "Include nlohmann json support thanks to VTK" FORCE)
+    endif()
+  endif()
 endif()
 
 # ----------------------------------------------------------------------------
@@ -1090,7 +1101,8 @@ VP_SET(VISP_HAVE_THREADS     TRUE IF (BUILD_MODULE_visp_core AND USE_THREADS))
 VP_SET(VISP_HAVE_XML2        TRUE IF (BUILD_MODULE_visp_core AND USE_XML2))
 VP_SET(VISP_HAVE_PCL         TRUE IF (BUILD_MODULE_visp_core AND USE_PCL))
 VP_SET(VISP_HAVE_TENSORRT    TRUE IF (BUILD_MODULE_visp_core AND USE_TENSORRT))
-VP_SET(VISP_HAVE_NLOHMANN_JSON   TRUE IF (BUILD_MODULE_visp_core AND USE_NLOHMANN_JSON))
+VP_SET(VISP_HAVE_NLOHMANN_JSON          TRUE IF (BUILD_MODULE_visp_core AND USE_NLOHMANN_JSON))
+VP_SET(VISP_HAVE_NLOHMANN_JSON_FROM_VTK TRUE IF (BUILD_MODULE_visp_core AND VISP_HAVE_NLOHMANN_JSON_FROM_VTK))
 
 VP_SET(VISP_HAVE_OGRE        TRUE IF (BUILD_MODULE_visp_ar AND USE_OGRE))
 VP_SET(VISP_HAVE_OIS         TRUE IF (BUILD_MODULE_visp_ar AND USE_OIS))
@@ -1844,7 +1856,11 @@ status("  Misc: ")
 status("    Use Clipper (built-in):"  WITH_CLIPPER     THEN "yes (ver ${CLIPPER_VERSION})" ELSE "no")
 status("    Use pugixml (built-in):"  WITH_PUGIXML     THEN "yes (ver ${PUGIXML_VERSION})" ELSE "no")
 status("    Use libxml2:"             USE_XML2         THEN "yes (ver ${XML2_VERSION_STRING})" ELSE "no")
-status("    Use json (nlohmann):"     USE_NLOHMANN_JSON THEN "yes (ver ${nlohmann_json_VERSION})" ELSE "no")
+if(VISP_HAVE_NLOHMANN_JSON_FROM_VTK)
+status("    Use json (nlohmann vtk):"     USE_NLOHMANN_JSON THEN "yes (ver ${VTK_NLOHMANN_JSON_VERSION})" ELSE "no")
+else()
+status("    Use json (nlohmann system):"  USE_NLOHMANN_JSON THEN "yes (ver ${nlohmann_json_VERSION})" ELSE "no")
+endif()
 status("")
 status("  Optimization: ")
 status("    Use OpenMP:"             USE_OPENMP         THEN "yes" ELSE "no")

--- a/ci/docker/ubuntu-dep-src/Dockerfile
+++ b/ci/docker/ubuntu-dep-src/Dockerfile
@@ -91,8 +91,8 @@ RUN cd ${HOME}/visp-ws/3rdparty \
     && git clone --depth 1 --branch $LATEST_TAG $GIT_ADDRESS \
     && cd OpenBLAS \
     && mkdir install \
-    && make -j$(nproc) \
-    && make -j$(nproc) install PREFIX=$(pwd)/install
+    && make -j$(($(nproc) / 2)) \
+    && make -j$(($(nproc) / 2)) install PREFIX=$(pwd)/install
 
 ENV OpenBLAS_HOME=${HOME}/visp-ws/3rdparty/OpenBLAS/install
 
@@ -107,7 +107,7 @@ RUN cd ${HOME}/visp-ws/3rdparty \
     && cmake .. -DVTK_ANDROID_BUILD=OFF -DVTK_BUILD_DOCUMENTATION=OFF -DVTK_BUILD_EXAMPLES=OFF -DVTK_BUILD_EXAMPLES=OFF \
       -DCMAKE_BUILD_TYPE=Release -DVTK_GROUP_ENABLE_Imaging=DONT_WANT -DVTK_GROUP_ENABLE_MPI=DONT_WANT \
       -DVTK_GROUP_ENABLE_Web=DONT_WANT -DCMAKE_INSTALL_PREFIX=${HOME}/visp-ws/3rdparty/VTK/build/install \
-    && make -j$(nproc) install
+    && make -j$(($(nproc) / 2)) install
 
 ENV VTK_DIR=${HOME}/visp-ws/3rdparty/VTK/build/install
 
@@ -121,7 +121,7 @@ RUN cd ${HOME}/visp-ws/3rdparty \
     && mkdir install \
     && cmake .. -DBUILD_EXAMPLES=OFF -DBUILD_PERF_TESTS=OFF -DBUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${HOME}/visp-ws/3rdparty/opencv/build/install \
-    && make -j$(nproc) install
+    && make -j$(($(nproc) / 2)) install
 
 ENV OpenCV_DIR=${HOME}/visp-ws/3rdparty/opencv/build/install
 
@@ -135,7 +135,7 @@ RUN cd ${HOME}/visp-ws/3rdparty \
     && mkdir install \
     && cmake .. -DBUILD_EXAMPLES=OFF -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${HOME}/visp-ws/3rdparty/librealsense/build/install \
-    && make -j$(nproc) install
+    && make -j$(($(nproc) / 2)) install
 
 ENV REALSENSE2_DIR=${HOME}/visp-ws/3rdparty/librealsense/build/install
 
@@ -149,7 +149,7 @@ RUN cd ${HOME}/visp-ws/3rdparty \
     && mkdir install \
     && cmake .. -DBUILD_tools=OFF -DBUILD_global_tests=OFF -DPCL_DISABLE_GPU_TESTS=ON -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PREFIX=${HOME}/visp-ws/3rdparty/pcl/build/install \
-    && make -j10 install
+    && make -j$(($(nproc) / 3)) install
 
 ENV PCL_DIR=${HOME}/visp-ws/3rdparty/pcl/build/install
 
@@ -160,7 +160,7 @@ RUN mkdir -p ${HOME}/visp-ws \
     && echo "export VISP_WS=${HOME}/visp-ws" >> ${HOME}/.bashrc \
     && echo "export VISP_INPUT_IMAGE_PATH=${HOME}/visp-ws/visp-images" >> ${HOME}/.bashrc
 
-# Download ViSP fork
+# Download ViSP
 RUN cd ${HOME}/visp-ws \
     && git clone ${GIT_URL} ${GIT_BRANCH_CMD}
 
@@ -169,7 +169,7 @@ RUN cd ${HOME}/visp-ws \
     && mkdir visp-build \
     && cd visp-build \
     && cmake ../visp -DCMAKE_INSTALL_PREFIX=${HOME}/visp-ws/visp-build/install \
-    && make -j$(nproc) developer_scripts \
-    && make -j$(nproc) install
+    && make -j$(($(nproc) / 2)) developer_scripts \
+    && make -j$(($(nproc) / 2)) install
 
 CMD ["/bin/bash"]

--- a/ci/docker/ubuntu-dep-src/README.md
+++ b/ci/docker/ubuntu-dep-src/README.md
@@ -1,0 +1,73 @@
+# Docker dedicated to check compatibility with 3rd party last releases
+
+## Build docker image from Dockerfile
+
+- We suppose here that you already installed docker.
+If this is not the case, follow instructions provided for [Ubuntu](https://visp-doc.inria.fr/doxygen/visp-daily/tutorial-install-docker.html#install_docker_engine_ubuntu) or [MacOS](https://visp-doc.inria.fr/doxygen/visp-daily/tutorial-install-docker.html#install_docker_engine_mac).
+
+- Get ViSP source code
+  ```
+  $ cd $VISP_WS/
+  $ git clone https://github.com/lagadic/visp
+  ```
+
+- Build docker image from Dockerfile running the following:
+  ```
+  $ cd $VISP_WS/visp/ci/docker/ubuntu-dep-src
+  $ docker build -t vispci/vispci:ubuntu-dep-src .
+  ```
+  The version of ViSP that is considered is by default the master branch from github official repo in
+  https://github.com/lagadic/visp
+
+  There is also the possibility to build visp from a specific repo and branch using `GIT_URL` and `GIT_BRANCH_NAME`
+  args, like
+  ```
+  $ cd $VISP_WS/visp/ci/docker/ubuntu-dep-src
+  $ docker build -t vispci/vispci:ubuntu-dep-src --build-arg GIT_URL=https://github.com/lagadic/visp --build-arg GIT_BRANCH_NAME=master .
+  ```
+
+## Start the container
+
+### On Ubuntu host
+
+- On your computer running Ubuntu, allow access to the X11 server
+  ```
+  $ xhost +local:docker
+  non-network local connections being added to access control list
+  ```
+- Run your Docker container. The following command connects to the ubuntu-dep-src Docker container.
+  ```
+  $ docker run --rm -it --network=host --privileged \
+            --env=DISPLAY \
+            --env=QT_X11_NO_MITSHM=1 \
+            --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw \
+            --volume=/dev:/dev \
+            vispci/vispci:ubuntu-dep-src
+  vispci@6c8d67579659:~$ pwd
+  /home/vispci
+  ```
+
+### On MacOS host
+
+- Get your MacOS computer IP address
+  ```
+  $ IP=$(/usr/sbin/ipconfig getifaddr en0)
+  $ echo $IP
+  $ 192.168.1.18
+  ```
+- Allow connections from MacOS to XQuartz
+  ```
+  $ xhost + "$IP"
+  192.168.1.18 being added to access control list
+  ```
+- Run your Docker container. The following command connects to the ubuntu-dep-src Docker container.
+  ```
+  $ docker run --rm -it --network=host --privileged \
+            --env=DISPLAY="${IP}:0" \
+            --env=QT_X11_NO_MITSHM=1 \
+            --volume=/tmp/.X11-unix:/tmp/.X11-unix:rw \
+            --volume=/dev:/dev \
+            vispci/vispci:ubuntu-dep-src
+  vispci@6c8d67579659:~$ pwd
+  /home/vispci
+  ```

--- a/cmake/PCLTools.cmake
+++ b/cmake/PCLTools.cmake
@@ -257,6 +257,21 @@ macro(vp_find_pcl pcl_libraries pcl_deps_include_dirs pcl_deps_libraries)
       endif()
     endforeach()
 
+    find_path(VTK_NLOHMANN_JSON_INCLUDE_DIR vtknlohmannjson/include/vtknlohmann/json.hpp
+      PATHS
+        ${PCL_VTK_IMPORTED_INCS}
+    )
+    mark_as_advanced(VTK_NLOHMANN_JSON_INCLUDE_DIR)
+    if(VTK_NLOHMANN_JSON_INCLUDE_DIR)
+      vp_parse_header("${VTK_NLOHMANN_JSON_INCLUDE_DIR}/vtknlohmannjson/include/vtknlohmann/json.hpp" NLOHMANN_JSON_VERSION_LINES NLOHMANN_JSON_VERSION_MAJOR NLOHMANN_JSON_VERSION_MINOR NLOHMANN_JSON_VERSION_PATCH)
+      set(VTK_NLOHMANN_JSON_VERSION "${NLOHMANN_JSON_VERSION_MAJOR}.${NLOHMANN_JSON_VERSION_MINOR}.${NLOHMANN_JSON_VERSION_PATCH}")
+      list(APPEND ${pcl_deps_include_dirs} "${VTK_NLOHMANN_JSON_INCLUDE_DIR}/vtknlohmannjson/include")
+      set(VISP_HAVE_NLOHMANN_JSON_FROM_VTK TRUE)
+    else()
+      set(VISP_HAVE_NLOHMANN_JSON_FROM_VTK FALSE)
+      set(VTK_NLOHMANN_JSON_VERSION "n/a")
+    endif()
+
     # On win10 + msvc 15 2017 with pcl 1.9.1 opengl32.lib needed by vtkRenderingOpenGL-8.1-gd.lib is not found
     # Here we explicitly add opengl
     if(OPENGL_LIBRARIES)

--- a/cmake/VISPUtils.cmake
+++ b/cmake/VISPUtils.cmake
@@ -1248,6 +1248,14 @@ function(status text)
 endfunction()
 
 # read set of version defines from the header file
+# This macro allows to get defines values from a header file.
+# For example if the header.hpp file contains
+#   #define LIB_VERSION_MAJOR 1
+#   #define LIB_VERSION_MINOR 2
+#   #define LIB_VERSION_PATCH 3
+# to retrieve the values of these defines and compose a string version you may use
+#   vp_parse_header("header.hpp" LIB_VERSION_LINES LIB_VERSION_MAJOR LIB_VERSION_MINOR LIB_VERSION_PATCH)
+#   set(LIB_VERSION "${LIB_VERSION_MAJOR}.${LIB_VERSION_MINOR}.${LIB_VERSION_PATCH}")
 macro(vp_parse_header FILENAME FILE_VAR)
   set(vars_regex "")
   set(__parent_scope OFF)
@@ -1289,6 +1297,9 @@ macro(vp_parse_header FILENAME FILE_VAR)
 endmacro()
 
 # read single version define from the header file
+# Example to detect the version in header.hpp file that contains:
+#   #define MyLIB_VERSION_STR "1.2.3"
+# use vp_parse_header2(MyLIB "header.hpp" LIB_VERSION_STR)
 macro(vp_parse_header2 LIBNAME HDR_PATH VARNAME)
   vp_clear_vars(${LIBNAME}_VERSION_MAJOR
                 ${LIBNAME}_VERSION_MAJOR
@@ -1300,7 +1311,6 @@ macro(vp_parse_header2 LIBNAME HDR_PATH VARNAME)
   if(EXISTS "${HDR_PATH}")
     file(STRINGS "${HDR_PATH}" ${LIBNAME}_H REGEX "^#define[ \t]+${VARNAME}[ \t]+\"[^\"]*\".*$" LIMIT_COUNT 1)
   endif()
-
   if(${LIBNAME}_H)
     string(REGEX REPLACE "^.*[ \t]${VARNAME}[ \t]+\"([0-9]+).*$" "\\1" ${LIBNAME}_VERSION_MAJOR "${${LIBNAME}_H}")
     string(REGEX REPLACE "^.*[ \t]${VARNAME}[ \t]+\"[0-9]+\\.([0-9]+).*$" "\\1" ${LIBNAME}_VERSION_MINOR  "${${LIBNAME}_H}")

--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -1,6 +1,6 @@
 /*
  * ViSP, open source Visual Servoing Platform software.
- * Copyright (C) 2005 - 2023 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -524,15 +524,19 @@ namespace vp = VISP_NAMESPACE_NAME;
 // Defined if we want to use openmp
 #cmakedefine VISP_HAVE_OPENMP
 
-// Defined if nlohmann json parser is found
+// Defined if nlohmann json parser is found (either system or coming from VTK)
 #cmakedefine VISP_HAVE_NLOHMANN_JSON
 
-// Workaround for issue https://github.com/lagadic/visp/issues/1485
-#if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_PCL_VISUALIZATION)
-#include <vtkVersion.h>
-#if VTK_VERSION_NUMBER_QUICK >= VTK_VERSION_CHECK(9, 2, 0)
-#include <pcl/visualization/pcl_visualizer.h>
-#endif
+// Defined if nlohmann json parser is found in PCL thanks to VTK 3rd party
+#cmakedefine VISP_HAVE_NLOHMANN_JSON_FROM_VTK
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+#  if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_NLOHMANN_JSON_FROM_VTK)
+#    include <vtk_nlohmannjson.h>
+#    define VISP_NLOHMANN_JSON(x) <vtknlohmannjson/include/vtknlohmann/x>
+#  else
+#    define VISP_NLOHMANN_JSON(x) <nlohmann/x>
+#  endif
 #endif
 
 // Define c++ standard values also available in __cplusplus when gcc is used

--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -527,6 +527,14 @@ namespace vp = VISP_NAMESPACE_NAME;
 // Defined if nlohmann json parser is found
 #cmakedefine VISP_HAVE_NLOHMANN_JSON
 
+// Workaround for issue https://github.com/lagadic/visp/issues/1485
+#if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_PCL_VISUALIZATION)
+#include <vtkVersion.h>
+#if VTK_VERSION_NUMBER_QUICK >= VTK_VERSION_CHECK(9, 2, 0)
+#include <pcl/visualization/pcl_visualizer.h>
+#endif
+#endif
+
 // Define c++ standard values also available in __cplusplus when gcc is used
 #define VISP_CXX_STANDARD_98 ${VISP_CXX_STANDARD_98}
 #define VISP_CXX_STANDARD_11 ${VISP_CXX_STANDARD_11}

--- a/doc/tutorial/misc/tutorial-json.dox
+++ b/doc/tutorial/misc/tutorial-json.dox
@@ -29,7 +29,7 @@ Much of this section is a repeat of the library's documentation, available <a ta
 
 To use JSON in your code you should first include the relevant header:
 \code{.cpp}
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; // For convenience
 \endcode
 
@@ -62,7 +62,7 @@ void to_json(json& j, const YourType& t);
 \endcode
 These functions must be defined in the same scope namespace as YourType and must be accessible everywhere YourType is used. It is thus common to define it in the header where YourType is defined.
 \code
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 
 class YourType {
 public:

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -272,7 +272,7 @@ if(USE_OPENMP)
   endforeach()
 endif()
 
-if(USE_NLOHMANN_JSON)
+if(USE_NLOHMANN_JSON AND NOT VISP_HAVE_NLOHMANN_JSON_FROM_VTK)
   get_target_property(_inc_dirs "nlohmann_json::nlohmann_json" INTERFACE_INCLUDE_DIRECTORIES)
   list(APPEND opt_incs ${_inc_dirs})
 endif()

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -47,7 +47,7 @@
 #include <visp3/core/vpException.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE

--- a/modules/core/include/visp3/core/vpCameraParameters.h
+++ b/modules/core/include/visp3/core/vpCameraParameters.h
@@ -49,7 +49,7 @@
 #include <visp3/core/vpMatrix.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include<nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE
@@ -451,7 +451,7 @@ private:
 };
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include<nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 NLOHMANN_JSON_SERIALIZE_ENUM(vpCameraParameters::vpCameraParametersProjType, {
     {vpCameraParameters::perspectiveProjWithoutDistortion, "perspectiveWithoutDistortion"},
     {vpCameraParameters::perspectiveProjWithDistortion, "perspectiveWithDistortion"},

--- a/modules/core/include/visp3/core/vpCannyEdgeDetection.h
+++ b/modules/core/include/visp3/core/vpCannyEdgeDetection.h
@@ -42,7 +42,7 @@
 
 // 3rd parties include
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -43,7 +43,7 @@
 #include <visp3/core/vpConfig.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 BEGIN_VISP_NAMESPACE
 class vpMatrix;

--- a/modules/core/include/visp3/core/vpHomogeneousMatrix.h
+++ b/modules/core/include/visp3/core/vpHomogeneousMatrix.h
@@ -63,7 +63,7 @@ END_VISP_NAMESPACE
 #include <visp3/core/vpPoseVector.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE

--- a/modules/core/include/visp3/core/vpJsonParsing.h
+++ b/modules/core/include/visp3/core/vpJsonParsing.h
@@ -37,7 +37,7 @@
 #include <visp3/core/vpConfig.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 
 BEGIN_VISP_NAMESPACE
 /*!

--- a/modules/core/include/visp3/core/vpPolygon3D.h
+++ b/modules/core/include/visp3/core/vpPolygon3D.h
@@ -219,7 +219,7 @@ public:
 END_VISP_NAMESPACE
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #include <visp3/core/vpJsonParsing.h>
 NLOHMANN_JSON_SERIALIZE_ENUM(VISP_NAMESPACE_ADDRESSING vpPolygon3D::vpPolygon3DClippingType, {
     {VISP_NAMESPACE_ADDRESSING vpPolygon3D::NO_CLIPPING, "none"},

--- a/modules/core/include/visp3/core/vpPoseVector.h
+++ b/modules/core/include/visp3/core/vpPoseVector.h
@@ -331,7 +331,7 @@ public:
 };
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 inline void to_json(nlohmann::json &j, const vpPoseVector &r)
 {
   r.convert_to_json(j);

--- a/modules/core/test/camera/catchJsonCamera.cpp
+++ b/modules/core/test/camera/catchJsonCamera.cpp
@@ -41,7 +41,7 @@
 #include <visp3/core/vpIoTools.h>
 
 #if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_CATCH2)
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 #include <catch_amalgamated.hpp>

--- a/modules/core/test/math/catchJsonArrayConversion.cpp
+++ b/modules/core/test/math/catchJsonArrayConversion.cpp
@@ -45,7 +45,7 @@
 #include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpIoTools.h>
 
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 #include <catch_amalgamated.hpp>

--- a/modules/detection/include/visp3/detection/vpDetectorDNNOpenCV.h
+++ b/modules/detection/include/visp3/detection/vpDetectorDNNOpenCV.h
@@ -54,7 +54,7 @@
 #include <optional>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE

--- a/modules/gui/src/pointcloud/vpPclViewer.cpp
+++ b/modules/gui/src/pointcloud/vpPclViewer.cpp
@@ -37,7 +37,7 @@
 #include <visp3/core/vpConfig.h>
 #if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_PCL_IO) && defined(VISP_HAVE_THREADS)
 // PCL
-#include<pcl/io/pcd_io.h>
+#include <pcl/io/pcd_io.h>
 
 // ViSP
 #include <visp3/gui/vpPclViewer.h>

--- a/modules/gui/src/pointcloud/vpPclViewer.cpp
+++ b/modules/gui/src/pointcloud/vpPclViewer.cpp
@@ -36,13 +36,13 @@
 
 #include <visp3/core/vpConfig.h>
 #if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_PCL_IO) && defined(VISP_HAVE_THREADS)
-// PCL
-#include <pcl/io/pcd_io.h>
-
 // ViSP
 #include <visp3/gui/vpPclViewer.h>
 #include <visp3/gui/vpColorBlindFriendlyPalette.h>
 #include <visp3/core/vpIoTools.h>
+
+// PCL
+#include <pcl/io/pcd_io.h>
 
 BEGIN_VISP_NAMESPACE
 const std::vector<vpColorBlindFriendlyPalette::Palette> gcolor = { vpColorBlindFriendlyPalette::Palette::Green, vpColorBlindFriendlyPalette::Palette::Vermillon,vpColorBlindFriendlyPalette::Palette::Blue,

--- a/modules/imgproc/include/visp3/imgproc/vpCircleHoughTransform.h
+++ b/modules/imgproc/include/visp3/imgproc/vpCircleHoughTransform.h
@@ -44,7 +44,7 @@
 
 // 3rd parties inclue
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_17)

--- a/modules/io/CMakeLists.txt
+++ b/modules/io/CMakeLists.txt
@@ -62,7 +62,7 @@ if(WITH_STBIMAGE)
   include_directories(${STBIMAGE_INCLUDE_DIRS})
 endif()
 
-if(USE_NLOHMANN_JSON)
+if(USE_NLOHMANN_JSON AND NOT VISP_HAVE_NLOHMANN_JSON_FROM_VTK)
   get_target_property(_inc_dirs "nlohmann_json::nlohmann_json" INTERFACE_INCLUDE_DIRECTORIES)
   list(APPEND opt_incs ${_inc_dirs})
 endif()

--- a/modules/io/include/visp3/io/vpJsonArgumentParser.h
+++ b/modules/io/include/visp3/io/vpJsonArgumentParser.h
@@ -37,7 +37,7 @@
 #include <visp3/core/vpConfig.h>
 
 #if defined(VISP_HAVE_NLOHMANN_JSON)
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #include <visp3/core/vpException.h>
 #include <sstream>
 

--- a/modules/io/test/catchJsonArgumentParser.cpp
+++ b/modules/io/test/catchJsonArgumentParser.cpp
@@ -41,7 +41,7 @@
 #include <visp3/io/vpJsonArgumentParser.h>
 
 #if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_CATCH2)
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 #include <catch_amalgamated.hpp>

--- a/modules/tracker/dnn/include/visp3/dnn_tracker/vpMegaPose.h
+++ b/modules/tracker/dnn/include/visp3/dnn_tracker/vpMegaPose.h
@@ -49,7 +49,7 @@
 #include <visp3/core/vpRGBa.h>
 #include <visp3/core/vpRect.h>
 
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 
 BEGIN_VISP_NAMESPACE
 /**

--- a/modules/tracker/mbt/CMakeLists.txt
+++ b/modules/tracker/mbt/CMakeLists.txt
@@ -116,7 +116,7 @@ if(USE_PCL)
   list(APPEND opt_libs ${PCL_DEPS_LIBRARIES})
 endif()
 
-if(USE_NLOHMANN_JSON)
+if(USE_NLOHMANN_JSON AND NOT VISP_HAVE_NLOHMANN_JSON_FROM_VTK)
   get_target_property(_inc_dirs "nlohmann_json::nlohmann_json" INTERFACE_INCLUDE_DIRECTORIES)
   list(APPEND opt_incs ${_inc_dirs})
 endif()

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -46,7 +46,7 @@
 #include <visp3/mbt/vpMbKltTracker.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json_fwd.hpp>
+#include VISP_NLOHMANN_JSON(json_fwd.hpp)
 #include <visp3/core/vpJsonParsing.h>
 #endif
 

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbGenericTracker.h
@@ -36,19 +36,15 @@
  *\brief Generic model-based tracker
  */
 
-#ifndef _vpMbGenericTracker_h_
-#define _vpMbGenericTracker_h_
+#ifndef VP_MB_GENERIC_TRACKER_H
+#define VP_MB_GENERIC_TRACKER_H
 
 #include <visp3/core/vpConfig.h>
 #include <visp3/mbt/vpMbDepthDenseTracker.h>
 #include <visp3/mbt/vpMbDepthNormalTracker.h>
 #include <visp3/mbt/vpMbEdgeTracker.h>
 #include <visp3/mbt/vpMbKltTracker.h>
-
-#ifdef VISP_HAVE_NLOHMANN_JSON
-#include VISP_NLOHMANN_JSON(json_fwd.hpp)
 #include <visp3/core/vpJsonParsing.h>
-#endif
 
 BEGIN_VISP_NAMESPACE
 /*!

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtFaceDepthNormal.h
@@ -324,7 +324,7 @@ protected:
 END_VISP_NAMESPACE
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include<nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_PCL_COMMON) && defined(VISP_HAVE_PCL_SEGMENTATION) && defined(VISP_HAVE_PCL_FILTERS)
 NLOHMANN_JSON_SERIALIZE_ENUM(VISP_NAMESPACE_ADDRESSING vpMbtFaceDepthNormal::vpFeatureEstimationType, {
     {VISP_NAMESPACE_ADDRESSING vpMbtFaceDepthNormal::ROBUST_FEATURE_ESTIMATION, "robust"},

--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -42,7 +42,7 @@
 #include <visp3/mbt/vpMbtXmlGenericParser.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 #endif
 

--- a/modules/tracker/mbt/test/generic-with-dataset/catchMbtJsonSettings.cpp
+++ b/modules/tracker/mbt/test/generic-with-dataset/catchMbtJsonSettings.cpp
@@ -41,7 +41,7 @@
 #include <visp3/mbt/vpMbGenericTracker.h>
 
 #if defined(VISP_HAVE_NLOHMANN_JSON) && defined(VISP_HAVE_CATCH2)
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 #include <catch_amalgamated.hpp>

--- a/modules/tracker/me/include/visp3/me/vpMe.h
+++ b/modules/tracker/me/include/visp3/me/vpMe.h
@@ -45,7 +45,7 @@
 #include <visp3/core/vpMatrix.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE

--- a/modules/tracker/me/test/catchJsonMe.cpp
+++ b/modules/tracker/me/test/catchJsonMe.cpp
@@ -45,7 +45,7 @@
 #include <visp3/core/vpIoTools.h>
 #include <visp3/me/vpMe.h>
 
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 #include <catch_amalgamated.hpp>

--- a/tutorial/detection/dnn/tutorial-dnn-object-detection-live.cpp
+++ b/tutorial/detection/dnn/tutorial-dnn-object-detection-live.cpp
@@ -11,7 +11,7 @@
 #endif
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 #endif
 

--- a/tutorial/tracking/dnn/tutorial-megapose-live-single-object-tracking.cpp
+++ b/tutorial/tracking/dnn/tutorial-megapose-live-single-object-tracking.cpp
@@ -20,7 +20,7 @@
 #include <visp3/dnn_tracker/vpMegaPoseTracker.h>
 #include <visp3/io/vpJsonArgumentParser.h>
 
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 
 #include <opencv2/videoio.hpp>
 
@@ -193,7 +193,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(DetectionMethod, {
   {UNKNOWN, nullptr}, // Default value if the json string is not in "current", "desired" or "mean"
   {CLICK, "click"},
   {DNN, "dnn"} }
-);
+  );
 
 
 int main(int argc, const char *argv[])

--- a/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense-json.cpp
+++ b/tutorial/tracking/model-based/generic-rgbd/tutorial-mb-generic-tracker-rgbd-realsense-json.cpp
@@ -12,7 +12,7 @@
 #include <visp3/mbt/vpMbGenericTracker.h>
 #include <visp3/sensor/vpRealSense2.h>
 
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 

--- a/tutorial/visual-servo/ibvs/tutorial-ibvs-4pts-json.cpp
+++ b/tutorial/visual-servo/ibvs/tutorial-ibvs-4pts-json.cpp
@@ -8,7 +8,7 @@
 #include <visp3/vs/vpServo.h>
 
 
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 using json = nlohmann::json; //! json namespace shortcut
 
 #if defined(ENABLE_VISP_NAMESPACE)


### PR DESCRIPTION
…and nlohmann_json used as a built in 3rdparty by VTK > 9.2.0 when PCL is enabled. Fixes #1485.