### PR TITLE
[Feat] Array view

### DIFF
--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -259,6 +259,7 @@ public:
 #if ((__cplusplus >= 201103L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))) // Check if cxx11 or higher
   vpArray2D(vpArray2D<Type> &&A) noexcept
   {
+    std::cout << "IN vp array move constructor" << std::endl;
     rowNum = A.rowNum;
     colNum = A.colNum;
     rowPtrs = A.rowPtrs;
@@ -421,15 +422,16 @@ public:
   */
   void resize(unsigned int nrows, unsigned int ncols, bool flagNullify = true, bool recopy_ = true)
   {
-    if (!isMemoryOwner) {
-      throw vpException(vpException::badValue, "Cannot resize an array that is a view of another array");
-    }
+
     if ((nrows == rowNum) && (ncols == colNum)) {
       if (flagNullify && (this->data != nullptr)) {
         memset(this->data, 0, this->dsize * sizeof(Type));
       }
     }
     else {
+      if (!isMemoryOwner) {
+        throw vpException(vpException::badValue, "Cannot resize an array that is a view of another array");
+      }
       bool recopy = (!flagNullify) && recopy_; // priority to flagNullify
       bool colcond = (ncols != this->colNum) && (this->colNum > 0) && (ncols > 0);
       const bool recopyNeeded = colcond && ((!flagNullify) || recopy);
@@ -607,6 +609,7 @@ public:
 #if ((__cplusplus >= 201103L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))) // Check if cxx11 or higher
   vpArray2D<Type> &operator=(vpArray2D<Type> &&other) noexcept
   {
+    std::cout << "In Array operator=" << std::endl;
     if (this != &other) {
       if (isMemoryOwner && data) {
         free(data);

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -332,14 +332,15 @@ public:
     v.isRowPtrsOwner = false;
     return v;
   }
+
   /**
-   * @brief Create an array view of a raw data.
+   * \brief Create an array view of a raw data pointer.
    * This data is not owned by the resulting array and should be freed after the array is destroyed (not before)
    *
-   * @param data Pointer to the raw data
-   * @param numRows Number of rows
-   * @param numCols Number of columns
-   * @return vpArray2D<Type>
+   * \param data Pointer to the raw data
+   * \param numRows Number of rows
+   * \param numCols Number of columns
+   * \return vpArray2D<Type>
    */
   static vpArray2D<Type> view(Type *data, unsigned int numRows, unsigned int numCols)
   {
@@ -348,13 +349,32 @@ public:
     return v;
   }
 
+  /**
+   * \brief Create an array view of a raw data pointer.
+   * After this function has been called, the array \ref data can be modified through the view \ref v.
+   * This data is not owned by the resulting array and should be freed after the array is destroyed (not before).
+   *
+   * \param v The resulting view array
+   * \param data Pointer to the raw data
+   * \param numRows Number of rows
+   * \param numCols Number of columns
+   */
   static void view(vpArray2D<Type> &v, Type *data, unsigned int numRows, unsigned int numCols)
   {
     v.rowNum = numRows;
     v.colNum = numCols;
     v.dsize = numRows * numCols;
+
+    if ((v.isMemoryOwner == true) && (v.data != nullptr)) {
+      free(v.data);
+    }
     v.data = data;
     v.isMemoryOwner = false;
+
+    if ((v.isRowPtrsOwner == true) && (v.rowPtrs != nullptr)) {
+      free(v.rowPtrs);
+    }
+
     v.isRowPtrsOwner = true;
     v.rowPtrs = reinterpret_cast<Type **>(malloc(v.rowNum * sizeof(Type *)));
     for (unsigned int i = 0; i < v.rowNum; ++i) {
@@ -421,7 +441,6 @@ public:
   */
   void resize(unsigned int nrows, unsigned int ncols, bool flagNullify = true, bool recopy_ = true)
   {
-
     if ((nrows == rowNum) && (ncols == colNum)) {
       if (flagNullify && (this->data != nullptr)) {
         memset(this->data, 0, this->dsize * sizeof(Type));

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -259,7 +259,6 @@ public:
 #if ((__cplusplus >= 201103L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))) // Check if cxx11 or higher
   vpArray2D(vpArray2D<Type> &&A) noexcept
   {
-    std::cout << "IN vp array move constructor" << std::endl;
     rowNum = A.rowNum;
     colNum = A.colNum;
     rowPtrs = A.rowPtrs;
@@ -609,7 +608,6 @@ public:
 #if ((__cplusplus >= 201103L) || (defined(_MSVC_LANG) && (_MSVC_LANG >= 201103L))) // Check if cxx11 or higher
   vpArray2D<Type> &operator=(vpArray2D<Type> &&other) noexcept
   {
-    std::cout << "In Array operator=" << std::endl;
     if (this != &other) {
       if (isMemoryOwner && data) {
         free(data);

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -332,10 +332,24 @@ public:
     v.isRowPtrsOwner = false;
     return v;
   }
-
+  /**
+   * @brief Create an array view of a raw data.
+   * This data is not owned by the resulting array and should be freed after the array is destroyed (not before)
+   *
+   * @param data Pointer to the raw data
+   * @param numRows Number of rows
+   * @param numCols Number of columns
+   * @return vpArray2D<Type>
+   */
   static vpArray2D<Type> view(Type *data, unsigned int numRows, unsigned int numCols)
   {
     vpArray2D<Type> v;
+    vpArray2D<Type>::view(v, data, numRows, numCols);
+    return v;
+  }
+
+  static void view(vpArray2D<Type> &v, Type *data, unsigned int numRows, unsigned int numCols)
+  {
     v.rowNum = numRows;
     v.colNum = numCols;
     v.dsize = numRows * numCols;
@@ -346,8 +360,8 @@ public:
     for (unsigned int i = 0; i < v.rowNum; ++i) {
       v.rowPtrs[i] = data + i * v.colNum;
     }
-    return v;
   }
+
 
 
   /*!

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -289,6 +289,9 @@ public:
    */
   void clear()
   {
+    if (!isMemoryOwner) {
+      throw vpException(vpException::fatalError, "Cannot clear a vector view");
+    }
     if (data != nullptr) {
       free(data);
       data = nullptr;

--- a/modules/core/include/visp3/core/vpColVector.h
+++ b/modules/core/include/visp3/core/vpColVector.h
@@ -283,6 +283,8 @@ public:
   }
 #endif
 
+  static vpColVector view(double *data, unsigned int rows);
+
   /*!
    * Removes all elements from the vector (which are destroyed),
    * leaving the container with a size of 0.

--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -224,6 +224,8 @@ public:
   VP_EXPLICIT vpMatrix(const vpRowVector &v);
   VP_EXPLICIT vpMatrix(const vpTranslationVector &t);
 
+  static vpMatrix view(double *data, unsigned int rows, unsigned int cols);
+
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
   vpMatrix(vpMatrix &&A);
   VP_EXPLICIT vpMatrix(const std::initializer_list<double> &list);

--- a/modules/core/include/visp3/core/vpRowVector.h
+++ b/modules/core/include/visp3/core/vpRowVector.h
@@ -143,6 +143,8 @@ public:
   VP_EXPLICIT vpRowVector(const std::initializer_list<double> &list) : vpArray2D<double>(list) { }
 #endif
 
+  static vpRowVector view(double *data, unsigned int cols);
+
   /*!
     Removes all elements from the vector (which are destroyed),
     leaving the container with a size of 0.

--- a/modules/core/include/visp3/core/vpRowVector.h
+++ b/modules/core/include/visp3/core/vpRowVector.h
@@ -149,6 +149,9 @@ public:
   */
   void clear()
   {
+    if (!isMemoryOwner) {
+      throw vpException(vpException::fatalError, "Cannot clear a vector view");
+    }
     if (data != nullptr) {
       free(data);
       data = nullptr;

--- a/modules/core/src/math/matrix/vpColVector.cpp
+++ b/modules/core/src/math/matrix/vpColVector.cpp
@@ -266,6 +266,8 @@ vpColVector::vpColVector(vpColVector &&v) : vpArray2D<double>()
   rowPtrs = v.rowPtrs;
   dsize = v.dsize;
   data = v.data;
+  isMemoryOwner = v.isMemoryOwner;
+  isRowPtrsOwner = v.isRowPtrsOwner;
 
   v.rowNum = 0;
   v.colNum = 0;
@@ -497,6 +499,23 @@ vpColVector &vpColVector::operator=(vpColVector &&other)
   }
 
   return *this;
+}
+
+/**
+ * @brief Create a column vector view of a raw data array.
+ * The view can modify the contents of the raw data array,
+ * but may not resize it and does not own it: the memory is not released by the vector
+ * and it should be freed by the user after the view is released.
+ *
+ * @param data the raw data
+ * @param rows Number of rows
+ * @return the column vector view
+ */
+vpColVector vpColVector::view(double *data, unsigned int rows)
+{
+  vpColVector v;
+  vpArray2D<double>::view(v, data, rows, 1);
+  return v;
 }
 
 vpColVector &vpColVector::operator=(const std::initializer_list<double> &list)
@@ -912,7 +931,7 @@ double vpColVector::sum() const
   double sum = 0.0;
   for (unsigned int i = 0; i < rowNum; ++i) {
     sum += (*this)[i];
-}
+  }
   return sum;
 #endif
 }
@@ -925,7 +944,7 @@ double vpColVector::sumSquare() const
   double sum_square = 0.0;
   for (unsigned int i = 0; i < rowNum; ++i) {
     sum_square += (*this)[i] * (*this)[i];
-}
+  }
   return sum_square;
 #endif
 }
@@ -950,7 +969,7 @@ vpColVector vpColVector::hadamard(const vpColVector &v) const
 #else
   for (unsigned int i = 0; i < dsize; ++i) {
     out.data[i] = data[i] * v.data[i];
-}
+  }
 #endif
   return out;
 }

--- a/modules/core/src/math/matrix/vpColVector.cpp
+++ b/modules/core/src/math/matrix/vpColVector.cpp
@@ -473,14 +473,21 @@ std::vector<double> vpColVector::toStdVector() const
 vpColVector &vpColVector::operator=(vpColVector &&other)
 {
   if (this != &other) {
-    free(data);
-    free(rowPtrs);
+    if (isMemoryOwner && data != nullptr) {
+      free(data);
+
+    }
+    if (isRowPtrsOwner && rowPtrs != nullptr) {
+      free(rowPtrs);
+    }
 
     rowNum = other.rowNum;
     colNum = other.colNum;
     rowPtrs = other.rowPtrs;
     dsize = other.dsize;
     data = other.data;
+    isMemoryOwner = other.isMemoryOwner;
+    isRowPtrsOwner = other.isRowPtrsOwner;
 
     other.rowNum = 0;
     other.colNum = 0;
@@ -905,7 +912,7 @@ double vpColVector::sum() const
   double sum = 0.0;
   for (unsigned int i = 0; i < rowNum; ++i) {
     sum += (*this)[i];
-  }
+}
   return sum;
 #endif
 }
@@ -918,7 +925,7 @@ double vpColVector::sumSquare() const
   double sum_square = 0.0;
   for (unsigned int i = 0; i < rowNum; ++i) {
     sum_square += (*this)[i] * (*this)[i];
-  }
+}
   return sum_square;
 #endif
 }
@@ -943,7 +950,7 @@ vpColVector vpColVector::hadamard(const vpColVector &v) const
 #else
   for (unsigned int i = 0; i < dsize; ++i) {
     out.data[i] = data[i] * v.data[i];
-  }
+}
 #endif
   return out;
 }

--- a/modules/core/src/math/matrix/vpColVector.cpp
+++ b/modules/core/src/math/matrix/vpColVector.cpp
@@ -259,21 +259,9 @@ vpColVector::vpColVector(const std::vector<float> &v) : vpArray2D<double>(static
 }
 
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
-vpColVector::vpColVector(vpColVector &&v) : vpArray2D<double>()
+vpColVector::vpColVector(vpColVector &&v) : vpArray2D<double>(std::move(v))
 {
-  rowNum = v.rowNum;
-  colNum = v.colNum;
-  rowPtrs = v.rowPtrs;
-  dsize = v.dsize;
-  data = v.data;
-  isMemoryOwner = v.isMemoryOwner;
-  isRowPtrsOwner = v.isRowPtrsOwner;
 
-  v.rowNum = 0;
-  v.colNum = 0;
-  v.rowPtrs = nullptr;
-  v.dsize = 0;
-  v.data = nullptr;
 }
 #endif
 
@@ -474,30 +462,7 @@ std::vector<double> vpColVector::toStdVector() const
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
 vpColVector &vpColVector::operator=(vpColVector &&other)
 {
-  if (this != &other) {
-    if (isMemoryOwner && data != nullptr) {
-      free(data);
-
-    }
-    if (isRowPtrsOwner && rowPtrs != nullptr) {
-      free(rowPtrs);
-    }
-
-    rowNum = other.rowNum;
-    colNum = other.colNum;
-    rowPtrs = other.rowPtrs;
-    dsize = other.dsize;
-    data = other.data;
-    isMemoryOwner = other.isMemoryOwner;
-    isRowPtrsOwner = other.isRowPtrsOwner;
-
-    other.rowNum = 0;
-    other.colNum = 0;
-    other.rowPtrs = nullptr;
-    other.dsize = 0;
-    other.data = nullptr;
-  }
-
+  vpArray2D<double>::operator=(std::move(other));
   return *this;
 }
 

--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -203,22 +203,8 @@ vpMatrix::vpMatrix(const vpTranslationVector &t)
 }
 
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
-vpMatrix::vpMatrix(vpMatrix &&A) : vpArray2D<double>()
-{
-  rowNum = A.rowNum;
-  colNum = A.colNum;
-  rowPtrs = A.rowPtrs;
-  dsize = A.dsize;
-  data = A.data;
-  isMemoryOwner = A.isMemoryOwner;
-  isRowPtrsOwner = A.isRowPtrsOwner;
-
-  A.rowNum = 0;
-  A.colNum = 0;
-  A.rowPtrs = nullptr;
-  A.dsize = 0;
-  A.data = nullptr;
-}
+vpMatrix::vpMatrix(vpMatrix &&A) : vpArray2D<double>(std::move(A))
+{ }
 
 /*!
   Construct a matrix from a list of double values.
@@ -1256,7 +1242,7 @@ vpColVector vpMatrix::eigenValues() const
     gsl_vector_free(eval);
     gsl_matrix_free(m);
     gsl_matrix_free(evec);
-}
+  }
 #else
   {
     const char jobz = 'N';
@@ -1388,7 +1374,7 @@ void vpMatrix::eigenValues(vpColVector &evalue, vpMatrix &evector) const
     gsl_vector_free(eval);
     gsl_matrix_free(m);
     gsl_matrix_free(evec);
-}
+  }
 #else  // defined(VISP_HAVE_GSL)
   {
     const char jobz = 'V';

--- a/modules/core/src/math/matrix/vpMatrix.cpp
+++ b/modules/core/src/math/matrix/vpMatrix.cpp
@@ -209,7 +209,8 @@ vpMatrix::vpMatrix(vpMatrix &&A) : vpArray2D<double>()
   colNum = A.colNum;
   rowPtrs = A.rowPtrs;
   dsize = A.dsize;
-  data = A.data;
+  isMemoryOwner = A.isMemoryOwner;
+  isRowPtrsOwner = A.isRowPtrsOwner;
 
   A.rowNum = 0;
   A.colNum = 0;
@@ -1253,65 +1254,65 @@ vpColVector vpMatrix::eigenValues() const
   }
 #endif
 #else
-    throw(vpException(vpException::functionNotImplementedError, "Eigen values computation is not implemented. "
-                      "You should install Lapack 3rd party"));
+  throw(vpException(vpException::functionNotImplementedError, "Eigen values computation is not implemented. "
+                    "You should install Lapack 3rd party"));
 #endif
   return evalue;
-}
-
-/*!
-  Compute the eigenvalues of a n-by-n real symmetric matrix using
-  Lapack 3rd party.
-
-  \param evalue : Eigenvalues of the matrix, sorted in ascending order.
-
-  \param evector : Corresponding eigenvectors of the matrix.
-
-  \exception vpException::dimensionError If the matrix is not square.
-  \exception vpException::fatalError If the matrix is not symmetric.
-  \exception vpException::functionNotImplementedError If Lapack 3rd party is
-  not detected.
-
-  Here an example:
-  \code
-  #include <iostream>
-
-  #include <visp3/core/vpColVector.h>
-  #include <visp3/core/vpMatrix.h>
-
-  #ifdef ENABLE_VISP_NAMESPACE
-  using namespace VISP_NAMESPACE_NAME;
-  #endif
-
-  int main()
-  {
-    vpMatrix A(4,4); // A is a symmetric matrix
-    A[0][0] = 1/1.; A[0][1] = 1/2.; A[0][2] = 1/3.; A[0][3] = 1/4.;
-    A[1][0] = 1/2.; A[1][1] = 1/3.; A[1][2] = 1/4.; A[1][3] = 1/5.;
-    A[2][0] = 1/3.; A[2][1] = 1/4.; A[2][2] = 1/5.; A[2][3] = 1/6.;
-    A[3][0] = 1/4.; A[3][1] = 1/5.; A[3][2] = 1/6.; A[3][3] = 1/7.;
-    std::cout << "Initial symmetric matrix: \n" << A << std::endl;
-
-    vpColVector d; // Eigenvalues
-    vpMatrix    V; // Eigenvectors
-
-    // Compute the eigenvalues and eigenvectors
-    A.eigenValues(d, V);
-    std::cout << "Eigen values: \n" << d << std::endl;
-    std::cout << "Eigen vectors: \n" << V << std::endl;
-
-    vpMatrix D;
-    D.diag(d); // Eigenvalues are on the diagonal
-
-    std::cout << "D: " << D << std::endl;
-
-    // Verification: A * V = V * D
-    std::cout << "AV-VD = 0 ? \n" << (A*V) - (V*D) << std::endl;
   }
-  \endcode
 
-  \sa eigenValues()
-*/
+  /*!
+    Compute the eigenvalues of a n-by-n real symmetric matrix using
+    Lapack 3rd party.
+
+    \param evalue : Eigenvalues of the matrix, sorted in ascending order.
+
+    \param evector : Corresponding eigenvectors of the matrix.
+
+    \exception vpException::dimensionError If the matrix is not square.
+    \exception vpException::fatalError If the matrix is not symmetric.
+    \exception vpException::functionNotImplementedError If Lapack 3rd party is
+    not detected.
+
+    Here an example:
+    \code
+    #include <iostream>
+
+    #include <visp3/core/vpColVector.h>
+    #include <visp3/core/vpMatrix.h>
+
+    #ifdef ENABLE_VISP_NAMESPACE
+    using namespace VISP_NAMESPACE_NAME;
+    #endif
+
+    int main()
+    {
+      vpMatrix A(4,4); // A is a symmetric matrix
+      A[0][0] = 1/1.; A[0][1] = 1/2.; A[0][2] = 1/3.; A[0][3] = 1/4.;
+      A[1][0] = 1/2.; A[1][1] = 1/3.; A[1][2] = 1/4.; A[1][3] = 1/5.;
+      A[2][0] = 1/3.; A[2][1] = 1/4.; A[2][2] = 1/5.; A[2][3] = 1/6.;
+      A[3][0] = 1/4.; A[3][1] = 1/5.; A[3][2] = 1/6.; A[3][3] = 1/7.;
+      std::cout << "Initial symmetric matrix: \n" << A << std::endl;
+
+      vpColVector d; // Eigenvalues
+      vpMatrix    V; // Eigenvectors
+
+      // Compute the eigenvalues and eigenvectors
+      A.eigenValues(d, V);
+      std::cout << "Eigen values: \n" << d << std::endl;
+      std::cout << "Eigen vectors: \n" << V << std::endl;
+
+      vpMatrix D;
+      D.diag(d); // Eigenvalues are on the diagonal
+
+      std::cout << "D: " << D << std::endl;
+
+      // Verification: A * V = V * D
+      std::cout << "AV-VD = 0 ? \n" << (A*V) - (V*D) << std::endl;
+    }
+    \endcode
+
+    \sa eigenValues()
+  */
 void vpMatrix::eigenValues(vpColVector &evalue, vpMatrix &evector) const
 {
   if (rowNum != colNum) {
@@ -1386,29 +1387,29 @@ void vpMatrix::eigenValues(vpColVector &evalue, vpMatrix &evector) const
   }
 #endif // defined(VISP_HAVE_GSL)
 #else
-    throw(vpException(vpException::functionNotImplementedError, "Eigen values computation is not implemented. "
-                      "You should install Lapack 3rd party"));
+  throw(vpException(vpException::functionNotImplementedError, "Eigen values computation is not implemented. "
+                    "You should install Lapack 3rd party"));
 #endif
-}
+  }
 
-/*!
-  Function to compute the null space (the kernel) of a m-by-n matrix \f$\bf
-  A\f$.
+  /*!
+    Function to compute the null space (the kernel) of a m-by-n matrix \f$\bf
+    A\f$.
 
-  The null space of a matrix \f$\bf A\f$ is defined as \f$\mbox{Ker}({\bf A})
-  = { {\bf X} : {\bf A}*{\bf X} = {\bf 0}}\f$.
+    The null space of a matrix \f$\bf A\f$ is defined as \f$\mbox{Ker}({\bf A})
+    = { {\bf X} : {\bf A}*{\bf X} = {\bf 0}}\f$.
 
-  \param kerAt: The matrix that contains the null space (kernel) of \f$\bf
-  A\f$ defined by the matrix \f${\bf X}^T\f$. If matrix \f$\bf A\f$ is full
-  rank, the dimension of \c kerAt is (0, n), otherwise the dimension is (n-r,
-  n). This matrix is thus the transpose of \f$\mbox{Ker}({\bf A})\f$.
+    \param kerAt: The matrix that contains the null space (kernel) of \f$\bf
+    A\f$ defined by the matrix \f${\bf X}^T\f$. If matrix \f$\bf A\f$ is full
+    rank, the dimension of \c kerAt is (0, n), otherwise the dimension is (n-r,
+    n). This matrix is thus the transpose of \f$\mbox{Ker}({\bf A})\f$.
 
-  \param svThreshold: Threshold used to test the singular values. If
-  a singular value is lower than this threshold we consider that the
-  matrix is not full rank.
+    \param svThreshold: Threshold used to test the singular values. If
+    a singular value is lower than this threshold we consider that the
+    matrix is not full rank.
 
-  \return The rank of the matrix.
-*/
+    \return The rank of the matrix.
+  */
 unsigned int vpMatrix::kernel(vpMatrix &kerAt, double svThreshold) const
 {
   unsigned int nbline = getRows();

--- a/modules/core/src/math/matrix/vpMatrix_lu.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_lu.cpp
@@ -180,7 +180,6 @@ vpMatrix vpMatrix::inverseByLU() const
     inv[index_2][index_0] = (((*this)[index_1][index_0] * (*this)[index_2][index_1]) - ((*this)[index_1][index_1] * (*this)[index_2][index_0])) * d;
     inv[index_2][index_1] = (((*this)[index_0][index_1] * (*this)[index_2][index_0]) - ((*this)[index_0][index_0] * (*this)[index_2][index_1])) * d;
     inv[index_2][index_2] = (((*this)[index_0][index_0] * (*this)[index_1][index_1]) - ((*this)[index_0][index_1] * (*this)[index_1][index_0])) * d;
-    std::cout << "After computations" << std::endl;
     return inv;
   }
   else {
@@ -371,37 +370,37 @@ vpMatrix vpMatrix::inverseByLULapack() const
     return A;
   }
 #endif
-}
-
-/*!
-  Compute the determinant of a square matrix using the LU decomposition with
-  Lapack 3rd party.
-
-  \return The determinant of the matrix if the matrix is square.
-
-  \code
-  #include <iostream>
-
-  #include <visp3/core/vpMatrix.h>
-
-  #ifdef ENABLE_VISP_NAMESPACE
-  using namespace VISP_NAMESPACE_NAME;
-  #endif
-
-  int main()
-  {
-    vpMatrix A(3,3);
-    A[0][0] = 1/1.; A[0][1] = 1/2.; A[0][2] = 1/3.;
-    A[1][0] = 1/3.; A[1][1] = 1/4.; A[1][2] = 1/5.;
-    A[2][0] = 1/6.; A[2][1] = 1/7.; A[2][2] = 1/8.;
-    std::cout << "Initial matrix: \n" << A << std::endl;
-
-    // Compute the determinant
-    std:: cout << "Determinant by LU decomposition (Lapack): " << A.detByLULapack() << std::endl;
   }
-  \endcode
-  \sa detByLU(), detByLUEigen3(), detByLUOpenCV()
-*/
+
+  /*!
+    Compute the determinant of a square matrix using the LU decomposition with
+    Lapack 3rd party.
+
+    \return The determinant of the matrix if the matrix is square.
+
+    \code
+    #include <iostream>
+
+    #include <visp3/core/vpMatrix.h>
+
+    #ifdef ENABLE_VISP_NAMESPACE
+    using namespace VISP_NAMESPACE_NAME;
+    #endif
+
+    int main()
+    {
+      vpMatrix A(3,3);
+      A[0][0] = 1/1.; A[0][1] = 1/2.; A[0][2] = 1/3.;
+      A[1][0] = 1/3.; A[1][1] = 1/4.; A[1][2] = 1/5.;
+      A[2][0] = 1/6.; A[2][1] = 1/7.; A[2][2] = 1/8.;
+      std::cout << "Initial matrix: \n" << A << std::endl;
+
+      // Compute the determinant
+      std:: cout << "Determinant by LU decomposition (Lapack): " << A.detByLULapack() << std::endl;
+    }
+    \endcode
+    \sa detByLU(), detByLUEigen3(), detByLUOpenCV()
+  */
 double vpMatrix::detByLULapack() const
 {
 #if defined(VISP_HAVE_GSL)
@@ -473,7 +472,7 @@ double vpMatrix::detByLULapack() const
     return det;
   }
 #endif
-}
+  }
 #endif
 
 #if defined(VISP_HAVE_OPENCV)

--- a/modules/core/src/math/matrix/vpMatrix_lu.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_lu.cpp
@@ -180,6 +180,7 @@ vpMatrix vpMatrix::inverseByLU() const
     inv[index_2][index_0] = (((*this)[index_1][index_0] * (*this)[index_2][index_1]) - ((*this)[index_1][index_1] * (*this)[index_2][index_0])) * d;
     inv[index_2][index_1] = (((*this)[index_0][index_1] * (*this)[index_2][index_0]) - ((*this)[index_0][index_0] * (*this)[index_2][index_1])) * d;
     inv[index_2][index_2] = (((*this)[index_0][index_0] * (*this)[index_1][index_1]) - ((*this)[index_0][index_1] * (*this)[index_1][index_0])) * d;
+    std::cout << "After computations" << std::endl;
     return inv;
   }
   else {

--- a/modules/core/src/math/matrix/vpMatrix_operators.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_operators.cpp
@@ -243,10 +243,11 @@ vpMatrix &vpMatrix::operator=(const vpMatrix &A)
 vpMatrix &vpMatrix::operator=(vpMatrix &&other)
 {
   if (this != &other) {
-    if (data) {
+    if (isMemoryOwner && data != nullptr) {
       free(data);
+
     }
-    if (rowPtrs) {
+    if (isRowPtrsOwner && rowPtrs != nullptr) {
       free(rowPtrs);
     }
 
@@ -255,6 +256,8 @@ vpMatrix &vpMatrix::operator=(vpMatrix &&other)
     rowPtrs = other.rowPtrs;
     dsize = other.dsize;
     data = other.data;
+    isMemoryOwner = other.isMemoryOwner;
+    isRowPtrsOwner = other.isRowPtrsOwner;
 
     other.rowNum = 0;
     other.colNum = 0;
@@ -558,12 +561,12 @@ vpMatrix vpMatrix::operator*(const vpVelocityTwistMatrix &V) const
   }
 
   return M;
-}
+    }
 
-/*!
-  Operator that allow to multiply a matrix by a force/torque twist matrix.
-  The matrix should be of dimension m-by-6.
-*/
+    /*!
+      Operator that allow to multiply a matrix by a force/torque twist matrix.
+      The matrix should be of dimension m-by-6.
+    */
 vpMatrix vpMatrix::operator*(const vpForceTwistMatrix &V) const
 {
   if (colNum != V.getRows()) {
@@ -615,12 +618,12 @@ vpMatrix vpMatrix::operator*(const vpForceTwistMatrix &V) const
   }
 
   return M;
-}
+    }
 
-/*!
-  Operation C = A + B (A is unchanged).
-  \sa add2Matrices() to avoid matrix allocation for each use.
-*/
+    /*!
+      Operation C = A + B (A is unchanged).
+      \sa add2Matrices() to avoid matrix allocation for each use.
+    */
 vpMatrix vpMatrix::operator+(const vpMatrix &B) const
 {
   vpMatrix C;

--- a/modules/core/src/math/matrix/vpMatrix_operators.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_operators.cpp
@@ -242,30 +242,7 @@ vpMatrix &vpMatrix::operator=(const vpMatrix &A)
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
 vpMatrix &vpMatrix::operator=(vpMatrix &&other)
 {
-  if (this != &other) {
-    if (isMemoryOwner && data != nullptr) {
-      free(data);
-
-    }
-    if (isRowPtrsOwner && rowPtrs != nullptr) {
-      free(rowPtrs);
-    }
-
-    rowNum = other.rowNum;
-    colNum = other.colNum;
-    rowPtrs = other.rowPtrs;
-    dsize = other.dsize;
-    data = other.data;
-    isMemoryOwner = other.isMemoryOwner;
-    isRowPtrsOwner = other.isRowPtrsOwner;
-
-    other.rowNum = 0;
-    other.colNum = 0;
-    other.rowPtrs = nullptr;
-    other.dsize = 0;
-    other.data = nullptr;
-  }
-
+  vpArray2D<double>::operator=(std::move(other));
   return *this;
 }
 

--- a/modules/core/src/math/matrix/vpMatrix_operators.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_operators.cpp
@@ -561,12 +561,12 @@ vpMatrix vpMatrix::operator*(const vpVelocityTwistMatrix &V) const
   }
 
   return M;
-    }
+}
 
-    /*!
-      Operator that allow to multiply a matrix by a force/torque twist matrix.
-      The matrix should be of dimension m-by-6.
-    */
+/*!
+  Operator that allow to multiply a matrix by a force/torque twist matrix.
+  The matrix should be of dimension m-by-6.
+*/
 vpMatrix vpMatrix::operator*(const vpForceTwistMatrix &V) const
 {
   if (colNum != V.getRows()) {
@@ -618,12 +618,12 @@ vpMatrix vpMatrix::operator*(const vpForceTwistMatrix &V) const
   }
 
   return M;
-    }
+}
 
-    /*!
-      Operation C = A + B (A is unchanged).
-      \sa add2Matrices() to avoid matrix allocation for each use.
-    */
+/*!
+  Operation C = A + B (A is unchanged).
+  \sa add2Matrices() to avoid matrix allocation for each use.
+*/
 vpMatrix vpMatrix::operator+(const vpMatrix &B) const
 {
   vpMatrix C;

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -53,6 +53,24 @@
 #endif
 
 BEGIN_VISP_NAMESPACE
+
+/**
+*@brief Create a row vector view of a raw data array.
+* The view can modify the contents of the raw data array,
+*but may not resize it and does not own it : the memory is not released by the vector
+*and it should be freed by the user after the view is released.
+*
+*@param data the raw data
+*@param cols Number of columns
+*@return vpMatrix
+*/
+vpRowVector vpRowVector::view(double *data, unsigned int cols)
+{
+  vpRowVector v;
+  vpArray2D<double>::view(v, data, 1, cols);
+  return v;
+}
+
 //! Copy operator.   Allow operation such as A = v
 vpRowVector &vpRowVector::operator=(const vpRowVector &v)
 {
@@ -1435,5 +1453,5 @@ vpRowVector vpRowVector::hadamard(const vpRowVector &v) const
   }
 #endif
   return out;
-  }
+}
 END_VISP_NAMESPACE

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -133,14 +133,21 @@ vpRowVector &vpRowVector::operator=(double x)
 vpRowVector &vpRowVector::operator=(vpRowVector &&other)
 {
   if (this != &other) {
-    free(data);
-    free(rowPtrs);
+    if (isMemoryOwner && data != nullptr) {
+      free(data);
+
+    }
+    if (isRowPtrsOwner && rowPtrs != nullptr) {
+      free(rowPtrs);
+    }
 
     rowNum = other.rowNum;
     colNum = other.colNum;
     rowPtrs = other.rowPtrs;
     dsize = other.dsize;
     data = other.data;
+    isMemoryOwner = other.isMemoryOwner;
+    isRowPtrsOwner = other.isRowPtrsOwner;
 
     other.rowNum = 0;
     other.colNum = 0;
@@ -625,6 +632,8 @@ vpRowVector::vpRowVector(vpRowVector &&v) : vpArray2D<double>()
   rowPtrs = v.rowPtrs;
   dsize = v.dsize;
   data = v.data;
+  isMemoryOwner = v.isMemoryOwner;
+  isRowPtrsOwner = v.isRowPtrsOwner;
 
   v.rowNum = 0;
   v.colNum = 0;
@@ -1426,5 +1435,5 @@ vpRowVector vpRowVector::hadamard(const vpRowVector &v) const
   }
 #endif
   return out;
-}
+  }
 END_VISP_NAMESPACE

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -150,30 +150,7 @@ vpRowVector &vpRowVector::operator=(double x)
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
 vpRowVector &vpRowVector::operator=(vpRowVector &&other)
 {
-  if (this != &other) {
-    if (isMemoryOwner && data != nullptr) {
-      free(data);
-
-    }
-    if (isRowPtrsOwner && rowPtrs != nullptr) {
-      free(rowPtrs);
-    }
-
-    rowNum = other.rowNum;
-    colNum = other.colNum;
-    rowPtrs = other.rowPtrs;
-    dsize = other.dsize;
-    data = other.data;
-    isMemoryOwner = other.isMemoryOwner;
-    isRowPtrsOwner = other.isRowPtrsOwner;
-
-    other.rowNum = 0;
-    other.colNum = 0;
-    other.rowPtrs = nullptr;
-    other.dsize = 0;
-    other.data = nullptr;
-  }
-
+  vpArray2D<double>::operator=(std::move(other));
   return *this;
 }
 
@@ -643,22 +620,8 @@ vpRowVector::vpRowVector(const vpRowVector &v, unsigned int c, unsigned int ncol
 }
 
 #if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
-vpRowVector::vpRowVector(vpRowVector &&v) : vpArray2D<double>()
-{
-  rowNum = v.rowNum;
-  colNum = v.colNum;
-  rowPtrs = v.rowPtrs;
-  dsize = v.dsize;
-  data = v.data;
-  isMemoryOwner = v.isMemoryOwner;
-  isRowPtrsOwner = v.isRowPtrsOwner;
-
-  v.rowNum = 0;
-  v.colNum = 0;
-  v.rowPtrs = nullptr;
-  v.dsize = 0;
-  v.data = nullptr;
-}
+vpRowVector::vpRowVector(vpRowVector &&v) : vpArray2D<double>(std::move(v))
+{ }
 #endif
 
 /*!

--- a/modules/core/src/math/matrix/vpRowVector.cpp
+++ b/modules/core/src/math/matrix/vpRowVector.cpp
@@ -55,14 +55,14 @@
 BEGIN_VISP_NAMESPACE
 
 /**
-*@brief Create a row vector view of a raw data array.
+* \brief Create a row vector view of a raw data array.
 * The view can modify the contents of the raw data array,
-*but may not resize it and does not own it : the memory is not released by the vector
-*and it should be freed by the user after the view is released.
+* but may not resize it and does not own it : the memory is not released by the vector
+* and it should be freed by the user after the view is released.
 *
-*@param data the raw data
-*@param cols Number of columns
-*@return vpMatrix
+* \param data the raw data
+* \param cols Number of columns
+* \return vpMatrix
 */
 vpRowVector vpRowVector::view(double *data, unsigned int cols)
 {

--- a/modules/core/test/math/catchArray2D.cpp
+++ b/modules/core/test/math/catchArray2D.cpp
@@ -258,13 +258,52 @@ TEST_CASE("Building array views", "[view]")
   std::cout << "Testing views" << std::endl;
   SECTION("Modifying view modifies original array")
   {
-    vpArray2D<int> A(5, 5, 0);
-    vpArray2D<int> v = vpArray2D<int>::view(A);
-    REQUIRE((A == v));
-    v[0][0] = 5;
-    v[0][1] = 2;
-    REQUIRE((A[0][0] == 5));
-    REQUIRE((A == v));
+    {
+      vpArray2D<int> A(5, 5, 0);
+      vpArray2D<int> v = vpArray2D<int>::view(A);
+      REQUIRE((A == v));
+      v[0][0] = 5;
+      v[0][1] = 2;
+      A[1][1] = 3;
+      REQUIRE((v[1][1] == 3));
+      REQUIRE((A[0][0] == 5));
+      REQUIRE((A == v));
+    }
+    {
+      int s = 5;
+      int *array = new int[s * s];
+      vpArray2D<int> v = vpArray2D<int>::view(array, s, s);
+      v[0][0] = 5;
+      v[s - 1][s - 1] = 2;
+      REQUIRE(array[0] == 5);
+      REQUIRE(array[s * s - 1] == 2);
+      delete[] array;
+    }
+  }
+  SECTION("A view can be moved and then used")
+  {
+    {
+      vpArray2D<int> A(5, 5, 0);
+      vpArray2D<int> v = vpArray2D<int>::view(A);
+      vpArray2D<int> v2 = std::move(v);
+      REQUIRE((A == v2));
+      v2[0][0] = 5;
+      v2[0][1] = 2;
+      REQUIRE((A[0][0] == 5));
+      REQUIRE((A == v2));
+    }
+    {
+      int s = 5;
+      int *array = new int[s * s];
+      vpArray2D<int> v = vpArray2D<int>::view(array, s, s);
+      vpArray2D<int> v2 = std::move(v);
+      v2[0][0] = 5;
+      v2[s - 1][s - 1] = 2;
+      REQUIRE(array[0] == 5);
+      REQUIRE(array[s * s - 1] == 2);
+      delete[] array;
+    }
+
   }
   SECTION("Array can still be used after destroying view")
   {

--- a/modules/core/test/math/catchArray2D.cpp
+++ b/modules/core/test/math/catchArray2D.cpp
@@ -253,6 +253,58 @@ TEST_CASE("Test constructors with float", "[constructors]")
   }
 }
 
+TEST_CASE("Building array views", "[view]")
+{
+  std::cout << "Testing views" << std::endl;
+  SECTION("Modifying view modifies original array")
+  {
+    vpArray2D<int> A(5, 5, 0);
+    vpArray2D<int> v = vpArray2D<int>::view(A);
+    REQUIRE((A == v));
+    v[0][0] = 5;
+    v[0][1] = 2;
+    REQUIRE((A[0][0] == 5));
+    REQUIRE((A == v));
+  }
+  SECTION("Array can still be used after destroying view")
+  {
+    int s = 5;
+    vpArray2D<int> A(s, s, 0);
+    {
+      vpArray2D<int> v = vpArray2D<int>::view(A);
+      v[0][0] = 5;
+      v[s - 1][s - 1] = 2;
+    }
+    REQUIRE((A[0][0] == 5));
+    REQUIRE(A[s - 1][s - 1] == 2);
+
+    int *array = new int[s * s];
+    {
+      vpArray2D<int> v = vpArray2D<int>::view(array, s, s);
+      v[0][0] = 5;
+      v[s - 1][s - 1] = 2;
+
+    }
+    REQUIRE(array[0] == 5);
+    REQUIRE(array[s * s - 1] == 2);
+    delete[] array;
+  }
+  SECTION("Cannot resize view")
+  {
+    int s = 5;
+    vpArray2D<int> A(s, s, 0);
+    vpArray2D<int> v = vpArray2D<int>::view(A);
+    REQUIRE_THROWS(v.resize(1, 5, false, false));
+
+
+    int *array = new int[s * s];
+    v = vpArray2D<int>::view(array, s, s);
+    REQUIRE_THROWS(v.resize(1, 5, false, false));
+    delete[] array;
+
+  }
+}
+
 TEST_CASE("Test Hadamar product", "[hadamar]")
 {
   vpArray2D<int> A1(3, 5), A2(3, 5), A3;

--- a/modules/python/bindings/include/core/arrays.hpp
+++ b/modules/python/bindings/include/core/arrays.hpp
@@ -423,12 +423,25 @@ void bindings_vpArray2D(py::class_<vpArray2D<T>, std::shared_ptr<vpArray2D<T>>> 
     vpArray2D<T> result(shape[0], shape[1]);
     copy_data_from_np(np_array, result.data);
     return result;
-                         }), R"doc(
+  }), R"doc(
 Construct a 2D ViSP array by **copying** a 2D numpy array.
 
 :param np_array: The numpy array to copy.
 
 )doc", py::arg("np_array"));
+
+  pyArray2D.def_static("view", ([](np_array_c<T> &np_array) -> vpArray2D<T> {
+    verify_array_shape_and_dims(np_array, 2, "ViSP 2D array");
+    const std::vector<py::ssize_t> shape = np_array.request().shape;
+    return vpArray2D<T>::view(static_cast<T *>(np_array.request().ptr), shape[0], shape[1]);
+  }), R"doc(
+Construct a 2D ViSP array that is a **view** of a numpy array.
+When it is modified, the numpy array is also modified.
+It cannot be resized.
+
+:param np_array: The numpy array to copy.
+
+)doc", py::arg("np_array"), py::keep_alive<0, 1>());
 
   define_get_item_2d_array<py::class_<vpArray2D<T>, std::shared_ptr<vpArray2D<T>>>, vpArray2D<T>, T>(pyArray2D);
   define_set_item_2d_array<py::class_<vpArray2D<T>, std::shared_ptr<vpArray2D<T>>>, vpArray2D<T>, T>(pyArray2D);
@@ -449,12 +462,25 @@ void bindings_vpMatrix(py::class_<vpMatrix, std::shared_ptr<vpMatrix>, vpArray2D
     vpMatrix result(shape[0], shape[1]);
     copy_data_from_np(np_array, result.data);
     return result;
-                        }), R"doc(
+  }), R"doc(
 Construct a matrix by **copying** a 2D numpy array.
 
 :param np_array: The numpy array to copy.
 
 )doc", py::arg("np_array"));
+
+  pyMatrix.def_static("view", ([](np_array_c<double> &np_array) -> vpMatrix {
+    verify_array_shape_and_dims(np_array, 2, "ViSP Matrix");
+    const std::vector<py::ssize_t> shape = np_array.request().shape;
+    return vpMatrix::view(static_cast<double *>(np_array.request().ptr), shape[0], shape[1]);
+  }), R"doc(
+Construct a 2D ViSP Matrix that is a **view** of a numpy array.
+When it is modified, the numpy array is also modified.
+It cannot be resized.
+
+:param np_array: The numpy array to copy.
+
+)doc", py::arg("np_array"), py::keep_alive<0, 1>());
 
   add_print_helper(pyMatrix, &vpMatrix::csvPrint, "strCsv", csv_str_help);
   add_print_helper(pyMatrix, &vpMatrix::maplePrint, "strMaple", maple_str_help);
@@ -482,7 +508,7 @@ void bindings_vpRotationMatrix(py::class_<vpRotationMatrix, std::shared_ptr<vpRo
       throw std::runtime_error("Input numpy array is not a valid rotation matrix");
     }
     return result;
-                                }), R"doc(
+  }), R"doc(
 Construct a rotation matrix by **copying** a 2D numpy array.
 This numpy array should be of dimensions :math:`3 \times 3` and be a valid rotation matrix.
 If it is not a rotation matrix, an exception will be raised.
@@ -509,7 +535,7 @@ void bindings_vpHomogeneousMatrix(py::class_<vpHomogeneousMatrix, std::shared_pt
       throw std::runtime_error("Input numpy array is not a valid homogeneous matrix");
     }
     return result;
-                                   }), R"doc(
+  }), R"doc(
 Construct a homogeneous matrix by **copying** a 2D numpy array.
 This numpy array should be of dimensions :math:`4 \times 4` and be a valid homogeneous matrix.
 If it is not a homogeneous matrix, an exception will be raised.
@@ -537,7 +563,7 @@ void bindings_vpTranslationVector(py::class_<vpTranslationVector, std::shared_pt
     vpTranslationVector result;
     copy_data_from_np(np_array, result.data);
     return result;
-                                   }), R"doc(
+  }), R"doc(
 Construct a Translation vector by **copying** a 1D numpy array of size 3.
 
 :param np_array: The numpy 1D array to copy.
@@ -562,12 +588,26 @@ void bindings_vpColVector(py::class_<vpColVector, std::shared_ptr<vpColVector>, 
     vpColVector result(shape[0]);
     copy_data_from_np(np_array, result.data);
     return result;
-                           }), R"doc(
+  }), R"doc(
 Construct a column vector by **copying** a 1D numpy array.
 
 :param np_array: The numpy 1D array to copy.
 
 )doc", py::arg("np_array"));
+
+  pyColVector.def_static("view", ([](np_array_c<double> &np_array) -> vpColVector {
+    verify_array_shape_and_dims(np_array, 1, "ViSP column vector");
+    const std::vector<py::ssize_t> shape = np_array.request().shape;
+    return vpColVector::view(static_cast<double *>(np_array.request().ptr), shape[0]);
+  }), R"doc(
+Construct a column vector that is a **view** of a numpy array.
+When it is modified, the numpy array is also modified.
+It cannot be resized.
+
+:param np_array: The numpy array to copy.
+
+)doc", py::arg("np_array"), py::keep_alive<0, 1>());
+
   define_get_item_1d_array<py::class_<vpColVector, std::shared_ptr<vpColVector>, vpArray2D<double>>, vpColVector, double>(pyColVector);
   define_set_item_1d_array<py::class_<vpColVector, std::shared_ptr<vpColVector>, vpArray2D<double>>, vpColVector, double>(pyColVector);
 
@@ -590,12 +630,26 @@ void bindings_vpRowVector(py::class_<vpRowVector, std::shared_ptr<vpRowVector>, 
     vpRowVector result(shape[0]);
     copy_data_from_np(np_array, result.data);
     return result;
-                           }), R"doc(
+  }), R"doc(
 Construct a row vector by **copying** a 1D numpy array.
 
 :param np_array: The numpy 1D array to copy.
 
 )doc", py::arg("np_array"));
+
+  pyRowVector.def_static("view", ([](np_array_c<double> &np_array) -> vpRowVector {
+    verify_array_shape_and_dims(np_array, 1, "ViSP row vector");
+    const std::vector<py::ssize_t> shape = np_array.request().shape;
+    return vpRowVector::view(static_cast<double *>(np_array.request().ptr), shape[0]);
+  }), R"doc(
+Construct a row vector that is a **view** of a numpy array.
+When it is modified, the numpy array is also modified.
+It cannot be resized.
+
+:param np_array: The numpy array to copy.
+
+)doc", py::arg("np_array"), py::keep_alive<0, 1>());
+
   define_get_item_1d_array<py::class_<vpRowVector, std::shared_ptr<vpRowVector>, vpArray2D<double>>, vpRowVector, double>(pyRowVector);
   define_set_item_1d_array<py::class_<vpRowVector, std::shared_ptr<vpRowVector>, vpArray2D<double>>, vpRowVector, double>(pyRowVector);
 

--- a/modules/python/bindings/include/core/utils.hpp
+++ b/modules/python/bindings/include/core/utils.hpp
@@ -46,6 +46,10 @@ namespace py = pybind11;
 template<typename Item>
 using np_array_cf = py::array_t<Item, py::array::c_style | py::array::forcecast>;
 
+template<typename Item>
+using np_array_c = py::array_t<Item, py::array::c_style>;
+
+
 /*
  * Create a buffer info for a row major array
  */
@@ -99,6 +103,22 @@ void verify_array_shape_and_dims(np_array_cf<Item> np_array, unsigned dims, cons
     throw std::runtime_error(ss.str());
   }
 }
+
+template<typename Item>
+void verify_array_shape_and_dims(np_array_c<Item> np_array, unsigned dims, const char *class_name)
+{
+  py::buffer_info buffer = np_array.request();
+  std::vector<py::ssize_t> shape = buffer.shape;
+  if (shape.size() != dims) {
+    std::stringstream ss;
+    ss << "Tried to instanciate " << class_name
+      << " that expects a " << dims << "D array but got a numpy array of shape "
+      << shape_to_string(shape);
+
+    throw std::runtime_error(ss.str());
+  }
+}
+
 template<typename Item>
 void verify_array_shape_and_dims(np_array_cf<Item> np_array, std::vector<py::ssize_t> expected_dims, const char *class_name)
 {

--- a/modules/python/bindings/include/core/utils.hpp
+++ b/modules/python/bindings/include/core/utils.hpp
@@ -49,7 +49,6 @@ using np_array_cf = py::array_t<Item, py::array::c_style | py::array::forcecast>
 template<typename Item>
 using np_array_c = py::array_t<Item, py::array::c_style>;
 
-
 /*
  * Create a buffer info for a row major array
  */

--- a/modules/python/test/test_numpy_array.py
+++ b/modules/python/test/test_numpy_array.py
@@ -34,7 +34,7 @@
 #############################################################################
 
 import visp
-from visp.core import ArrayDouble2D, RotationMatrix, Matrix, HomogeneousMatrix, PoseVector
+from visp.core import ArrayDouble2D, RotationMatrix, Matrix, HomogeneousMatrix, PoseVector, ColVector, RowVector
 
 import numpy as np
 import pytest
@@ -48,6 +48,34 @@ def test_np_array_modifies_vp_array():
   assert np.all(array_np == 1.0)
   array_np[0:2, 0:2] = 2
   assert array.getMinValue() == 1 and array.getMaxValue() == 2
+
+def test_visp_view_of_np_array():
+  a = np.zeros((5, 5))
+  with pytest.raises(RuntimeError):
+    ColVector.view(a)
+  with pytest.raises(RuntimeError):
+    RowVector.view(a)
+  m = Matrix.view(a)
+  m[0, 0] = 1
+  assert a[0, 0] == 1
+  assert m.getRows() == a.shape[0] and m.getCols() == a.shape[1]
+  a = np.zeros(10)
+  with pytest.raises(RuntimeError):
+    Matrix.view(a)
+
+  v = ColVector.view(a)
+  v[0] = 1
+  assert a[0] == 1
+  assert v.getRows() == a.shape[0]
+
+  a = np.zeros(10)
+  v = RowVector.view(a)
+  v[0] = 1
+  assert a[0] == 1
+  assert v.getCols() == a.shape[0]
+
+
+
 
 def fn_test_not_writable_2d(R):
   R_np = np.array(R, copy=False)

--- a/modules/python/test/test_numpy_array.py
+++ b/modules/python/test/test_numpy_array.py
@@ -74,9 +74,6 @@ def test_visp_view_of_np_array():
   assert a[0] == 1
   assert v.getCols() == a.shape[0]
 
-
-
-
 def fn_test_not_writable_2d(R):
   R_np = np.array(R, copy=False)
   with pytest.raises(ValueError):
@@ -112,7 +109,6 @@ def test_numpy_constructor_interpreted_as_1d_vector():
     a = ArrayDouble2D(n_1d) # R = 0, c = 0
   ar = ArrayDouble2D(n_1d, r=len(n_1d))
   ac = ArrayDouble2D(n_1d, c=len(n_1d))
-
 
 def test_numpy_conversion_and_back():
   a = ArrayDouble2D(10, 10, 2.0)


### PR DESCRIPTION
This PR adds the ability to view a raw double array (not managed by a ViSP object) as a matrix, or vector.
This is useful to avoid unecessary copies of NumPy arrays when using them as function inputs.