### PR TITLE
Fixing other architectures CI failure due to change of API

### DIFF
--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run on arch
-      uses: uraimo/run-on-arch-action@v2.7.2
+      uses: uraimo/run-on-arch-action@v2
       # See issue https://github.com/uraimo/run-on-arch-action/issues/155 for the explanation on the weird use of the arch and distro
       # that resulted in error
       # ERROR: failed to solve: ${arch}/ubuntu:latest: failed to resolve source metadata for docker.io/${arch}/ubuntu:latest: no match for platform in manifest: not found

--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -29,22 +29,22 @@ jobs:
           #   distro: bullseye
           #   target: ARMV6
           - arch: armv7
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             target: ARMV7
             endianness: (Little Endian)
           - arch: aarch64
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             endianness: (Little Endian)
           - arch: riscv64
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             target: RISC-V
             endianness: (Little Endian)
           - arch: ppc64le
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             target: POWER8
             endianness: (Little Endian)
           - arch: s390x
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             target: Z13
             endianness: (Big Endian)
 
@@ -54,10 +54,14 @@ jobs:
 
     - name: Run on arch
       uses: uraimo/run-on-arch-action@v2.7.2
+      # See issue https://github.com/uraimo/run-on-arch-action/issues/155 for the explanation on the weird use of the arch and distro
+      # that resulted in error
+      # ERROR: failed to solve: ${arch}/ubuntu:latest: failed to resolve source metadata for docker.io/${arch}/ubuntu:latest: no match for platform in manifest: not found
       with:
         githubToken: ${{ github.token }}
-        arch: ${{ matrix.arch }}
-        distro: ${{ matrix.distro }}
+        arch: none
+        distro: none
+        base_image: "--platform=linux/${{ matrix.arch }} ${{ matrix.distro }}"
 
         run: |
           lscpu

--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -29,7 +29,7 @@ jobs:
           #   distro: bullseye
           #   target: ARMV6
           - arch: armv7
-            distro: ubuntu:latest
+            distro: ubuntu22.04
             target: ARMV7
             endianness: (Little Endian)
           - arch: aarch64

--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -28,10 +28,10 @@ jobs:
           # - arch: armv6
           #   distro: bullseye
           #   target: ARMV6
-          - arch: armv7
-            distro: ubuntu22.04
-            target: ARMV7
-            endianness: (Little Endian)
+          #- arch: armv7
+          #  distro: ubuntu:latest
+          #  target: ARMV7
+          #  endianness: (Little Endian)
           - arch: aarch64
             distro: ubuntu:latest
             endianness: (Little Endian)

--- a/.github/workflows/other-arch.yml
+++ b/.github/workflows/other-arch.yml
@@ -32,14 +32,14 @@ jobs:
           #   distro: ubuntu20.04
           #   target: ARMV7
           - arch: aarch64
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             target: ARMV8
             endianness: (Little Endian)
           # - arch: ppc64le
           #   distro: ubuntu20.04
           #   target: POWER8
           - arch: s390x
-            distro: ubuntu_latest
+            distro: ubuntu:latest
             target: Z13
             endianness: (Big Endian)
 
@@ -51,8 +51,9 @@ jobs:
       uses: uraimo/run-on-arch-action@v2.7.2
       with:
         githubToken: ${{ github.token }}
-        arch: ${{ matrix.arch }}
-        distro: ${{ matrix.distro }}
+        arch: none
+        distro: none
+        base_image: "--platform=linux/${{ matrix.arch }} ${{ matrix.distro }}"
 
         run: |
           lscpu

--- a/.github/workflows/other-arch.yml
+++ b/.github/workflows/other-arch.yml
@@ -48,7 +48,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run on arch
-      uses: uraimo/run-on-arch-action@v2.7.2
+      uses: uraimo/run-on-arch-action@v2
+      # See issue https://github.com/uraimo/run-on-arch-action/issues/155 for the explanation on the weird use of the arch and distro
+      # that resulted in error
+      # ERROR: failed to solve: ${arch}/ubuntu:latest: failed to resolve source metadata for docker.io/${arch}/ubuntu:latest: no match for platform in manifest: not found
       with:
         githubToken: ${{ github.token }}
         arch: none


### PR DESCRIPTION
The other architectures CI threw the following error:

`ERROR: failed to solve: ${arch}/ubuntu:latest: failed to resolve source metadata for docker.io/${arch}/ubuntu:latest: no match for platform in manifest: not found`

This seems to be due to a change of API.
Trying a workaround.