### PR TITLE
Fix nix workflow warning

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: DeterminateSystems/flakehub-cache-action@main
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix build -L


### PR DESCRIPTION
Magic Nix Cache is deprecated

Magic Nix Cache has been deprecated due to a change in the underlying GitHub APIs and will stop working on 1 February 2025. To continue caching Nix builds in GitHub Actions, use FlakeHub Cache instead.

Replace...
      - uses: DeterminateSystems/magic-nix-cache-action@main

...with...
      - uses: DeterminateSystems/flakehub-cache-action@main

For more details: https://dtr.mn/magic-nix-cache-eol