### PR TITLE
Check image dimension in vpImageFilter::gaussianBlur function

### DIFF
--- a/modules/core/src/image/vpImageFilter.cpp
+++ b/modules/core/src/image/vpImageFilter.cpp
@@ -320,6 +320,13 @@ void vpImageFilter::gaussianBlur<double, double>(const vpImage<double> &I, vpIma
 void vpImageFilter::gaussianBlur(const vpImage<vpRGBa> &I, vpImage<vpRGBa> &GI, unsigned int size, double sigma, bool normalize,
                                  const vpImage<bool> *p_mask)
 {
+  if (size-1 > I.getWidth() || size-1 > I.getHeight()) {
+    std::ostringstream oss;
+    oss << "Image size (" << I.getWidth() << "x" << I.getHeight() << ") is too small for the Gaussian kernel ("
+      << "size=" << size << "), min size is " << (size-1);
+    throw vpException(vpException::dimensionError, oss.str());
+  }
+
   double *fg = new double[(size + 1) / 2];
   vpImageFilter::getGaussianKernel(fg, size, sigma, normalize);
   vpImage<vpRGBa> GIx;


### PR DESCRIPTION
To avoid segfault when the image is too small, e.g.:
- `exe --sigma 2 --height 18 --width 11`

```c++
#include <visp3/core/vpImage.h>
#include <visp3/io/vpImageIo.h>
#include <visp3/core/vpImageFilter.h>
#include <visp3/core/vpGaussianFilter.h>

int main(int argc, const char *argv[])
{
  float sigma = 1.0f;
  unsigned int width = 17, height = 11;

  for (int i = 1; i < argc; i++) {
    if (std::string(argv[i]) == "--sigma" && i + 1 < argc) {
      sigma = std::atof(argv[++i]);
    }
    else if (std::string(argv[i]) == "--width" && i + 1 < argc) {
      width = std::atoi(argv[++i]);
    }
    else if (std::string(argv[i]) == "--height" && i + 1 < argc) {
      height = std::atoi(argv[++i]);
    }
    else if (std::string(argv[i]) == "--help" || std::string(argv[i]) == "-h") {
      std::cout << "\nUsage: " << argv[0]
        << " [--sigma <Gaussian sigma value>]"
        << " [--width <image width>] [--height <image height>]"
        << " [--help] [-h]\n"
        << std::endl;
      return EXIT_SUCCESS;
    }
  }

  const unsigned int kernelSize = 6*sigma + 1;
  std::cout << "Gaussian sigma: " << sigma << std::endl;
  std::cout << "Gaussian kernel size: " << kernelSize << std::endl;
  std::cout << "Image size: " << width << "x" << height << std::endl;

  vpImage<unsigned char> I(height, width, 0), I_blur;
  for (unsigned int i = 0; i < I.getHeight(); i++) {
    for (unsigned int j = 0; j < I.getWidth(); j++) {
      I[i][j] = static_cast<unsigned char>(i*I.getWidth() + j);
    }
  }

  vpImage<vpRGBa> I_color, I_color_blur;
  vpImageConvert::convert(I, I_color);

  vpImageFilter::gaussianBlur(I_color, I_color_blur, kernelSize, 0);

  return EXIT_SUCCESS;
}
```