### PR TITLE
Fix warning: defaulted and deleted functions only available with -std=c++11 or -std=gnu++11

### DIFF
--- a/modules/core/include/visp3/core/vpRGBa.h
+++ b/modules/core/include/visp3/core/vpRGBa.h
@@ -126,9 +126,13 @@ public:
   }
 
   /*!
-    Copy constructor.
-  */
+   * Copy constructor.
+   */
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
   inline vpRGBa(const vpRGBa &v) = default;
+#else
+  inline vpRGBa(const vpRGBa &v) : R(v.R), G(v.G), B(v.B), A(v.A) { }
+#endif
 
   /*!
     Create a RGBa value from a 4 dimension column vector.
@@ -148,9 +152,11 @@ public:
   vpRGBa &operator=(const unsigned char &v);
   vpRGBa &operator=(const unsigned int &v);
   vpRGBa &operator=(const int &v);
-  vpRGBa &operator=(const vpRGBa &v) = default;
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
   vpRGBa &operator=(vpRGBa &&v) = default;
+  vpRGBa &operator=(const vpRGBa &v) = default;
+#else
+  vpRGBa &operator=(const vpRGBa &v);
 #endif
   vpRGBa &operator=(const vpColVector &v);
   bool operator==(const vpRGBa &v) const;

--- a/modules/core/include/visp3/core/vpRGBf.h
+++ b/modules/core/include/visp3/core/vpRGBf.h
@@ -105,10 +105,13 @@ public:
   }
 
   /*!
-    Copy constructor.
-  */
+   * Copy constructor.
+   */
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
   inline vpRGBf(const vpRGBf &v) = default;
-
+#else
+  inline vpRGBf(const vpRGBf &v) : R(v.R), G(v.G), B(v.B) { }
+#endif
   /*!
     Create a RGB value from a 3 dimensional column vector.
 
@@ -120,9 +123,11 @@ public:
 
   vpRGBf &operator=(float v);
   vpRGBf &operator=(int v);
-  vpRGBf &operator=(const vpRGBf &v) = default;
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+  vpRGBf &operator=(const vpRGBf &v) = default;
   vpRGBf &operator=(vpRGBf &&v) = default;
+#else
+  vpRGBf &operator=(const vpRGBf &v);
 #endif
   vpRGBf &operator=(const vpColVector &v);
   bool operator==(const vpRGBf &v) const;

--- a/modules/core/src/image/vpRGBa.cpp
+++ b/modules/core/src/image/vpRGBa.cpp
@@ -86,6 +86,20 @@ vpRGBa &vpRGBa::operator=(const int &v)
   return *this;
 }
 
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
+/*!
+ * Copy operator.
+ */
+vpRGBa &vpRGBa::operator=(const vpRGBa &v)
+{
+  this->R = v.R;
+  this->G = v.G;
+  this->B = v.B;
+  this->A = v.A;
+  return *this;
+}
+#endif
+
 /*!
   Cast a vpColVector in a vpRGBa
 

--- a/modules/core/src/image/vpRGBf.cpp
+++ b/modules/core/src/image/vpRGBf.cpp
@@ -69,6 +69,19 @@ vpRGBf &vpRGBf::operator=(int v)
   return *this;
 }
 
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
+/*!
+ * Copy operator.
+ */
+vpRGBf &vpRGBf::operator=(const vpRGBf &v)
+{
+  this->R = v.R;
+  this->G = v.G;
+  this->B = v.B;
+  return *this;
+}
+#endif
+
 /*!
   Cast a vpColVector in a vpRGBf
 


### PR DESCRIPTION
Warning detected on centos 7.2 ci