### PR TITLE
[FIX] Fixed the memorization of the voting points for the CHT

### DIFF
--- a/modules/imgproc/include/visp3/imgproc/vpCircleHoughTransform.h
+++ b/modules/imgproc/include/visp3/imgproc/vpCircleHoughTransform.h
@@ -1042,9 +1042,38 @@ public:
     }
   }
 
+  /*!
+   * \brief Set the mask that permits to ignore some pixels when performing the circle detection.
+   *
+   * \param[in] mask A boolean image where pixels set to true means that the pixel
+   * must be considered and set to false means that the pixel must be ignored.
+   */
   inline void setMask(const vpImage<bool> &mask)
   {
     mp_mask = &mask;
+  }
+
+  /*!
+   * \brief Set the mask that permits to ignore some pixels when performing the circle detection.
+   *
+   * \param[in] mask Either a boolean image where pixels set to true means that the pixel
+   * must be considered and set to false means that the pixel must be ignored, or nullptr
+   * to deactivate the mask.
+   */
+  inline void setMask(const vpImage<bool> *mask)
+  {
+    mp_mask = mask;
+  }
+
+  /*!
+   * \brief Permits to either activate or deactivate the memorization
+   * of the points that voted for the detected circles.
+   *
+   * \param[in] record True to activate the feature, false to deactivate it.
+   */
+  inline void setRecordVotingPoints(const bool &record)
+  {
+    m_algoParams.m_recordVotingPoints = record;
   }
   //@}
 
@@ -1178,6 +1207,25 @@ public:
   inline std::vector<unsigned int> getDetectionsVotes() const
   {
     return m_finalCircleVotes;
+  }
+
+  /*!
+   * Get the points that voted for the detections that are outputed by vpCircleHoughTransform::detect().
+   */
+  inline std::vector<std::vector<std::pair<unsigned int, unsigned int> > > getDetectionsVotingPoints() const
+  {
+    if (!m_algoParams.m_recordVotingPoints) {
+      throw(vpException(vpException::fatalError, "Asking voting points when it was not asked to remember them."));
+    }
+    return m_finalCirclesVotingPoints;
+  }
+
+  /*!
+   * Returns true if it was asked to record the points that voted for the detections.
+   */
+  inline bool getRecordVotingPoints() const
+  {
+    return m_algoParams.getRecordVotingPoints();
   }
   //@}
 

--- a/modules/imgproc/src/vpCircleHoughTransform_circles.cpp
+++ b/modules/imgproc/src/vpCircleHoughTransform_circles.cpp
@@ -139,7 +139,6 @@ vpCircleHoughTransform::computeCircleCandidates()
   nbBins = std::max<int>(static_cast<int>(1), nbBins); // Avoid having 0 bins, which causes segfault
   std::vector<float> radiusAccumList; // Radius accumulator for each center candidates.
   std::vector<float> radiusActualValueList; // Vector that contains the actual distance between the edge points and the center candidates.
-  std::vector<std::vector<std::pair<unsigned int, unsigned int> > > votingPoints(nbBins); // Vectors that contain the points voting for each radius bin
 
   float rmin2 = m_algoParams.m_minRadius * m_algoParams.m_minRadius;
   float rmax2 = m_algoParams.m_maxRadius * m_algoParams.m_maxRadius;
@@ -153,6 +152,7 @@ vpCircleHoughTransform::computeCircleCandidates()
   data.m_recordVotingPoints = m_algoParams.m_recordVotingPoints;
 
   for (size_t i = 0; i < nbCenterCandidates; ++i) {
+    std::vector<std::vector<std::pair<unsigned int, unsigned int> > > votingPoints(nbBins); // Vectors that contain the points voting for each radius bin
     std::pair<float, float> centerCandidate = m_centerCandidatesList[i];
     // Initialize the radius accumulator of the candidate with 0s
     radiusAccumList.clear();

--- a/modules/imgproc/src/vpCircleHoughTransform_common.cpp
+++ b/modules/imgproc/src/vpCircleHoughTransform_common.cpp
@@ -268,8 +268,11 @@ vpCircleHoughTransform::detect(const vpImage<unsigned char> &I)
   m_circleCandidates.clear();
   m_circleCandidatesVotes.clear();
   m_circleCandidatesProbabilities.clear();
+  m_circleCandidatesVotingPoints.clear();
   m_finalCircles.clear();
   m_finalCircleVotes.clear();
+  m_finalCirclesProbabilities.clear();
+  m_finalCirclesVotingPoints.clear();
 
   // Ensuring that the difference between the max and min radii is big enough to take into account
   // the pixelization of the image


### PR DESCRIPTION
The voting points vector was not reinitialized when evaluating a new center, it remembered the voting points for the same radii but other circles