### PR TITLE
Fix build issue detected on windows ci

### DIFF
--- a/modules/tracker/klt/include/visp3/klt/vpKltOpencv.h
+++ b/modules/tracker/klt/include/visp3/klt/vpKltOpencv.h
@@ -54,7 +54,7 @@
 #include <opencv2/video/tracking.hpp>
 
 #if defined(VISP_HAVE_NLOHMANN_JSON)
-#include <nlohmann/json.hpp>
+#include VISP_NLOHMANN_JSON(json.hpp)
 #endif
 
 BEGIN_VISP_NAMESPACE


### PR DESCRIPTION
modules\tracker\klt\include\visp3/klt/vpKltOpencv.h(57,10): fatal  error C1083: Impossible d'ouvrir le fichier include : 'nlohmann/json.hpp' : No such file or directory