### PR TITLE
Hotfix for windows conda CI

### DIFF
--- a/.github/workflows/conda/environment_windows.yml
+++ b/.github/workflows/conda/environment_windows.yml
@@ -15,3 +15,4 @@ dependencies:
   - libpng
   - mkl-devel
   - pybind11
+  - libiconv <=1.17


### PR DESCRIPTION
Windows conda-based CI is broken due to the update of libiconv to v1.18. Thanks @jorisv for helping on this ! 
This hotfix force the use of previous version meanwhile an issue will be open on the libiconv package feedstock. 