### PR TITLE
Make vpPanda3DFrameworkManager destructor public

### DIFF
--- a/modules/ar/include/visp3/ar/vpPanda3DFrameworkManager.h
+++ b/modules/ar/include/visp3/ar/vpPanda3DFrameworkManager.h
@@ -59,12 +59,9 @@ private:
   vpPanda3DFrameworkManager() : m_frameworkIsOpen(false)
   { }
 
+public:
   virtual ~vpPanda3DFrameworkManager()
   { }
-
-
-public:
-
   void initFramework();
 
   void exit();


### PR DESCRIPTION
Allows to fix Python bindings build when Panda3D is used 
```
x86_64-conda-linux-gnu/include/c++/11.2.0/bits/shared_ptr_base.h:600:15: error: 'virtual vpPanda3DFrameworkManager::~vpPanda3DFrameworkManager()' is private within this context
```