### PR TITLE
Fix warnings "has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]"

### DIFF
--- a/modules/core/include/visp3/core/vpImageMorphology.h
+++ b/modules/core/include/visp3/core/vpImageMorphology.h
@@ -143,6 +143,10 @@ private:
   public:
     vpPixelOperation() { }
 
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+    virtual ~vpPixelOperation() = default;
+#endif
+
     virtual T operator()(const T &, const T &) = 0;
   };
 

--- a/modules/core/include/visp3/core/vpUKSigmaDrawerAbstract.h
+++ b/modules/core/include/visp3/core/vpUKSigmaDrawerAbstract.h
@@ -61,6 +61,8 @@ public:
 
   inline vpUKSigmaDrawerAbstract(const unsigned int &n) : m_n(n) { }
 
+  virtual ~vpUKSigmaDrawerAbstract() = default;
+
   /**
    * \brief Draw the sigma points according to the current mean and covariance of the state
    * of the Unscented Kalman filter.


### PR DESCRIPTION
When using `-Weffc++` flag, see https://github.com/lagadic/visp/commit/afc5bc9d9b5b913f687a9f95e57ff1267b1a9a03
there are some `"warning: ‘class vpUKSigmaDrawerAbstract’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]"` warnings.

This PR fixes warnings detected with `-Wnon-virtual-dtor` flag.