### PR TITLE
Test for deleted construction-copyable / copyable code

### DIFF
--- a/modules/core/include/visp3/core/vpMoment.h
+++ b/modules/core/include/visp3/core/vpMoment.h
@@ -131,6 +131,11 @@ protected:
   //  }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMoment(const vpMoment &) = delete; // non construction-copyable
+  vpMoment &operator=(const vpMoment &) = delete; // non copyable
+#endif
+
 public:
   vpMoment();
 

--- a/modules/core/include/visp3/core/vpMomentCommon.h
+++ b/modules/core/include/visp3/core/vpMomentCommon.h
@@ -126,6 +126,11 @@ private:
   //  }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMomentCommon(const vpMomentCommon &) = delete; // non construction-copyable
+  vpMomentCommon &operator=(const vpMomentCommon &) = delete; // non copyable
+#endif
+
 public:
   vpMomentCommon(double dstSurface, const std::vector<double> &ref, double refAlpha, double dstZ = 1.0,
                  bool flg_sxsyfromnormalized = false);

--- a/modules/core/include/visp3/core/vpMutex.h
+++ b/modules/core/include/visp3/core/vpMutex.h
@@ -182,6 +182,10 @@ public:
     //    }
     //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+    vpScopedLock &operator=(const vpScopedLock &) = delete; // non copyable
+#endif
+
   public:
     //! Constructor that locks the mutex.
     vpScopedLock(vpMutex &mutex) : _mutex(mutex) { _mutex.lock(); }

--- a/modules/sensor/include/visp3/sensor/vpV4l2Grabber.h
+++ b/modules/sensor/include/visp3/sensor/vpV4l2Grabber.h
@@ -211,6 +211,11 @@ public:
   //  }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpV4l2Grabber(const vpV4l2Grabber &) = delete; // non construction-copyable
+  vpV4l2Grabber &operator=(const vpV4l2Grabber &) = delete; // non copyable
+#endif
+
 public:
   vpV4l2Grabber();
   VP_EXPLICIT vpV4l2Grabber(bool verbose);

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCircle.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCircle.h
@@ -121,6 +121,11 @@ public:
   //    }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMbtDistanceCircle(const vpMbtDistanceCircle &) = delete; // non construction-copyable
+  vpMbtDistanceCircle &operator=(const vpMbtDistanceCircle &) = delete; // non copyable
+#endif
+
 public:
   vpMbtDistanceCircle();
   virtual ~vpMbtDistanceCircle();

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCylinder.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceCylinder.h
@@ -136,6 +136,11 @@ public:
   //    }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMbtDistanceCylinder(const vpMbtDistanceCylinder &) = delete; // non construction-copyable
+  vpMbtDistanceCylinder &operator=(const vpMbtDistanceCylinder &) = delete; // non copyable
+#endif
+
 public:
   vpMbtDistanceCylinder();
   virtual ~vpMbtDistanceCylinder();

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltCylinder.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltCylinder.h
@@ -129,6 +129,11 @@ private:
   //    }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMbtDistanceKltCylinder(const vpMbtDistanceKltCylinder &) = delete; // non construction-copyable
+  vpMbtDistanceKltCylinder &operator=(const vpMbtDistanceKltCylinder &) = delete; // non copyable
+#endif
+
 public:
   vpMbtDistanceKltCylinder();
   virtual ~vpMbtDistanceKltCylinder();

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltPoints.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceKltPoints.h
@@ -130,6 +130,11 @@ private:
   //    }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMbtDistanceKltPoints(const vpMbtDistanceKltPoints &) = delete; // non construction-copyable
+  vpMbtDistanceKltPoints &operator=(const vpMbtDistanceKltPoints &) = delete; // non copyable
+#endif
+
 public:
   vpMbtDistanceKltPoints();
   virtual ~vpMbtDistanceKltPoints();

--- a/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceLine.h
+++ b/modules/tracker/mbt/include/visp3/mbt/vpMbtDistanceLine.h
@@ -130,6 +130,11 @@ public:
   //    }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpMbtDistanceLine(const vpMbtDistanceLine &) = delete; // non construction-copyable
+  vpMbtDistanceLine &operator=(const vpMbtDistanceLine &) = delete; // non copyable
+#endif
+
 public:
   vpMbtDistanceLine();
   virtual ~vpMbtDistanceLine();

--- a/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMI.h
+++ b/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMI.h
@@ -142,6 +142,11 @@ protected:
   //    }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpTemplateTrackerMI(const vpTemplateTrackerMI &) = delete; // non construction-copyable
+  vpTemplateTrackerMI &operator=(const vpTemplateTrackerMI &) = delete; // non copyable
+#endif
+
 public:
   //! Default constructor.
   vpTemplateTrackerMI()

--- a/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIESM.h
+++ b/modules/tracker/tt_mi/include/visp3/tt_mi/vpTemplateTrackerMIESM.h
@@ -96,6 +96,11 @@ protected:
   //  }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpTemplateTrackerMIESM(const vpTemplateTrackerMIESM &) = delete; // non construction-copyable
+  vpTemplateTrackerMIESM &operator=(const vpTemplateTrackerMIESM &) = delete; // non copyable
+#endif
+
 public:
   //! Default constructor.
   vpTemplateTrackerMIESM()

--- a/modules/visual_features/include/visp3/visual_features/vpFeatureMoment.h
+++ b/modules/visual_features/include/visp3/visual_features/vpFeatureMoment.h
@@ -188,6 +188,11 @@ protected:
   //  }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpFeatureMoment(const vpFeatureMoment &) = delete; // non construction-copyable
+  vpFeatureMoment &operator=(const vpFeatureMoment &) = delete; // non copyable
+#endif
+
 public:
   /*!
    * Initializes the feature with information about the database of moment

--- a/modules/vs/include/visp3/vs/vpServo.h
+++ b/modules/vs/include/visp3/vs/vpServo.h
@@ -273,6 +273,11 @@ public:
   //  }
   //#endif
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpServo(const vpServo &) = delete; // non construction-copyable
+  vpServo &operator=(const vpServo &) = delete; // non copyable
+#endif
+
 public:
   /*!
    * Default constructor that initializes the following settings:


### PR DESCRIPTION
Some classes seem to have deleted "copy constructor" / "copy operator", see: https://github.com/lagadic/visp/commit/afc5bc9d9b5b913f687a9f95e57ff1267b1a9a03

The following code build correctly but will segfault at runtime:

```c++
#include <visp3/core/vpConfig.h>
#include <visp3/core/vpIoTools.h>
#include <visp3/mbt/vpMbGenericTracker.h>

static std::string ipath = vpIoTools::getViSPImagesDataPath();

int main()
{
  const std::string cao_filename =
    vpIoTools::createFilePath(ipath, "mbt/cube_and_cylinder.cao");
  vpMbGenericTracker tracker;
  const bool verbose = true;
  tracker.loadModel(cao_filename, verbose);

  std::list<vpMbtDistanceCylinder *> cylinders;
  tracker.getLcylinder(cylinders);
  std::cout << "cylinders=" << cylinders.size() << std::endl;

  // vpMbtDistanceCylinder cylinder(*(cylinders.front()));
  for (auto cylinder : cylinders) {
    vpMbtDistanceCylinder cy = *cylinder;
    // cy.buildFrom(*cylinder->p1, *cylinder->p2, cylinder->radius);
    // vpMbtDistanceCylinder cy2 = cy;
    std::cout << cylinder->p1->get_oX() << std::endl;
  }

  return EXIT_SUCCESS;
}
```

This pull request tries to see if the library still builds with `=delete` copy constructor / operator.

---

If possible, adding "non construction-copyable" / "non copyable" function member for these specific classes would produce build failure and would directly warn the user these classes cannot be copied:

```c++
#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
  vpMbtDistanceCylinder(const vpMbtDistanceCylinder &) = delete; // non construction-copyable
  vpMbtDistanceCylinder &operator=(const vpMbtDistanceCylinder &) = delete; // non copyable
#endif
```