### PR TITLE
Save reprojection error for each image in the resulting xml file

### DIFF
--- a/apps/calibration/intrinsic/visp-calibrate-camera.cpp
+++ b/apps/calibration/intrinsic/visp-calibrate-camera.cpp
@@ -439,12 +439,14 @@ int main(int argc, const char *argv[])
 
       d->init(I);
       vpDisplay::setTitle(I, "Without distortion results");
-
+      ss_additional_info << "<reprojection_error><without_distortion>";
       for (size_t i = 0; i < calibrator.size(); i++) {
         double reproj_error = sqrt(calibrator[i].getResidual() / calibrator[i].get_npt());
 
         const CalibInfo &calib = calib_info[i];
         std::cout << "Image " << calib.m_frame_name << " reprojection error: " << reproj_error << std::endl;
+
+        ss_additional_info << "<image>" << reproj_error << "</image>";
         I = calib.m_img;
         vpDisplay::display(I);
 
@@ -482,8 +484,9 @@ int main(int argc, const char *argv[])
       }
 
       std::cout << "\nGlobal reprojection error: " << error << std::endl;
-      ss_additional_info << "<global_reprojection_error><without_distortion>" << error << "</without_distortion>";
+      ss_additional_info << "<global_reprojection_error>" << error << "</global_reprojection_error>";
 
+      ss_additional_info << "</without_distortion>";
       vpXmlParserCamera xml;
 
       if (xml.save(cam, opt_output_file_name.c_str(), opt_camera_name, I.getWidth(), I.getHeight()) ==
@@ -516,11 +519,13 @@ int main(int argc, const char *argv[])
       std::cout << cam << std::endl;
       vpDisplay::setTitle(I, "With distortion results");
 
+      ss_additional_info << "<with_distortion>";
       for (size_t i = 0; i < calibrator.size(); i++) {
         double reproj_error = sqrt(calibrator[i].getResidual_dist() / calibrator[i].get_npt());
 
         const CalibInfo &calib = calib_info[i];
         std::cout << "Image " << calib.m_frame_name << " reprojection error: " << reproj_error << std::endl;
+        ss_additional_info << "<image>" << reproj_error << "</image>";
         I = calib.m_img;
         vpDisplay::display(I);
 
@@ -556,9 +561,10 @@ int main(int argc, const char *argv[])
           vpTime::wait(s.tempo * 1000);
         }
       }
-
       std::cout << "\nGlobal reprojection error: " << error << std::endl;
-      ss_additional_info << "<with_distortion>" << error << "</with_distortion></global_reprojection_error>";
+      ss_additional_info << "<global_reprojection_error>" << error << "</global_reprojection_error>";
+
+      ss_additional_info << "</with_distortion></reprojection_error>";
 
       vpImage<unsigned char> I_undist;
       vpImage<unsigned char> I_dist_undist(I.getHeight(), 2 * I.getWidth());


### PR DESCRIPTION
Intrinsic calibration produces now the following xml file with reprojection errors as additional info:

```
% cat camera.xml
<?xml version="1.0"?>
<root>
  <!--This file stores intrinsic camera parameters used
   in the vpCameraParameters Class of ViSP available
   at https://visp.inria.fr/download/ .
   It can be read with the parse method of
   the vpXmlParserCamera class.-->
  <camera>
    <!--Name of the camera-->
    <name>Camera</name>
    <!--Size of the image on which camera calibration was performed-->
    <image_width>640</image_width>
    <image_height>480</image_height>
    <!--Intrinsic camera parameters computed for each projection model-->
    <model>
      <!--Projection model type-->
      <type>perspectiveProjWithoutDistortion</type>
      <!--Pixel ratio-->
      <px>557.25485010539455</px>
      <py>561.17983205643293</py>
      <!--Principal point-->
      <u0>360.0793526644224</u0>
      <v0>235.52040441989564</v0>
    </model>
    <model>
      <!--Projection model type-->
      <type>perspectiveProjWithDistortion</type>
      <!--Pixel ratio-->
      <px>536.98426882336514</px>
      <py>537.42098727996699</py>
      <!--Principal point-->
      <u0>344.1106726372517</u0>
      <v0>235.17402278079743</v0>
      <!--Undistorted to distorted distortion parameter-->
      <kud>-0.26727954018340483</kud>
      <!--Distorted to undistorted distortion parameter-->
      <kdu>0.30811992346154732</kdu>
    </model>
    <!--Additional information-->
    <additional_information>
      <date>2025/03/06 09:17:19</date>
      <nb_calibration_images>13</nb_calibration_images>
      <calibration_pattern_type>Chessboard</calibration_pattern_type>
      <board_size>9x6</board_size>
      <square_size>0.025</square_size>
      <reprojection_error>
        <without_distortion>
          <image>1.23009</image>
          <image>1.4479</image>
          <image>2.07849</image>
          <image>1.55391</image>
          <image>1.6979</image>
          <image>2.2849</image>
          <image>1.38791</image>
          <image>1.66505</image>
          <image>0.944746</image>
          <image>1.25912</image>
          <image>1.84517</image>
          <image>0.862164</image>
          <image>1.25425</image>
          <global_reprojection_error>1.5528</global_reprojection_error>
        </without_distortion>
        <with_distortion>
          <image>0.239524</image>
          <image>1.23998</image>
          <image>0.32084</image>
          <image>0.260246</image>
          <image>0.233655</image>
          <image>0.329736</image>
          <image>0.24755</image>
          <image>0.260183</image>
          <image>0.315593</image>
          <image>0.198595</image>
          <image>0.228694</image>
          <image>0.406181</image>
          <image>0.194952</image>
          <global_reprojection_error>0.434157</global_reprojection_error>
        </with_distortion>
      </reprojection_error>
      <camera_poses>
        <cMo>-0.08850511196  -0.1086255869  0.4229682013  0.1408105979  0.2208833127  0.01502572493</cMo>
        <cMo>-0.07039192888  0.08185274845  0.3685979378  0.4482244115  0.6289505113  -1.325251516</cMo>
        <cMo>-0.05107058839  -0.1002902856  0.3364966925  -0.2914305332  0.1238930137  0.3477197919</cMo>
        <cMo>-0.1087970938  -0.06700272028  0.3494413961  -0.1205411989  0.2238307847  -0.003285892102</cMo>
        <cMo>0.04784651899  -0.1140465854  0.3392122509  -0.3331158005  0.4097035788  1.304212749</cMo>
        <cMo>0.160136556  -0.06515780376  0.3815833119  0.3204799595  0.2266591305  1.667096264</cMo>
        <cMo>0.005075004378  -0.0716906411  0.4152067105  0.1986327002  0.3349024685  1.86913986</cMo>
        <cMo>0.06855453931  -0.087583316  0.3404653186  -0.1269049962  0.4635087173  1.748445179</cMo>
        <cMo>-0.07622111746  -0.08105065716  0.2981633496  0.1987762657  -0.4488341121  0.1354284405</cMo>
        <cMo>0.03583229702  -0.1108774196  0.3613675665  -0.4314182753  -0.5113417132  1.333678423</cMo>
        <cMo>0.0401248549  -0.1020969572  0.3445032764  -0.2662362438  0.3443441152  1.522237939</cMo>
        <cMo>0.02396291721  -0.09099307392  0.3112619919  0.4529346612  -0.3193549806  1.245572274</cMo>
        <cMo>0.03472784118  -0.1079526735  0.33472772  -0.1718412229  -0.4813894921  1.348285059</cMo>
        <cMo_dist>-0.07661381617  -0.1085688981  0.4003480492  0.1682281819  0.2703019062  0.01344228168</cMo_dist>
        <cMo_dist>-0.05978250358  0.08323472139  0.3540349985  0.4146581353  0.6466346432  -1.336317135</cMo_dist>
        <cMo_dist>-0.04094572305  -0.1000649382  0.3187343436  -0.2814927361  0.1815868901  0.3544685038</cMo_dist>
        <cMo_dist>-0.09953553748  -0.06699775386  0.3311909808  -0.1147337346  0.2351254056  -0.002273549305</cMo_dist>
        <cMo_dist>0.05740570098  -0.1148657185  0.318138578  -0.2976985051  0.4268999767  1.311797528</cMo_dist>
        <cMo_dist>0.1661787419  -0.06524239744  0.3380916463  0.4034217166  0.303973624  1.649409845</cMo_dist>
        <cMo_dist>0.0182028761  -0.07151210182  0.3905563416  0.1725146046  0.3466699788  1.868092519</cMo_dist>
        <cMo_dist>0.07797369855  -0.08758418801  0.3176622931  -0.09719340084  0.4802753988  1.752361848</cMo_dist>
        <cMo_dist>-0.06738215892  -0.08077996667  0.2789813682  0.2019436508  -0.4260055128  0.1329008991</cMo_dist>
        <cMo_dist>0.04572153866  -0.1106647096  0.3391396207  -0.4227543541  -0.5001401355  1.335601269</cMo_dist>
        <cMo_dist>0.04965829714  -0.1021922494  0.3230845017  -0.2442271552  0.3486700082  1.529618139</cMo_dist>
        <cMo_dist>0.03267481523  -0.09134322129  0.2922552347  0.4616592695  -0.2854858069  1.239449511</cMo_dist>
        <cMo_dist>0.04391324121  -0.1078920125  0.3135431949  -0.1734246774  -0.4713429017  1.346435352</cMo_dist>
      </camera_poses>
    </additional_information>
  </camera>
</root>
```