### PR TITLE
Fix broken conda linux CI

### DIFF
--- a/.github/workflows/conda/environment_linux.yml
+++ b/.github/workflows/conda/environment_linux.yml
@@ -8,6 +8,7 @@ dependencies:
   - xorg-libx11
   - xorg-libxfixes
   - mesa-libegl-cos7-x86_64
+  - icu
   - libxml2
   - libdc1394 >=2.2.6
   - librealsense


### PR DESCRIPTION
It seems that last libxml2 conda package release used is a variant without `icu` library, whereas it actually needs `icu`.