### PR TITLE
Add short support with vpImageConvert::convert() cv::Mat to vpImage<float>

### DIFF
--- a/modules/core/src/image/vpImageConvert_opencv.cpp
+++ b/modules/core/src/image/vpImageConvert_opencv.cpp
@@ -283,9 +283,9 @@ void vpImageConvert::convert(const cv::Mat &src, vpImage<unsigned char> &dest, b
 }
 
 /*!
- * Converts cv::Mat CV_32FC1 format to ViSP vpImage<float>.
+ * Converts cv::Mat CV_32FC1 / CV_16SC1 format to ViSP vpImage<float>.
  *
- * \param[in] src : OpenCV image in CV_32FC1 format.
+ * \param[in] src : OpenCV image in CV_32FC1 / CV_16SC1 format.
  * \param[out] dest : ViSP image in float format.
  * \param[in] flip : When true during conversion flip image vertically.
  */
@@ -296,7 +296,7 @@ void vpImageConvert::convert(const cv::Mat &src, vpImage<float> &dest, bool flip
   unsigned int destCols = dest.getCols();
 
   if (src.type() == CV_32FC1) {
-    for (unsigned int i = 0; i < destRows; ++i)
+    for (unsigned int i = 0; i < destRows; ++i) {
       for (unsigned int j = 0; j < destCols; ++j) {
         if (flip) {
           dest[dest.getRows() - i - 1][j] = src.at<float>(static_cast<int>(i), static_cast<int>(j));
@@ -305,6 +305,19 @@ void vpImageConvert::convert(const cv::Mat &src, vpImage<float> &dest, bool flip
           dest[i][j] = src.at<float>(static_cast<int>(i), static_cast<int>(j));
         }
       }
+    }
+  }
+  else if (src.type() == CV_16SC1) {
+    for (unsigned int i = 0; i < destRows; ++i) {
+      for (unsigned int j = 0; j < destCols; ++j) {
+        if (flip) {
+          dest[dest.getRows() - i - 1][j] = src.at<short>(static_cast<int>(i), static_cast<int>(j));
+        }
+        else {
+          dest[i][j] = src.at<short>(static_cast<int>(i), static_cast<int>(j));
+        }
+      }
+    }
   }
   else {
     throw vpException(vpException::badValue, "cv::Mat type is not supported!");


### PR DESCRIPTION
Without this quick fix, the following code cannot run:

```c++
#include <iostream>
#include <visp3/core/vpConfig.h>
#include <visp3/core/vpIoTools.h>
#include <visp3/core/vpCannyEdgeDetection.h>
#include <visp3/io/vpImageIo.h>

int main(int argc, const char **argv)
{
  std::cout << "getBuildInformation()\n" << vpIoTools::getBuildInformation() << std::endl;

  int gaussianKernelSize = 3;
  float gaussianStdev = 0.5f;
  int apertureSize = 3;
  vpImageFilter::vpCannyFilteringAndGradientType filteringType = vpImageFilter::CANNY_GBLUR_SOBEL_FILTERING;
  // Canny parameters
  float lowerThresh = -1.;
  float upperThresh = -1.;
  float lowerThreshRatio = 0.6f;
  float upperThreshRatio = 1.5f;
  vpImageFilter::vpCannyBackendType backend = vpImageFilter::vpCannyBackendType::CANNY_OPENCV_BACKEND;
  // vpImageFilter::vpCannyBackendType backend = vpImageFilter::vpCannyBackendType::CANNY_VISP_BACKEND;

  vpCannyEdgeDetection cannyDetector(gaussianKernelSize, gaussianStdev, apertureSize,
                                    lowerThresh, upperThresh, lowerThreshRatio, upperThreshRatio,
                                    filteringType);

  vpImage<unsigned char> I_gray, I_canny_visp;
  vpImageIo::read(I_gray, "/tmp/Klimt.png");
  std::cout << "I_gray=" << I_gray.getWidth() << "x" << I_gray.getHeight() << std::endl;

  vpImageFilter::canny(I_gray, I_canny_visp, gaussianKernelSize, lowerThresh, upperThresh, apertureSize,
        gaussianStdev, lowerThreshRatio, upperThreshRatio, false,
        backend,
        vpImageFilter::CANNY_GBLUR_SOBEL_FILTERING);

  vpImage<float> dIx, dIy;
  std::cout << "vpImageFilter::computePartialDerivatives" << std::endl;
  vpImageFilter::computePartialDerivatives(I_gray, dIx, dIy, true, true, true, gaussianKernelSize, gaussianStdev,
      apertureSize, filteringType, backend);

  // Set the gradients of the vpCannyEdgeDetection
  std::cout << "cannyDetector.setGradients(dIx, dIy)" << std::endl;
  cannyDetector.setGradients(dIx, dIy);
  std::cout << "cannyDetector.detect(I_gray)" << std::endl;
  I_canny_visp = cannyDetector.detect(I_gray);

  vpImageIo::write(I_canny_visp, "/tmp/I_res.png");

  return EXIT_SUCCESS;
}
```

---

This is because https://github.com/lagadic/visp/blob/a65eebc2fffc3814889fbe40c3b1a8ee182d1bd4/modules/core/src/image/vpImageFilter.cpp#L599 returns a `CV_16S` mat but there is no conversion from `CV_16S` to `vpImage<float>` needed here https://github.com/lagadic/visp/blob/a65eebc2fffc3814889fbe40c3b1a8ee182d1bd4/modules/core/include/visp3/core/vpImageFilter.h#L169

Computing Sobel with `CV_32F` datatype would produce an issue here https://github.com/lagadic/visp/blob/a65eebc2fffc3814889fbe40c3b1a8ee182d1bd4/modules/core/src/image/vpImageFilter_canny.cpp#L461 since `cv::Canny` expects `CV_16S` type.

---

Maybe extend `void vpImageConvert::convert(const cv::Mat &src, vpImage<float> &dest, bool flip)` to not only float type but also `CV_8U`, `CV_8S`, etc?

Another possibility should be to compute the image gradient with `CV_32F` precision and add this conversion before calling `cv::Canny()`:

```c++
    cv::Mat cv_dx_2 = cv_dx, cv_dy_2 = cv_dy;
    if (cv_dx.type() == CV_32F) {
      double min_val = 0, max_val = 0;
      cv::minMaxLoc(cv_dx, &min_val, &max_val);
      double alpha = 65535 / (max_val - min_val);
      double beta = -alpha * min_val;
      cv_dx.convertTo(cv_dx_2, CV_16S, alpha, beta);
    }
    if (cv_dy.type() == CV_32F) {
      double min_val = 0, max_val = 0;
      cv::minMaxLoc(cv_dy, &min_val, &max_val);
      double alpha = 65535 / (max_val - min_val);
      double beta = -alpha * min_val;
      cv_dx.convertTo(cv_dy_2, CV_16S, alpha, beta);
    }
```