### PR TITLE
Update CAO model loading to avoid "Exception: basic_ios::clear: iostream error"

### DIFF
--- a/cmake/VISPUtils.cmake
+++ b/cmake/VISPUtils.cmake
@@ -1849,7 +1849,11 @@ function(vp_find_dataset found location version major minor patch)
 
   # Check version
   if(_found)
-    if(EXISTS "${_location}/circle/circle.png")
+    if(EXISTS "${_location}/mbt-cao/circle_model.cao")
+      set(_major "3")
+      set(_minor "7")
+      set(_patch "0")
+    elseif(EXISTS "${_location}/circle/circle.png")
       set(_major "3")
       set(_minor "6")
       set(_patch "0")


### PR DESCRIPTION
https://github.com/lagadic/visp-images/pull/26

Avoid exception when loading a CAO model with no new line at the end of the file:
```
Cannot get the number of circles. Defaulting to zero.
Exception: basic_ios::clear: iostream error
```

Remove pointers usage and add some sanity checks.