### PR TITLE
Fix deleted functions

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -88,12 +88,15 @@ ViSP 3.x.x (Version in development)
     . [#1337] The pose of the automatic data generation pipeline from blenderproc seems wrong
     . [#1341] SVD computation fails with Lapack when m < n
     . [#1370] encountered compilation errors while building the ViSP library
+    . [#1404] Compilation error when no GUI library is available
     . [#1424] Unable to detect Yarp 3.9.0
     . [#1485] Build issue around nlohmann_json usage with VTK 9.2.0 or more recent version used as an embedded
               3rdparty by PCL
     . [#1487] Segfault with vpCannyEdgeDetection with a certain image
     . [#1494] Memory management issue in vpArray2D::resize()
     . [#1495] vpMeLine is unable to seek extremities
+    . [#1519] Dataset not detected when tests are disabled
+    . [#1521] Build issues with OpenCV 5.0.0
 ----------------------------------------------
 ViSP 3.6.0 (released September 22, 2023)
   - Contributors:

--- a/modules/visual_features/include/visp3/visual_features/vpFeatureMoment.h
+++ b/modules/visual_features/include/visp3/visual_features/vpFeatureMoment.h
@@ -187,10 +187,11 @@ protected:
   //    implemented!"); return *this;
   //  }
   //#endif
-
+#if !defined(VISP_MOMENTS_COMBINE_MATRICES)
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
   vpFeatureMoment(const vpFeatureMoment &) = delete; // non construction-copyable
   vpFeatureMoment &operator=(const vpFeatureMoment &) = delete; // non copyable
+#endif
 #endif
 
 public:


### PR DESCRIPTION
This PR follows changes introduced in PR #1530 that breaks build on Fedora 25 when `ENABLE_MOMENTS_COMBINE_MATRICES` is set to `ON` during CMake configuration 