### PR TITLE
Add xorg-xorgproto dep on linux

### DIFF
--- a/.github/workflows/conda/environment_linux.yml
+++ b/.github/workflows/conda/environment_linux.yml
@@ -7,6 +7,7 @@ dependencies:
   - ninja
   - xorg-libx11
   - xorg-libxfixes
+  - xorg-xorgproto
   - mesa-libegl-cos7-x86_64
   - icu
   - libxml2


### PR DESCRIPTION
Fixes broken Conda-based CI on linux, most probably due to an update of a conda package.