### PR TITLE
Fix build error with cv::v_mul when OpenCV >= 4.9 && < 4.11 on exotic platforms

### DIFF
--- a/modules/tracker/mbt/src/depth/vpMbtFaceDepthDense.cpp
+++ b/modules/tracker/mbt/src/depth/vpMbtFaceDepthDense.cpp
@@ -75,9 +75,19 @@
 #endif
 
 #if (VISP_HAVE_OPENCV_VERSION >= 0x040101 || (VISP_HAVE_OPENCV_VERSION < 0x040000 && VISP_HAVE_OPENCV_VERSION >= 0x030407)) && USE_SIMD_CODE
+
+// See: https://github.com/lagadic/visp/issues/1606
+// 0x040B00 --> (4<<16 | 11<<8 | 0)
+// Only starting from OpenCV 4.11 cv::v_mul is available for all the platforms
+// So if OpenCV >= 4.11 || OpenCV < 4.9 --> use OpenCV HAL API
+// Otherwise, only if between >= 4.9 && < 4.11 and on regular platform (X86 && ARM64) --> use OpenCV HAL API
+#if (VISP_HAVE_OPENCV_VERSION >= 0x040B00) || (VISP_HAVE_OPENCV_VERSION < 0x040900) || \
+  ( (VISP_HAVE_OPENCV_VERSION >= 0x040900) && (VISP_HAVE_OPENCV_VERSION < 0x040B00) && (USE_SSE || USE_NEON) )
 #define USE_OPENCV_HAL 1
 #include <opencv2/core/simd_intrinsics.hpp>
 #include <opencv2/core/hal/intrin.hpp>
+#endif
+
 #endif
 
 #if !USE_OPENCV_HAL && (USE_SSE || USE_NEON)


### PR DESCRIPTION
Try to fix https://github.com/lagadic/visp/issues/1606

OpenCV HAL API for v_mul is available for all the platforms only starting from 4.11: https://docs.opencv.org/4.11.0/df/d91/group__core__hal__intrin.html#gaaa56a561e899888ef65fc2c2e258b892

So between >= 4.9 and < 4.11 we should be able to use OpenCV HAL only with regular architectures: X86 or ARM64

---

General configurations:

<details>
  <summary>Build is OK for "amd64 	3.6.0-4	Installed	13d 3h 37m	x86-ubc-01"</summary>
  
  ```bash
-- Performing Test HAVE_SSE2 (check file: cmake/checks/cpu_sse2.cpp)
-- Performing Test HAVE_SSE2 - Success
-- Performing Test HAVE_SSE3 (check file: cmake/checks/cpu_sse3.cpp)
-- Performing Test HAVE_SSE3 - Success
-- Performing Test HAVE_SSSE3 (check file: cmake/checks/cpu_ssse3.cpp)
-- Performing Test HAVE_SSSE3 - Success
-- Performing Test HAVE_SSE4_1 (check file: cmake/checks/cpu_sse41.cpp)
-- Performing Test HAVE_SSE4_1 - Failed
-- Performing Test HAVE_SSE4_2 (check file: cmake/checks/cpu_sse42.cpp)
-- Performing Test HAVE_SSE4_2 - Failed
-- Performing Test HAVE_AVX (check file: cmake/checks/cpu_avx.cpp)
-- Performing Test HAVE_AVX - Failed
-- Performing Test HAVE_AVX2 (check file: cmake/checks/cpu_avx2.cpp)
-- Performing Test HAVE_AVX2 - Failed
-- Performing Test HAVE_NEON (check file: cmake/checks/cpu_neon.cpp)
-- Performing Test HAVE_NEON - Failed
-- 
-- ==========================================================
-- General configuration information for ViSP 3.6.0
-- 
--   Version control:               unknown
-- 
--   Platform:
--     Timestamp:                   2025-02-16T17:47:35Z
--     Host:                        Linux 6.1.0-31-amd64 x86_64
--     CMake:                       3.31.5
--     CMake generator:             Unix Makefiles
--     CMake build tool:            /usr/bin/gmake
--     Configuration:               Release
-- 
--   System information:
--     Number of CPU logical cores: 6
--     Number of CPU physical cores: 6
--     Total physical memory (in MiB): 15990
--     OS name:                     Linux
--     OS release:                  6.1.0-31-amd64
--     OS version:                  #1 SMP PREEMPT_DYNAMIC Debian 6.1.128-1 (2025-02-07)
--     OS platform:                 x86_64
--     CPU name:                    Unknown AMD family
--     Is the CPU 64-bit?           yes
--     Does the CPU have FPU?       yes
--     CPU optimization:            SSE2 SSE3 SSSE3
-- 
--   C/C++:
--     Built as dynamic libs?:      yes
--     C++ Compiler:                /usr/bin/c++  (ver 14.2.0)
--     C++ flags (Release):         -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection
--     C++ flags (Debug):           -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g
--     C Compiler:                  /usr/bin/cc
--     C flags (Release):           -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection
--     C flags (Debug):             -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -msse2 -msse3 -mssse3 -fPIC -g
--     Linker flags (Release):      -Wl,-z,relro -Wl,-z,now -Wl,-z,relro -Wl,-z,now
--     Linker flags (Debug):        -Wl,-z,relro -Wl,-z,now
--     Use cxx standard:            17
-- 
--   ViSP modules:
--     To be built:                 core dnn_tracker gui imgproc io java_bindings_generator klt me sensor ar blob robot visual_features vs vision detection mbt tt tt_mi
--     Disabled:                    -
--     Disabled by dependency:      -
--     Unavailable:                 java
-- 
--   Python (for build):            no
-- 
--   Java:                          
--     ant:                         no
--     JNI:                         no
-- 
--   Build options: 
--     Build deprecated:            yes
--     Build with moment combine:   no
-- 
--   OpenCV: 
--     Version:                     4.10.0
--     Modules:                     calib3d core dnn features2d flann highgui imgcodecs imgproc ml objdetect photo stitching video videoio alphamat aruco bgsegm bioinspired ccalib cvv datasets dnn_objdetect dnn_superres dpm face freetype fuzzy hdf hfs img_hash intensity_transform line_descriptor mcc optflow phase_unwrapping plot quality rapid reg rgbd saliency shape signal stereo structured_light superres surface_matching text tracking videostab viz wechat_qrcode ximgproc xobjdetect xphoto
--     OpenCV dir:                  /usr/lib/x86_64-linux-gnu/cmake/opencv4
-- 
--   Mathematics: 
--     Blas/Lapack:                 yes
--     \- Use MKL:                  no
--     \- Use OpenBLAS:             no
--     \- Use Atlas:                no
--     \- Use Netlib:               no
--     \- Use GSL:                  yes (ver 2.8)
--     \- Use Lapack (built-in):    no
--     Use Eigen3:                  yes (ver 3.4.0)
--     Use OpenCV:                  yes (ver 4.10.0)
-- 
--   Simulator: 
--     Ogre simulator: 
--     \- Use Ogre3D:               no
--     \- Use OIS:                  no
--     Coin simulator: 
--     \- Use Coin3D:               yes (ver 4.0.3)
--     \- Use SoWin:                no
--     \- Use SoXt:                 no
--     \- Use SoQt:                 no
--     \- Use Qt5:                  no
--     \- Use Qt4:                  no
--     \- Use Qt3:                  no
-- 
--   Media I/O: 
--     Use JPEG:                    yes (ver 62)
--     Use PNG:                     yes (ver 1.6.47)
--     \- Use ZLIB:                 yes (ver 1.3.1)
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use stb_image (built-in):    yes (ver 2.27.0)
--     Use TinyEXR (built-in):      yes (ver 1.0.2)
-- 
--   Real robots: 
--     Use Afma4:                   no
--     Use Afma6:                   no
--     Use Franka:                  no
--     Use Viper650:                no
--     Use Viper850:                no
--     Use ur_rtde:                 no
--     Use Kinova Jaco:             no
--     Use aria (Pioneer):          no
--     Use PTU46:                   no
--     Use Biclops PTU:             no
--     Use Flir PTU SDK:            no
--     Use MAVSDK:                  no
--     Use Parrot ARSDK:            no
--     \-Use ffmpeg:                no
--     Use Virtuose:                no
--     Use qbdevice (built-in):     yes (ver 2.6.0)
--     Use takktile2 (built-in):    yes (ver 1.0.0)
-- 
--   GUI: 
--     Use X11:                     yes
--     Use GTK:                     no
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use GDI:                     no
--     Use Direct3D:                no
-- 
--   Cameras: 
--     Use DC1394-2.x:              yes (ver 2.2.6)
--     Use CMU 1394:                no
--     Use V4L2:                    yes (ver 1.28.1)
--     Use directshow:              no
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use FLIR Flycapture:         no
--     Use Basler Pylon:            no
--     Use IDS uEye:                no
-- 
--   RGB-D sensors: 
--     Use Realsense:               no
--     Use Realsense2:              no
--     Use Occipital Structure:     no
--     Use Kinect:                  no
--     \- Use libfreenect:          no
--     \- Use libusb-1:             no
--     \- Use pthread:              yes
--     Use PCL:                     no
--     \- Use VTK:                  no
-- 
--   F/T sensors: 
--     Use atidaq (built-in):       no
--     Use comedi:                  no
--     Use IIT SDK:                 no
-- 
--   Mocap: 
--     Use Qualisys:                no
--     Use Vicon:                   no
-- 
--   Detection: 
--     Use zbar:                    no
--     Use dmtx:                    yes (ver 0.7.7)
--     Use AprilTag (built-in):     yes (ver 3.1.1)
--     \- Use AprilTag big family:  no
-- 
--   Misc: 
--     Use Clipper (built-in):      yes (ver 6.4.2)
--     Use pugixml (built-in):      yes (ver 1.9.0)
--     Use libxml2:                 yes (ver 2.9.14)
--     Use json (nlohmann):         yes (ver 3.11.3)
-- 
--   Optimization: 
--     Use OpenMP:                  yes
--     Use pthread:                 yes
--     Use pthread (built-in):      no
--     Use Simd (built-in):         yes (ver 4.9.109)
-- 
--   DNN: 
--     Use CUDA Toolkit:            no
--     Use TensorRT:                no
-- 
--   Documentation: 
--     Use doxygen:                 yes
--     \- Use mathjax:              no
-- 
--   Tests and samples:
--     Use catch2 (built-in):       yes (ver 2.13.7)
--     Tests:                       yes
--     Demos:                       yes
--     Examples:                    yes
--     Tutorials:                   yes
--     Dataset found:               yes (ver 3.6.0 in /usr/share/visp-images-data/ViSP-images)
-- 
--   Library dirs:
--     Eigen3 include dir:          /usr/share/eigen3/cmake
--     OpenCV dir:                  /usr/lib/x86_64-linux-gnu/cmake/opencv4
-- 
--   Install path:                  /usr
-- 
-- ==========================================================
-- Configuring done (31.3s)
-- Generating done (3.5s)
  ```
</details>

<details>
  <summary>Build is OK for "arm64 	3.6.0-4	Installed	13d 2h 37m	arm-ubc-01"</summary>
  
  ```bash
-- Performing Test HAVE_SSE2 (check file: cmake/checks/cpu_sse2.cpp)
-- Performing Test HAVE_SSE2 - Failed
-- Performing Test HAVE_SSE3 (check file: cmake/checks/cpu_sse3.cpp)
-- Performing Test HAVE_SSE3 - Failed
-- Performing Test HAVE_SSSE3 (check file: cmake/checks/cpu_ssse3.cpp)
-- Performing Test HAVE_SSSE3 - Failed
-- Performing Test HAVE_SSE4_1 (check file: cmake/checks/cpu_sse41.cpp)
-- Performing Test HAVE_SSE4_1 - Failed
-- Performing Test HAVE_SSE4_2 (check file: cmake/checks/cpu_sse42.cpp)
-- Performing Test HAVE_SSE4_2 - Failed
-- Performing Test HAVE_AVX (check file: cmake/checks/cpu_avx.cpp)
-- Performing Test HAVE_AVX - Failed
-- Performing Test HAVE_AVX2 (check file: cmake/checks/cpu_avx2.cpp)
-- Performing Test HAVE_AVX2 - Failed
-- Performing Test HAVE_NEON (check file: cmake/checks/cpu_neon.cpp)
-- Performing Test HAVE_NEON - Success
-- 
-- ==========================================================
-- General configuration information for ViSP 3.6.0
-- 
--   Version control:               unknown
-- 
--   Platform:
--     Timestamp:                   2025-02-16T17:47:35Z
--     Host:                        Linux 6.1.0-31-arm64 aarch64
--     CMake:                       3.31.5
--     CMake generator:             Unix Makefiles
--     CMake build tool:            /usr/bin/gmake
--     Configuration:               Release
-- 
--   System information:
--     Number of CPU logical cores: 4
--     Number of CPU physical cores: 1
--     Total physical memory (in MiB): 11950
--     OS name:                     Linux
--     OS release:                  6.1.0-31-arm64
--     OS version:                  #1 SMP Debian 6.1.128-1 (2025-02-07)
--     OS platform:                 aarch64
--     CPU name:                    Unknown family
--     Is the CPU 64-bit?           yes
--     Does the CPU have FPU?       no
--     CPU optimization:            NEON
-- 
--   C/C++:
--     Built as dynamic libs?:      yes
--     C++ Compiler:                /usr/bin/c++  (ver 14.2.0)
--     C++ flags (Release):         -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard
--     C++ flags (Debug):           -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g
--     C Compiler:                  /usr/bin/cc
--     C flags (Release):           -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard
--     C flags (Debug):             -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -mbranch-protection=standard -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g
--     Linker flags (Release):      -Wl,-z,relro -Wl,-z,now -Wl,-z,relro -Wl,-z,now
--     Linker flags (Debug):        -Wl,-z,relro -Wl,-z,now
--     Use cxx standard:            17
-- 
--   ViSP modules:
--     To be built:                 core dnn_tracker gui imgproc io java_bindings_generator klt me sensor ar blob robot visual_features vs vision detection mbt tt tt_mi
--     Disabled:                    -
--     Disabled by dependency:      -
--     Unavailable:                 java
-- 
--   Python (for build):            no
-- 
--   Java:                          
--     ant:                         no
--     JNI:                         no
-- 
--   Build options: 
--     Build deprecated:            yes
--     Build with moment combine:   no
-- 
--   OpenCV: 
--     Version:                     4.10.0
--     Modules:                     calib3d core dnn features2d flann highgui imgcodecs imgproc ml objdetect photo stitching video videoio alphamat aruco bgsegm bioinspired ccalib cvv datasets dnn_objdetect dnn_superres dpm face freetype fuzzy hdf hfs img_hash intensity_transform line_descriptor mcc optflow phase_unwrapping plot quality rapid reg rgbd saliency shape signal stereo structured_light superres surface_matching text tracking videostab viz wechat_qrcode ximgproc xobjdetect xphoto
--     OpenCV dir:                  /usr/lib/aarch64-linux-gnu/cmake/opencv4
-- 
--   Mathematics: 
--     Blas/Lapack:                 yes
--     \- Use MKL:                  no
--     \- Use OpenBLAS:             no
--     \- Use Atlas:                no
--     \- Use Netlib:               no
--     \- Use GSL:                  yes (ver 2.8)
--     \- Use Lapack (built-in):    no
--     Use Eigen3:                  yes (ver 3.4.0)
--     Use OpenCV:                  yes (ver 4.10.0)
-- 
--   Simulator: 
--     Ogre simulator: 
--     \- Use Ogre3D:               no
--     \- Use OIS:                  no
--     Coin simulator: 
--     \- Use Coin3D:               yes (ver 4.0.3)
--     \- Use SoWin:                no
--     \- Use SoXt:                 no
--     \- Use SoQt:                 no
--     \- Use Qt5:                  no
--     \- Use Qt4:                  no
--     \- Use Qt3:                  no
-- 
--   Media I/O: 
--     Use JPEG:                    yes (ver 62)
--     Use PNG:                     yes (ver 1.6.47)
--     \- Use ZLIB:                 yes (ver 1.3.1)
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use stb_image (built-in):    yes (ver 2.27.0)
--     Use TinyEXR (built-in):      yes (ver 1.0.2)
-- 
--   Real robots: 
--     Use Afma4:                   no
--     Use Afma6:                   no
--     Use Franka:                  no
--     Use Viper650:                no
--     Use Viper850:                no
--     Use ur_rtde:                 no
--     Use Kinova Jaco:             no
--     Use aria (Pioneer):          no
--     Use PTU46:                   no
--     Use Biclops PTU:             no
--     Use Flir PTU SDK:            no
--     Use MAVSDK:                  no
--     Use Parrot ARSDK:            no
--     \-Use ffmpeg:                no
--     Use Virtuose:                no
--     Use qbdevice (built-in):     yes (ver 2.6.0)
--     Use takktile2 (built-in):    yes (ver 1.0.0)
-- 
--   GUI: 
--     Use X11:                     yes
--     Use GTK:                     no
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use GDI:                     no
--     Use Direct3D:                no
-- 
--   Cameras: 
--     Use DC1394-2.x:              yes (ver 2.2.6)
--     Use CMU 1394:                no
--     Use V4L2:                    yes (ver 1.28.1)
--     Use directshow:              no
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use FLIR Flycapture:         no
--     Use Basler Pylon:            no
--     Use IDS uEye:                no
-- 
--   RGB-D sensors: 
--     Use Realsense:               no
--     Use Realsense2:              no
--     Use Occipital Structure:     no
--     Use Kinect:                  no
--     \- Use libfreenect:          no
--     \- Use libusb-1:             no
--     \- Use pthread:              yes
--     Use PCL:                     no
--     \- Use VTK:                  no
-- 
--   F/T sensors: 
--     Use atidaq (built-in):       no
--     Use comedi:                  no
--     Use IIT SDK:                 no
-- 
--   Mocap: 
--     Use Qualisys:                no
--     Use Vicon:                   no
-- 
--   Detection: 
--     Use zbar:                    no
--     Use dmtx:                    yes (ver 0.7.7)
--     Use AprilTag (built-in):     yes (ver 3.1.1)
--     \- Use AprilTag big family:  no
-- 
--   Misc: 
--     Use Clipper (built-in):      yes (ver 6.4.2)
--     Use pugixml (built-in):      yes (ver 1.9.0)
--     Use libxml2:                 yes (ver 2.9.14)
--     Use json (nlohmann):         yes (ver 3.11.3)
-- 
--   Optimization: 
--     Use OpenMP:                  yes
--     Use pthread:                 yes
--     Use pthread (built-in):      no
--     Use Simd (built-in):         yes (ver 4.9.109)
-- 
--   DNN: 
--     Use CUDA Toolkit:            no
--     Use TensorRT:                no
-- 
--   Documentation: 
--     Use doxygen:                 yes
--     \- Use mathjax:              no
-- 
--   Tests and samples:
--     Use catch2 (built-in):       yes (ver 2.13.7)
--     Tests:                       yes
--     Demos:                       yes
--     Examples:                    yes
--     Tutorials:                   yes
--     Dataset found:               yes (ver 3.6.0 in /usr/share/visp-images-data/ViSP-images)
-- 
--   Library dirs:
--     Eigen3 include dir:          /usr/share/eigen3/cmake
--     OpenCV dir:                  /usr/lib/aarch64-linux-gnu/cmake/opencv4
-- 
--   Install path:                  /usr
-- 
-- ==========================================================
-- Configuring done (87.9s)
-- Generating done (8.0s)
  ```
</details>

---

Builds are NOK for:
- `armel`
- `armhf`
- `mips64el`
- `riscv64`
- `s390x`

<details>
  <summary>Build is NOK for "s390x  3.6.0-4	Build-Attempted	11d 2h 21m	zani"</summary>
  
  ```bash
-- Performing Test HAVE_SSE2 (check file: cmake/checks/cpu_sse2.cpp)
-- Performing Test HAVE_SSE2 - Failed
-- Performing Test HAVE_SSE3 (check file: cmake/checks/cpu_sse3.cpp)
-- Performing Test HAVE_SSE3 - Failed
-- Performing Test HAVE_SSSE3 (check file: cmake/checks/cpu_ssse3.cpp)
-- Performing Test HAVE_SSSE3 - Failed
-- Performing Test HAVE_SSE4_1 (check file: cmake/checks/cpu_sse41.cpp)
-- Performing Test HAVE_SSE4_1 - Failed
-- Performing Test HAVE_SSE4_2 (check file: cmake/checks/cpu_sse42.cpp)
-- Performing Test HAVE_SSE4_2 - Failed
-- Performing Test HAVE_AVX (check file: cmake/checks/cpu_avx.cpp)
-- Performing Test HAVE_AVX - Failed
-- Performing Test HAVE_AVX2 (check file: cmake/checks/cpu_avx2.cpp)
-- Performing Test HAVE_AVX2 - Failed
-- Performing Test HAVE_NEON (check file: cmake/checks/cpu_neon.cpp)
-- Performing Test HAVE_NEON - Failed
-- 
-- ==========================================================
-- General configuration information for ViSP 3.6.0
-- 
--   Version control:               unknown
-- 
--   Platform:
--     Timestamp:                   2025-02-16T17:47:35Z
--     Host:                        Linux 6.1.0-31-s390x s390x
--     CMake:                       3.31.6
--     CMake generator:             Unix Makefiles
--     CMake build tool:            /usr/bin/gmake
--     Configuration:               Release
-- 
--   System information:
--     Number of CPU logical cores: 2
--     Number of CPU physical cores: 2
--     Total physical memory (in MiB): 8026
--     OS name:                     Linux
--     OS release:                  6.1.0-31-s390x
--     OS version:                  #1 SMP Debian 6.1.128-1 (2025-02-07)
--     OS platform:                 s390x
--     CPU name:                    3241.00
--     Is the CPU 64-bit?           yes
--     Does the CPU have FPU?       no
--     CPU optimization:
-- 
--   C/C++:
--     Built as dynamic libs?:      yes
--     C++ Compiler:                /usr/bin/c++  (ver 14.2.0)
--     C++ flags (Release):         -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -Wformat -Werror=format-security
--     C++ flags (Debug):           -g -O2 -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g
--     C Compiler:                  /usr/bin/cc
--     C flags (Release):           -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -Wformat -Werror=format-security
--     C flags (Debug):             -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/visp-3.6.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -Wall -Wextra -fopenmp -std=c++17 -fvisibility=hidden -fPIC -g
--     Linker flags (Release):      -Wl,-z,relro -Wl,-z,now -Wl,-z,relro -Wl,-z,now
--     Linker flags (Debug):        -Wl,-z,relro -Wl,-z,now
--     Use cxx standard:            17
-- 
--   ViSP modules:
--     To be built:                 core dnn_tracker gui imgproc io java_bindings_generator klt me sensor ar blob robot visual_features vs vision detection mbt tt tt_mi
--     Disabled:                    -
--     Disabled by dependency:      -
--     Unavailable:                 java
-- 
--   Python (for build):            no
-- 
--   Java:                          
--     ant:                         no
--     JNI:                         no
-- 
--   Build options: 
--     Build deprecated:            yes
--     Build with moment combine:   no
-- 
--   OpenCV: 
--     Version:                     4.10.0
--     Modules:                     calib3d core dnn features2d flann highgui imgcodecs imgproc ml objdetect photo stitching video videoio alphamat aruco bgsegm bioinspired ccalib cvv datasets dnn_objdetect dnn_superres dpm face freetype fuzzy hdf hfs img_hash intensity_transform line_descriptor mcc optflow phase_unwrapping plot quality rapid reg rgbd saliency shape signal stereo structured_light superres surface_matching text tracking videostab viz wechat_qrcode ximgproc xobjdetect xphoto
--     OpenCV dir:                  /usr/lib/s390x-linux-gnu/cmake/opencv4
-- 
--   Mathematics: 
--     Blas/Lapack:                 yes
--     \- Use MKL:                  no
--     \- Use OpenBLAS:             no
--     \- Use Atlas:                no
--     \- Use Netlib:               no
--     \- Use GSL:                  yes (ver 2.8)
--     \- Use Lapack (built-in):    no
--     Use Eigen3:                  yes (ver 3.4.0)
--     Use OpenCV:                  yes (ver 4.10.0)
-- 
--   Simulator: 
--     Ogre simulator: 
--     \- Use Ogre3D:               no
--     \- Use OIS:                  no
--     Coin simulator: 
--     \- Use Coin3D:               yes (ver 4.0.3)
--     \- Use SoWin:                no
--     \- Use SoXt:                 no
--     \- Use SoQt:                 no
--     \- Use Qt5:                  no
--     \- Use Qt4:                  no
--     \- Use Qt3:                  no
-- 
--   Media I/O: 
--     Use JPEG:                    yes (ver 62)
--     Use PNG:                     yes (ver 1.6.47)
--     \- Use ZLIB:                 yes (ver 1.3.1)
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use stb_image (built-in):    yes (ver 2.27.0)
--     Use TinyEXR (built-in):      yes (ver 1.0.2)
-- 
--   Real robots: 
--     Use Afma4:                   no
--     Use Afma6:                   no
--     Use Franka:                  no
--     Use Viper650:                no
--     Use Viper850:                no
--     Use ur_rtde:                 no
--     Use Kinova Jaco:             no
--     Use aria (Pioneer):          no
--     Use PTU46:                   no
--     Use Biclops PTU:             no
--     Use Flir PTU SDK:            no
--     Use MAVSDK:                  no
--     Use Parrot ARSDK:            no
--     \-Use ffmpeg:                no
--     Use Virtuose:                no
--     Use qbdevice (built-in):     yes (ver 2.6.0)
--     Use takktile2 (built-in):    yes (ver 1.0.0)
-- 
--   GUI: 
--     Use X11:                     yes
--     Use GTK:                     no
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use GDI:                     no
--     Use Direct3D:                no
-- 
--   Cameras: 
--     Use DC1394-2.x:              yes (ver 2.2.6)
--     Use CMU 1394:                no
--     Use V4L2:                    yes (ver 1.28.1)
--     Use directshow:              no
--     Use OpenCV:                  yes (ver 4.10.0)
--     Use FLIR Flycapture:         no
--     Use Basler Pylon:            no
--     Use IDS uEye:                no
-- 
--   RGB-D sensors: 
--     Use Realsense:               no
--     Use Realsense2:              no
--     Use Occipital Structure:     no
--     Use Kinect:                  no
--     \- Use libfreenect:          no
--     \- Use libusb-1:             no
--     \- Use pthread:              yes
--     Use PCL:                     no
--     \- Use VTK:                  no
-- 
--   F/T sensors: 
--     Use atidaq (built-in):       no
--     Use comedi:                  no
--     Use IIT SDK:                 no
-- 
--   Mocap: 
--     Use Qualisys:                no
--     Use Vicon:                   no
-- 
--   Detection: 
--     Use zbar:                    no
--     Use dmtx:                    yes (ver 0.7.7)
--     Use AprilTag (built-in):     yes (ver 3.1.1)
--     \- Use AprilTag big family:  no
-- 
--   Misc: 
--     Use Clipper (built-in):      yes (ver 6.4.2)
--     Use pugixml (built-in):      yes (ver 1.9.0)
--     Use libxml2:                 yes (ver 2.9.14)
--     Use json (nlohmann):         yes (ver 3.11.3)
-- 
--   Optimization: 
--     Use OpenMP:                  yes
--     Use pthread:                 yes
--     Use pthread (built-in):      no
--     Use Simd (built-in):         yes (ver 4.9.109)
-- 
--   DNN: 
--     Use CUDA Toolkit:            no
--     Use TensorRT:                no
-- 
--   Documentation: 
--     Use doxygen:                 yes
--     \- Use mathjax:              no
-- 
--   Tests and samples:
--     Use catch2 (built-in):       yes (ver 2.13.7)
--     Tests:                       yes
--     Demos:                       yes
--     Examples:                    yes
--     Tutorials:                   yes
--     Dataset found:               yes (ver 3.6.0 in /usr/share/visp-images-data/ViSP-images)
-- 
--   Library dirs:
--     Eigen3 include dir:          /usr/share/eigen3/cmake
--     OpenCV dir:                  /usr/lib/s390x-linux-gnu/cmake/opencv4
-- 
--   Install path:                  /usr
-- 
-- ==========================================================
-- Configuring done (9.8s)
-- Generating done (2.2s)
  ```
</details>