### PR TITLE
Improvements and optimization for Render-Based Tracker

### DIFF
--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -45,6 +45,7 @@
 
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpException.h>
+#include <visp3/core/vpMath.h>
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
 #include VISP_NLOHMANN_JSON(json.hpp)
@@ -1180,6 +1181,17 @@ public:
   */
   static void insert(const vpArray2D<Type> &A, const vpArray2D<Type> &B, vpArray2D<Type> &C, unsigned int r, unsigned int c);
   //@}
+
+  static bool isFinite(const vpArray2D<double> &A)
+  {
+    const unsigned int s = A.size();
+    for (unsigned int i = 0; i < s; ++i) {
+      if (vpMath::isNaN(A.data[i]) || vpMath::isInf(A.data[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
 
 protected:
   //! Number of rows in the array

--- a/modules/core/include/visp3/core/vpArray2D.h
+++ b/modules/core/include/visp3/core/vpArray2D.h
@@ -1186,7 +1186,7 @@ public:
   {
     const unsigned int s = A.size();
     for (unsigned int i = 0; i < s; ++i) {
-      if (vpMath::isNaN(A.data[i]) || vpMath::isInf(A.data[i])) {
+      if (!vpMath::isFinite(A.data[i])) {
         return false;
       }
     }

--- a/modules/python/config/rbt.json
+++ b/modules/python/config/rbt.json
@@ -347,9 +347,10 @@
         },
         {
           "static": false,
-          "signature": "void selectValidNewCandidates(const vpCameraParameters&, const vpHomogeneousMatrix&, const vpArray2D<int>&, const vpMatrix&, const vpImage<float>&, vpMatrix&, std::list<int>&)",
+          "signature": "void selectValidNewCandidates(const vpCameraParameters&, const vpHomogeneousMatrix&, const vpArray2D<int>&, const vpMatrix&,  const vpImage<float>&, const vpImage<float>&, vpMatrix&, std::list<int>&)",
           "use_default_param_policy": false,
           "param_is_input": [
+            true,
             true,
             true,
             true,
@@ -359,6 +360,7 @@
             false
           ],
           "param_is_output": [
+            false,
             false,
             false,
             false,

--- a/modules/python/config/rbt.json
+++ b/modules/python/config/rbt.json
@@ -292,7 +292,7 @@
       "methods": [
         {
           "static": false,
-          "signature": "void getVisiblePoints(const unsigned int, const unsigned int, const vpMatrix&, const vpMatrix&, const vpColVector&, std::list<int>&)",
+          "signature": "void getVisiblePoints(const unsigned int, const unsigned int, const vpMatrix&, const vpMatrix&, const vpColVector&, std::vector<int>&)",
           "use_default_param_policy": false,
           "param_is_input": [
             true,
@@ -313,7 +313,7 @@
         },
         {
           "static": false,
-          "signature": "void getOutliers(const vpArray2D<int>&, const vpMatrix&, const vpMatrix&, std::list<int>&)",
+          "signature": "void getOutliers(const vpArray2D<int>&, const vpMatrix&, const vpMatrix&, std::vector<int>&)",
           "use_default_param_policy": false,
           "param_is_input": [
             true,
@@ -330,7 +330,7 @@
         },
         {
           "static": false,
-          "signature": "void updatePoints(const vpArray2D<int>&, const vpMatrix&, std::list<int>&, unsigned int&)",
+          "signature": "void updatePoints(const vpArray2D<int>&, const vpMatrix&, std::vector<int>&, unsigned int&)",
           "use_default_param_policy": false,
           "param_is_input": [
             true,
@@ -347,7 +347,7 @@
         },
         {
           "static": false,
-          "signature": "void selectValidNewCandidates(const vpCameraParameters&, const vpHomogeneousMatrix&, const vpArray2D<int>&, const vpMatrix&,  const vpImage<float>&, const vpImage<float>&, vpMatrix&, std::list<int>&)",
+          "signature": "void selectValidNewCandidates(const vpCameraParameters&, const vpHomogeneousMatrix&, const vpArray2D<int>&, const vpMatrix&,  const vpImage<float>&, const vpImage<float>&, vpMatrix&, std::vector<int>&)",
           "use_default_param_policy": false,
           "param_is_input": [
             true,
@@ -372,7 +372,7 @@
         },
         {
           "static": false,
-          "signature": "void getVisiblePoints(const unsigned int, const unsigned int, const vpCameraParameters&, const vpHomogeneousMatrix&, const vpImage<float>&, std::list<int>&)",
+          "signature": "void getVisiblePoints(const unsigned int, const unsigned int, const vpCameraParameters&, const vpHomogeneousMatrix&, const vpImage<float>&, std::vector<int>&)",
           "use_default_param_policy": false,
           "param_is_input": [
             true,

--- a/modules/tracker/rbt/include/visp3/rbt/vpPointMap.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpPointMap.h
@@ -45,11 +45,12 @@ BEGIN_VISP_NAMESPACE
 class VISP_EXPORT vpPointMap
 {
 public:
-  vpPointMap(unsigned maxPoints, double minDistNewPoints, double maxDepthErrorVisibility, double outlierThreshold)
+  vpPointMap(unsigned maxPoints, double minDistNewPoints, double maxDepthErrorVisibility, double maxDepthErrorCandidate, double outlierThreshold)
   {
     m_maxPoints = maxPoints;
     m_minDistNewPoint = minDistNewPoints;
-    m_maxDepthError = maxDepthErrorVisibility;
+    m_maxDepthErrorVisible = maxDepthErrorVisibility;
+    m_maxDepthErrorCandidate = maxDepthErrorCandidate;
     m_outlierThreshold = outlierThreshold;
   }
   /**
@@ -66,8 +67,11 @@ public:
   double getMinDistanceAddNewPoints() const { return m_minDistNewPoint; }
   void setMinDistanceAddNewPoints(double distance) { m_minDistNewPoint = distance; }
 
-  double getMaxDepthErrorVisibilityCriterion() const { return m_maxDepthError; }
-  void setMaxDepthErrorVisibilityCriterion(double depthError) { m_maxDepthError = depthError; }
+  double getMaxDepthErrorVisibilityCriterion() const { return m_maxDepthErrorVisible; }
+  void setMaxDepthErrorVisibilityCriterion(double depthError) { m_maxDepthErrorVisible = depthError; }
+
+  double getMaxDepthErrorCandidate() const { return m_maxDepthErrorCandidate; }
+  void setMaxDepthErrorCandidate(double depthError) { m_maxDepthErrorCandidate = depthError; }
 
   double getOutlierReprojectionErrorThreshold() const { return m_outlierThreshold; }
   void setOutlierReprojectionErrorThreshold(double thresholdPx) { m_outlierThreshold = thresholdPx; }
@@ -95,7 +99,8 @@ public:
 
   void selectValidNewCandidates(const vpCameraParameters &cam, const vpHomogeneousMatrix &cTw,
    const vpArray2D<int> &originalIndices, const vpMatrix &uvs,
-   const vpImage<float> &depth, vpMatrix &oXs, std::list<int> &validCandidateIndices);
+   const vpImage<float> &modelDepth, const vpImage<float> &depth,
+   vpMatrix &oXs, std::list<int> &validCandidateIndices);
 
   void updatePoints(const vpArray2D<int> &indicesToRemove, const vpMatrix &pointsToAdd, std::list<int> &removedIndices, unsigned int &numAddedPoints);
   void updatePoint(unsigned int index, double X, double Y, double Z)
@@ -176,7 +181,8 @@ private:
   vpMatrix m_X; // N x 3, points expressed in world frame
   unsigned m_maxPoints;
   double m_minDistNewPoint;
-  double m_maxDepthError;
+  double m_maxDepthErrorVisible;
+  double m_maxDepthErrorCandidate;
   double m_outlierThreshold;
 };
 

--- a/modules/tracker/rbt/include/visp3/rbt/vpPointMap.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpPointMap.h
@@ -91,18 +91,18 @@ public:
   void project(const vpCameraParameters &cam, const vpArray2D<int> &indices, const vpHomogeneousMatrix &cTw, vpMatrix &cX, vpMatrix &xs, vpMatrix &uvs);
 
 
-  void getVisiblePoints(const unsigned int h, const unsigned int w, const vpMatrix &cX, const vpMatrix &uvs, const vpColVector &expectedZ, std::list<int> &indices);
-  void getVisiblePoints(const unsigned int h, const unsigned int w, const vpCameraParameters &cam, const vpHomogeneousMatrix &cTw, const vpImage<float> &depth, std::list<int> &indices);
+  void getVisiblePoints(const unsigned int h, const unsigned int w, const vpMatrix &cX, const vpMatrix &uvs, const vpColVector &expectedZ, std::vector<int> &indices);
+  void getVisiblePoints(const unsigned int h, const unsigned int w, const vpCameraParameters &cam, const vpHomogeneousMatrix &cTw, const vpImage<float> &depth, std::vector<int> &indices);
 
   void getOutliers(const vpArray2D<int> &originalIndices, const vpMatrix &uvs,
-  const vpMatrix &observations, std::list<int> &indices);
+  const vpMatrix &observations, std::vector<int> &indices);
 
   void selectValidNewCandidates(const vpCameraParameters &cam, const vpHomogeneousMatrix &cTw,
    const vpArray2D<int> &originalIndices, const vpMatrix &uvs,
    const vpImage<float> &modelDepth, const vpImage<float> &depth,
-   vpMatrix &oXs, std::list<int> &validCandidateIndices);
+   vpMatrix &oXs, std::vector<int> &validCandidateIndices);
 
-  void updatePoints(const vpArray2D<int> &indicesToRemove, const vpMatrix &pointsToAdd, std::list<int> &removedIndices, unsigned int &numAddedPoints);
+  void updatePoints(const vpArray2D<int> &indicesToRemove, const vpMatrix &pointsToAdd, std::vector<int> &removedIndices, unsigned int &numAddedPoints);
   void updatePoint(unsigned int index, double X, double Y, double Z)
   {
     m_X[index][0] = X;
@@ -179,6 +179,7 @@ public:
 
 private:
   vpMatrix m_X; // N x 3, points expressed in world frame
+  vpMatrix m_Xt; // 3 x N points, in world frame (same as m_X)
   unsigned m_maxPoints;
   double m_minDistNewPoint;
   double m_maxDepthErrorVisible;

--- a/modules/tracker/rbt/include/visp3/rbt/vpPointMap.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpPointMap.h
@@ -179,7 +179,6 @@ public:
 
 private:
   vpMatrix m_X; // N x 3, points expressed in world frame
-  vpMatrix m_Xt; // 3 x N points, in world frame (same as m_X)
   unsigned m_maxPoints;
   double m_minDistNewPoint;
   double m_maxDepthErrorVisible;

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBADDSMetric.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBADDSMetric.h
@@ -42,7 +42,7 @@ BEGIN_VISP_NAMESPACE
 class VISP_EXPORT vpRBADDSMetric
 {
 public:
-  vpRBADDSMetric(unsigned int numPoints, unsigned int seed) : m_seed(seed), m_map(numPoints, 0.0, 0.0, 0.0), m_random(seed)
+  vpRBADDSMetric(unsigned int numPoints, unsigned int seed) : m_seed(seed), m_map(numPoints, 0.0, 0.0, 0.0, 0.0), m_random(seed)
   {
 
   }

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBADDSMetric.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBADDSMetric.h
@@ -60,7 +60,7 @@ public:
       }
     }
     vpArray2D<int> empty;
-    std::list<int> removed;
+    std::vector<int> removed;
     unsigned int added;
     m_map.updatePoints(empty, oX, removed, added);
     if (added != m_map.getNumMaxPoints()) {

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
@@ -152,43 +152,83 @@ public:
 
   struct vpDepthPoint
   {
-    vpDepthPoint() : currentPoint(3), cameraNormal(3), objectNormal(3)
-    { }
-
-    inline void update(const vpHomogeneousMatrix &cMo, const vpRotationMatrix &cRo)
-    {
-      oP.changeFrame(cMo);
-      oP.projection();
-      cameraNormal = cRo * objectNormal;
-    }
-
-    inline void error(vpColVector &e, unsigned i) const
-    {
-      double D = -((cameraNormal[0] * oP.get_X()) + (cameraNormal[1] * oP.get_Y()) + (cameraNormal[2] * oP.get_Z()));
-      double projNormal = cameraNormal[0] * currentPoint[0] + cameraNormal[1] * currentPoint[1] + cameraNormal[2] * currentPoint[2];
-
-      e[i] = D + projNormal;
-    }
-
-    inline void interaction(vpMatrix &L, unsigned i)
-    {
-      const double X = oP.get_X(), Y = oP.get_Y(), Z = oP.get_Z();
-      const double nx = cameraNormal[0], ny = cameraNormal[1], nz = cameraNormal[2];
-      L[i][0] = nx;
-      L[i][1] = ny;
-      L[i][2] = nz;
-      L[i][3] = nz * Y - ny * Z;
-      L[i][4] = nx * Z - nz * X;
-      L[i][5] = ny * X - nx * Y;
-    }
-
+    vpDepthPoint() { }
   public:
-    vpPoint oP;
-    vpColVector currentPoint;
-    vpColVector cameraNormal;
-    vpColVector objectNormal;
-    vpImagePoint pixelPos;
-    //vpFeatureDepth f;
+    std::array<double, 3> oX, observation, objectNormal;
+    std::array<double, 2> pixelPos;
+
+  };
+
+  class vpDepthPointSet
+  {
+  public:
+    vpDepthPointSet()
+    {
+
+    }
+    void build(const std::vector<vpDepthPoint> &points)
+    {
+      unsigned int numPoints = points.size();
+      std::vector<vpMatrix *> matrices = { &m_oXt, &m_oNt, &m_cXt, &m_cNt, &m_observations };
+      for (vpMatrix *m: matrices) {
+        m->resize(3, numPoints, false, false);
+      }
+
+      for (unsigned int i = 0; i < numPoints; ++i) {
+        for (unsigned int j = 0; j < 3; ++j) {
+          m_oXt[j][i] = points[i].oX[j];
+          m_oNt[j][i] = points[i].objectNormal[j];
+          m_observations[j][i] = points[i].observation[j];
+        }
+      }
+
+    }
+
+    void update(const vpHomogeneousMatrix &cMo)
+    {
+      const vpRotationMatrix cRo = cMo.getRotationMatrix();
+      const vpTranslationVector t = cMo.getTranslationVector();
+      vpMatrix::mult2Matrices(cRo, m_oXt, m_cXt);
+      vpMatrix::mult2Matrices(cRo, m_oNt, m_cNt);
+
+      for (unsigned int i = 0; i < m_cXt.getCols(); ++i) {
+        for (unsigned int j = 0; j < 3; ++j) {
+          m_cXt[j][i] += t[j];
+        }
+      }
+
+    }
+    void errorAndInteraction(vpColVector &e, vpMatrix &L) const
+    {
+      const unsigned int numPoints = m_oXt.getCols();
+      e.resize(numPoints, false);
+#ifdef VISP_HAVE_OPENMP
+#pragma omp parallel for
+#endif
+      for (unsigned int i = 0; i < numPoints; ++i) {
+        const double X = m_cXt[0][i], Y = m_cXt[1][i], Z = m_cXt[2][i];
+        const double nX = m_cNt[0][i], nY = m_cNt[1][i], nZ = m_cNt[2][i];
+
+        const double D = -((nX * X) + (nY  * Y) + (nZ * Z));
+        double projNormal = nX * m_observations[0][i] + nY  * m_observations[1][i] + nZ * m_observations[2][i];
+
+        e[i] = D + projNormal;
+        L[i][0] = nX;
+        L[i][1] = nY;
+        L[i][2] = nZ;
+        L[i][3] = nZ * Y - nY * Z;
+        L[i][4] = nX * Z - nZ * X;
+        L[i][5] = nY * X - nX * Y;
+
+      }
+    }
+  private:
+    vpMatrix m_observations; // A 3xN matrix containing the observed 3D points from the camera
+    vpMatrix m_oXt; // a 3xN matrix containing the 3D points in object frame
+    vpMatrix m_oNt; // a 3xN matrix containing the 3D normals on the object
+    vpMatrix m_cXt;
+    vpMatrix m_cNt;
+
   };
 
 #if defined(VISP_HAVE_NLOHMANN_JSON)
@@ -215,6 +255,7 @@ public:
 protected:
 
   std::vector<vpDepthPoint> m_depthPoints;
+  vpDepthPointSet m_depthPointSet;
   vpRobust m_robust;
   unsigned int m_step;
   bool m_useMask;

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
@@ -1,6 +1,6 @@
 /*
  * ViSP, open source Visual Servoing Platform software.
- * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2025 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -181,10 +181,9 @@ public:
           m_observations[j][i] = points[i].observation[j];
         }
       }
-
     }
 
-    void update(const vpHomogeneousMatrix &cMo)
+    inline void update(const vpHomogeneousMatrix &cMo)
     {
       const vpRotationMatrix cRo = cMo.getRotationMatrix();
       const vpTranslationVector t = cMo.getTranslationVector();
@@ -197,7 +196,8 @@ public:
         }
       }
     }
-    void errorAndInteraction(vpColVector &e, vpMatrix &L) const
+
+    inline void errorAndInteraction(vpColVector &e, vpMatrix &L) const
     {
       const unsigned int numPoints = m_oXt.getCols();
       e.resize(numPoints, false);
@@ -213,13 +213,13 @@ public:
         double projNormal = nX * m_observations[0][i] + nY  * m_observations[1][i] + nZ * m_observations[2][i];
 
         e[i] = D + projNormal;
+
         L[i][0] = nX;
         L[i][1] = nY;
         L[i][2] = nZ;
         L[i][3] = nZ * Y - nY * Z;
         L[i][4] = nX * Z - nZ * X;
         L[i][5] = nY * X - nX * Y;
-
       }
     }
 

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
@@ -202,6 +202,7 @@ public:
     {
       const unsigned int numPoints = m_oXt.getCols();
       e.resize(numPoints, false);
+      L.resize(numPoints, 6, false, false);
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel for
 #endif

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBDenseDepthTracker.h
@@ -196,7 +196,6 @@ public:
           m_cXt[j][i] += t[j];
         }
       }
-
     }
     void errorAndInteraction(vpColVector &e, vpMatrix &L) const
     {
@@ -223,6 +222,12 @@ public:
 
       }
     }
+
+    const vpMatrix &getPointsObject() const { return m_oXt; }
+    const vpMatrix &getNormalsObject() const { return m_oNt; }
+    const vpMatrix &getPointsCamera() const { return m_cXt; }
+    const vpMatrix &getNormalsCamera() const { return m_cNt; }
+
   private:
     vpMatrix m_observations; // A 3xN matrix containing the observed 3D points from the camera
     vpMatrix m_oXt; // a 3xN matrix containing the 3D points in object frame

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBSilhouetteCCDTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBSilhouetteCCDTracker.h
@@ -147,7 +147,12 @@ inline void from_json(const nlohmann::json &j, vpCCDParameters &ccdParameters)
   ccdParameters.start_h = ccdParameters.h;
   ccdParameters.delta_h = j.value("delta_h", ccdParameters.delta_h);
   ccdParameters.start_delta_h = ccdParameters.delta_h;
-  ccdParameters.min_h = j.value("min_h", ccdParameters.min_h);
+  if (j.contains("min_h")) {
+    ccdParameters.min_h = j.value("min_h", ccdParameters.min_h);
+  }
+  else {
+    ccdParameters.min_h = ccdParameters.h;
+  }
 
   ccdParameters.phi_dim = j.value("phi_dim", ccdParameters.phi_dim);
   if (j.contains("gamma")) {

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTracker.h
@@ -43,7 +43,7 @@
 #include <visp3/rbt/vpRBSilhouettePointsExtractionSettings.h>
 #include <visp3/rbt/vpPanda3DDepthFilters.h>
 #include <visp3/rbt/vpObjectCentricRenderer.h>
-#include <visp3/rbt/vpRBTrackerLogger.h>
+#include <visp3/rbt/vpRBTrackingTimings.h>
 #include <visp3/rbt/vpRBADDSMetric.h>
 #include <visp3/core/vpDisplay.h>
 
@@ -80,7 +80,7 @@ public:
   void setPose(const vpHomogeneousMatrix &cMo);
   vpObjectCentricRenderer &getRenderer();
   const vpRBFeatureTrackerInput &getMostRecentFrame() const { return m_currentFrame; }
-  const vpRBTrackerLogger &getLogger() const { return m_logger; }
+  const vpRBTrackingTimings &getLogger() const { return m_logger; }
 
   vpMatrix getCovariance() const;
 
@@ -266,7 +266,7 @@ protected:
 
   unsigned m_imageHeight, m_imageWidth; //! Color and render image dimensions
 
-  vpRBTrackerLogger m_logger;
+  vpRBTrackingTimings m_logger;
   bool m_verbose;
 
   std::shared_ptr<vpObjectMask> m_mask;

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTracker.h
@@ -43,7 +43,7 @@
 #include <visp3/rbt/vpRBSilhouettePointsExtractionSettings.h>
 #include <visp3/rbt/vpPanda3DDepthFilters.h>
 #include <visp3/rbt/vpObjectCentricRenderer.h>
-#include <visp3/rbt/vpRBTrackingTimings.h>
+#include <visp3/rbt/vpRBTrackingResult.h>
 #include <visp3/rbt/vpRBADDSMetric.h>
 #include <visp3/core/vpDisplay.h>
 
@@ -80,7 +80,6 @@ public:
   void setPose(const vpHomogeneousMatrix &cMo);
   vpObjectCentricRenderer &getRenderer();
   const vpRBFeatureTrackerInput &getMostRecentFrame() const { return m_currentFrame; }
-  const vpRBTrackingTimings &getLogger() const { return m_logger; }
 
   vpMatrix getCovariance() const;
 
@@ -199,9 +198,9 @@ public:
    * @{
    */
   void startTracking();
-  void track(const vpImage<unsigned char> &I);
-  void track(const vpImage<unsigned char> &I, const vpImage<vpRGBa> &IRGB);
-  void track(const vpImage<unsigned char> &I, const vpImage<vpRGBa> &IRGB, const vpImage<float> &depth);
+  vpRBTrackingResult track(const vpImage<unsigned char> &I);
+  vpRBTrackingResult track(const vpImage<unsigned char> &I, const vpImage<vpRGBa> &IRGB);
+  vpRBTrackingResult track(const vpImage<unsigned char> &I, const vpImage<vpRGBa> &IRGB, const vpImage<float> &depth);
   /**
    * @}
    */
@@ -222,7 +221,7 @@ public:
 
 protected:
 
-  void track(vpRBFeatureTrackerInput &input);
+  vpRBTrackingResult track(vpRBFeatureTrackerInput &input);
   void updateRender(vpRBFeatureTrackerInput &frame);
 
   std::vector<vpRBSilhouettePoint> extractSilhouettePoints(
@@ -266,7 +265,6 @@ protected:
 
   unsigned m_imageHeight, m_imageWidth; //! Color and render image dimensions
 
-  vpRBTrackingTimings m_logger;
   bool m_verbose;
 
   std::shared_ptr<vpObjectMask> m_mask;

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTracker.h
@@ -146,6 +146,13 @@ public:
     m_muIterFactor = factor;
   }
 
+  bool scaleInvariantRegularization() const { return m_scaleInvariantOptim; }
+  inline void setScaleInvariantRegularization(bool invariant)
+  {
+
+    m_scaleInvariantOptim = invariant;
+  }
+
   std::shared_ptr<vpRBDriftDetector> getDriftDetector() const { return m_driftDetector; }
   inline void setDriftDetector(const std::shared_ptr<vpRBDriftDetector> &detector)
   {

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingResult.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingResult.h
@@ -1,6 +1,6 @@
 /*
  * ViSP, open source Visual Servoing Platform software.
- * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2025 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,15 +113,12 @@ public:
     m_odometryMotion = vpHomogeneousMatrix();
   }
 
-  unsigned int numIterations() const { return m_cMos.size(); }
+  unsigned int getNumIterations() const { return m_cMos.size(); }
   const std::vector<vpHomogeneousMatrix> &getPoses() const { return m_cMos; }
   vpHomogeneousMatrix getPoseBeforeTracking() const { return m_cMoBeforeTracking; }
 
   const std::vector<vpColVector> &getVelocities() const { return m_velocities; }
   const std::vector<double> &getConvergenceMetricValues() const { return m_convergenceMetric; }
-
-
-
 
   vpRBTrackingTimings &timer() { return m_timings; }
 
@@ -154,7 +151,7 @@ public:
   std::vector<vpRBFeatureResult> getFeatureData() const { return m_featureData; }
 
 
-  void onEndIter(const vpHomogeneousMatrix &cMo, const vpColVector &v, const double convergenceMetric, const vpMatrix &JTJ, const vpColVector &JTR, double mu)
+  inline void onEndIter(const vpHomogeneousMatrix &cMo, const vpColVector &v, const double convergenceMetric, const vpMatrix &JTJ, const vpColVector &JTR, double mu)
   {
     m_cMos.push_back(cMo);
     m_velocities.push_back(v);
@@ -165,7 +162,7 @@ public:
 
   }
 
-  void logFeatures(const std::vector<std::shared_ptr<vpRBFeatureTracker>> &features)
+  inline void logFeatures(const std::vector<std::shared_ptr<vpRBFeatureTracker>> &features)
   {
     if (m_featureData.size() == 0) {
       m_featureData.resize(features.size());

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingResult.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingResult.h
@@ -1,0 +1,122 @@
+/*
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See https://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/*!
+  \file vpRBKltTracker.h
+  \brief KLT features in the context of render based tracking
+*/
+#ifndef VP_RB_TRACKING_RESULT_H
+#define VP_RB_TRACKING_RESULT_H
+
+#include <visp3/core/vpConfig.h>
+
+
+#include <vector>
+#include <visp3/core/vpColVector.h>
+#include <visp3/core/vpHomogeneousMatrix.h>
+
+
+#include <visp3/rbt/vpRBTrackingTimings.h>
+#include <visp3/rbt/vpRBFeatureTracker.h>
+
+BEGIN_VISP_NAMESPACE
+
+class VISP_EXPORT vpRBFeatureResult
+{
+
+public:
+  vpRBFeatureResult() = default;
+  void onIter(vpRBFeatureTracker &tracker)
+  {
+    m_numFeatures.push_back(tracker.getNumFeatures());
+    m_overallWeight.push_back(tracker.getVVSTrackerWeight());
+    m_error.push_back(tracker.getWeightedError());
+    m_JTJ.push_back(tracker.getLTL());
+    m_JTR.push_back(tracker.getLTR());
+  }
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+
+#endif
+
+
+
+
+private:
+  std::vector<unsigned int> m_numFeatures;
+  std::vector<double> m_overallWeight;
+
+  std::vector<vpColVector> m_error;
+  std::vector<vpMatrix> m_JTJ;
+  std::vector<vpColVector> m_JTR;
+};
+
+
+enum vpRBTrackingStoppingReason
+{
+  MAX_ITERS = 0,
+  CONVERGENCE_CRITERION = 1,
+  OBJECT_NOT_IN_IMAGE = 2,
+  EXCEPTION = 3,
+  INVALID_REASON = 4
+};
+
+
+class VISP_EXPORT vpRBTrackingResult
+{
+public:
+
+  vpRBTrackingResult()
+  {
+    m_odometryMotion = vpHomogeneousMatrix();
+  }
+
+  unsigned int numIterations() const { return m_cMos.size(); }
+  const std::vector<vpHomogeneousMatrix> &getPoses() const { return m_cMos; }
+
+
+  vpRBTrackingTimings &timings() { return m_timings; }
+
+  void setOdometryMotion(const vpHomogeneousMatrix &cMw)
+  {
+    m_odometryMotion = cMw;
+  }
+
+private:
+  vpRBTrackingStoppingReason m_stopReason;
+  vpRBTrackingTimings m_timings;
+  std::vector<vpHomogeneousMatrix> m_cMos;
+  vpHomogeneousMatrix m_odometryMotion;
+  std::vector<vpRBFeatureResult> m_featureData;
+};
+
+END_VISP_NAMESPACE
+
+#endif

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingTimings.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingTimings.h
@@ -208,7 +208,7 @@ inline void from_json(const nlohmann::json &j, vpRBTrackingTimings &result)
 inline void to_json(nlohmann::json &j, const vpRBTrackingTimings &result)
 {
   j["render"] = result.m_renderTime;
-  j["silhouette"] = result.m_silhouetteExtractionTime;
+  j["silhouetteExtraction"] = result.m_silhouetteExtractionTime;
   j["mask"] = result.m_maskTime;
   j["drift"] = result.m_driftTime;
   j["odometry"] = result.m_odometryTime;

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingTimings.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingTimings.h
@@ -29,11 +29,11 @@
  */
 
 /*!
-  \file vpRBTrackerLogger.h
+  \file vpRBTrackingTimings.h
   \brief Information storage for render based tracking process.
 */
-#ifndef VP_RB_TRACKER_LOGGER_H
-#define VP_RB_TRACKER_LOGGER_H
+#ifndef VP_RB_TRACKING_TIMINGS_H
+#define VP_RB_TRACKING_TIMINGS_H
 
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpMath.h>
@@ -50,11 +50,11 @@ BEGIN_VISP_NAMESPACE
   \ingroup group_rbt_core
 */
 
-class vpRBTrackerLogger;
+class vpRBTrackingTimings;
 
-std::ostream &operator<<(std::ostream &s, const vpRBTrackerLogger &I);
+std::ostream &operator<<(std::ostream &s, const vpRBTrackingTimings &I);
 
-class VISP_EXPORT vpRBTrackerLogger
+class VISP_EXPORT vpRBTrackingTimings
 {
 public:
   inline void reset()
@@ -71,7 +71,7 @@ public:
     m_trackerVVSIterTimes.clear();
   }
 
-  friend std::ostream &operator<<(std::ostream &, const vpRBTrackerLogger &);
+  friend std::ostream &operator<<(std::ostream &, const vpRBTrackingTimings &);
 
   void startTimer() { m_startTime = vpTime::measureTimeMs(); }
   inline double endTimer()
@@ -147,7 +147,7 @@ private:
 
 };
 
-inline std::ostream &operator<<(std::ostream &out, const vpRBTrackerLogger &timer)
+inline std::ostream &operator<<(std::ostream &out, const vpRBTrackingTimings &timer)
 {
   const auto default_precision { out.precision() };
   auto flags = out.flags();

--- a/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingTimings.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBTrackingTimings.h
@@ -39,6 +39,7 @@
 #include <visp3/core/vpMath.h>
 #include <visp3/core/vpTime.h>
 
+
 #if defined(VISP_HAVE_NLOHMANN_JSON)
 #include VISP_NLOHMANN_JSON(json.hpp)
 #endif
@@ -128,22 +129,26 @@ public:
     m_odometryTime = elapsed;
   }
 
+#ifdef VISP_HAVE_NLOHMANN_JSON
+  inline friend void from_json(const nlohmann::json &j, vpRBTrackingTimings &result);
+  inline friend void to_json(nlohmann::json &j, const vpRBTrackingTimings &result);
+
+#endif
+
 private:
   double m_startTime;
+
   double m_renderTime;
   double m_silhouetteExtractionTime;
   double m_maskTime;
   double m_driftTime;
   double m_odometryTime;
+
   std::map<int, std::vector<double>> m_trackerVVSIterTimes;
-
   std::map<int, double> m_trackerIterStartTime;
-
   std::map<int, double> m_trackerFeatureExtractionTime;
-
   std::map<int, double> m_trackerFeatureTrackingTime;
   std::map<int, double> m_trackerInitVVSTime;
-  std::map<int, int> m_trackerNumFeatures;
 
 };
 
@@ -183,6 +188,40 @@ inline std::ostream &operator<<(std::ostream &out, const vpRBTrackingTimings &ti
   out << std::setprecision(default_precision); // restore defaults
   return out;
 }
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+inline void from_json(const nlohmann::json &j, vpRBTrackingTimings &result)
+{
+  result.m_renderTime = j.at("render");
+  result.m_silhouetteExtractionTime = j.at("silhouetteExtraction");
+  result.m_maskTime = j.at("mask");
+  result.m_driftTime = j.at("drift");
+  result.m_odometryTime = j.at("odometry");
+
+  nlohmann::json jf = j.at("features");
+  result.m_trackerVVSIterTimes = jf.at("vvs");
+  result.m_trackerIterStartTime = jf.at("start");
+  result.m_trackerFeatureExtractionTime = jf.at("extraction");
+  result.m_trackerFeatureTrackingTime = jf.at("tracking");
+  result.m_trackerInitVVSTime = jf.at("vvsInit");
+}
+inline void to_json(nlohmann::json &j, const vpRBTrackingTimings &result)
+{
+  j["render"] = result.m_renderTime;
+  j["silhouette"] = result.m_silhouetteExtractionTime;
+  j["mask"] = result.m_maskTime;
+  j["drift"] = result.m_driftTime;
+  j["odometry"] = result.m_odometryTime;
+  nlohmann::json jf;
+  jf["vvs"] = result.m_trackerVVSIterTimes;
+  jf["start"] = result.m_trackerIterStartTime;
+  jf["extraction"] = result.m_trackerFeatureExtractionTime;
+  jf["tracking"] = result.m_trackerFeatureTrackingTime;
+  jf["vvsInit"] = result.m_trackerInitVVSTime;
+  j["features"] = jf;
+}
+#endif
+
 
 END_VISP_NAMESPACE
 

--- a/modules/tracker/rbt/src/core/vpRBTracker.cpp
+++ b/modules/tracker/rbt/src/core/vpRBTracker.cpp
@@ -639,12 +639,13 @@ void vpRBTracker::loadConfiguration(const nlohmann::json &j)
   m_verbose = verboseSettings.value("enabled", m_verbose);
 
   m_displaySilhouette = j.value("displaySilhouette", m_displaySilhouette);
-
-  const nlohmann::json cameraSettings = j.at("camera");
-  m_cam = cameraSettings.at("intrinsics");
-  m_imageHeight = cameraSettings.value("height", m_imageHeight);
-  m_imageWidth = cameraSettings.value("width", m_imageWidth);
-  setCameraParameters(m_cam, m_imageHeight, m_imageWidth);
+  if (j.contains("camera")) {
+    const nlohmann::json cameraSettings = j.at("camera");
+    m_cam = cameraSettings.at("intrinsics");
+    m_imageHeight = cameraSettings.value("height", m_imageHeight);
+    m_imageWidth = cameraSettings.value("width", m_imageWidth);
+    setCameraParameters(m_cam, m_imageHeight, m_imageWidth);
+  }
 
   if (j.contains("model")) {
     setModelPath(j.at("model"));

--- a/modules/tracker/rbt/src/core/vpRBTracker.cpp
+++ b/modules/tracker/rbt/src/core/vpRBTracker.cpp
@@ -653,7 +653,7 @@ void vpRBTracker::loadConfiguration(const nlohmann::json &j)
   setOptimizationGain(vvsSettings.value("gain", m_lambda));
   setOptimizationInitialMu(vvsSettings.value("mu", m_muInit));
   setOptimizationMuIterFactor(vvsSettings.value("muIterFactor", m_muIterFactor));
-  setOptimizationMuIterFactor(vvsSettings.value("scaleInvariant", m_scaleInvariantOptim));
+  setScaleInvariantRegularization(vvsSettings.value("scaleInvariant", m_scaleInvariantOptim));
   m_convergedMetricThreshold = (vvsSettings.value("convergenceMetricThreshold", m_convergedMetricThreshold));
 
   m_depthSilhouetteSettings = j.at("silhouetteExtractionSettings");

--- a/modules/tracker/rbt/src/core/vpRBTracker.cpp
+++ b/modules/tracker/rbt/src/core/vpRBTracker.cpp
@@ -373,7 +373,10 @@ vpRBTrackingResult vpRBTracker::track(vpRBFeatureTrackerInput &input)
         const double weight = tracker->getVVSTrackerWeight();
         LTL += weight * tracker->getLTL();
         LTR += weight * tracker->getLTR();
+
+
         error += weight * (tracker->getWeightedError()).sumSquare();
+
         //std::cout << "Error = " << (weight * tracker->getWeightedError()).sumSquare() << std::endl;
       }
     }

--- a/modules/tracker/rbt/src/core/vpRBTracker.cpp
+++ b/modules/tracker/rbt/src/core/vpRBTracker.cpp
@@ -267,13 +267,12 @@ vpRBTrackingResult vpRBTracker::track(vpRBFeatureTrackerInput &input)
       shouldRerender = adds > rerenderThreshold;
       result.setOdometryMetricAndThreshold(adds, rerenderThreshold);
     }
-    result.setOdometryMotion(cnTc);
+    result.setOdometryMotion(cMo_beforeOdo, cnTc, m_cMo);
     if (shouldRerender) {
       updateRender(input);
       if (requiresSilhouetteCandidates) {
-        const vpHomogeneousMatrix cTcp = m_cMo * m_cMoPrev.inverse();
         input.silhouettePoints = extractSilhouettePoints(input.renders.normals, input.renders.depth,
-                                                        input.renders.silhouetteCanny, input.renders.isSilhouette, input.cam, cTcp);
+                                                        input.renders.silhouetteCanny, input.renders.isSilhouette, input.cam, cnTc);
         if (input.silhouettePoints.size() == 0) {
           result.setStoppingReason(vpRBTrackingStoppingReason::OBJECT_NOT_IN_IMAGE);
           return result;
@@ -335,6 +334,7 @@ vpRBTrackingResult vpRBTracker::track(vpRBFeatureTrackerInput &input)
   double mu = m_muInit;
   vpColVector firstMotion(6, 0.0);
   unsigned int iter = 0;
+  result.beforeIter(m_cMo);
   for (iter = 0; iter < m_vvsIterations; ++iter) {
     id = 0;
     for (std::shared_ptr<vpRBFeatureTracker> &tracker : m_trackers) {
@@ -425,6 +425,8 @@ vpRBTrackingResult vpRBTracker::track(vpRBFeatureTrackerInput &input)
       break;
     }
   }
+
+
 
   if (iter == m_vvsIterations) {
     result.setStoppingReason(vpRBTrackingStoppingReason::MAX_ITERS);

--- a/modules/tracker/rbt/src/core/vpRBTrackingResult.cpp
+++ b/modules/tracker/rbt/src/core/vpRBTrackingResult.cpp
@@ -1,6 +1,6 @@
 /*
  * ViSP, open source Visual Servoing Platform software.
- * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2025 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,13 +28,14 @@
  * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#if defined(VISP_HAVE_NLOHMANN_JSON)
-#include VISP_NLOHMANN_JSON(json.hpp)
-#endif
+#include <visp3/core/vpConfig.h>
+#include <visp3/rbt/vpRBTrackingResult.h>
 
 #include <iostream>
 
-#include <visp3/rbt/vpRBTrackingResult.h>
+#if defined(VISP_HAVE_NLOHMANN_JSON)
+#include VISP_NLOHMANN_JSON(json.hpp)
+#endif
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
 

--- a/modules/tracker/rbt/src/core/vpRBTrackingResult.cpp
+++ b/modules/tracker/rbt/src/core/vpRBTrackingResult.cpp
@@ -1,0 +1,63 @@
+/*
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See https://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#if defined(VISP_HAVE_NLOHMANN_JSON)
+#include VISP_NLOHMANN_JSON(json.hpp)
+#endif
+
+#include <iostream>
+
+#include <visp3/rbt/vpRBTrackingResult.h>
+
+#ifdef VISP_HAVE_NLOHMANN_JSON
+
+void vpRBTrackingResult::saveToFile(const std::string &path) const
+{
+  nlohmann::json j = *this;
+  std::ofstream out(path);
+  if (!out.good()) {
+    throw vpException(vpException::ioError, "Path %s could not be opened to write tracking results", path.c_str());
+  }
+  out << j.dump(2);
+  out.close();
+}
+
+vpRBTrackingResult vpRBTrackingResult::readFromJsonFile(const std::string &path)
+{
+  vpRBTrackingResult result;
+  std::ifstream input(path);
+  if (!input.good()) {
+    throw vpException(vpException::ioError, "Path %s could not be opened to read tracking results", path.c_str());
+  }
+  nlohmann::json j = nlohmann::json::parse(input);
+  result = j;
+  return result;
+}
+#endif

--- a/modules/tracker/rbt/src/features/vpRBDenseDepthTracker.cpp
+++ b/modules/tracker/rbt/src/features/vpRBDenseDepthTracker.cpp
@@ -37,7 +37,7 @@
 #endif
 BEGIN_VISP_NAMESPACE
 
-#define VISP_DEBUG_RB_DEPTH_DENSE_TRACKER 1
+// #define VISP_DEBUG_RB_DEPTH_DENSE_TRACKER 1
 
 
 void fastProjection(const vpHomogeneousMatrix &oTc, double X, double Y, double Z, std::array<double, 3> &p)

--- a/modules/tracker/rbt/src/features/vpRBSilhouetteCCDTracker.cpp
+++ b/modules/tracker/rbt/src/features/vpRBSilhouetteCCDTracker.cpp
@@ -417,9 +417,6 @@ void vpRBSilhouetteCCDTracker::display(const vpCameraParameters &/*cam*/, const 
 
 void vpRBSilhouetteCCDTracker::updateCCDPoints(const vpHomogeneousMatrix &cMo)
 {
-#ifdef VISP_HAVE_OPENMP
-#pragma omp parallel for
-#endif
   for (vpRBSilhouetteControlPoint &p : m_controlPoints) {
     p.updateSilhouettePoint(cMo);
   }
@@ -688,7 +685,7 @@ void vpRBSilhouetteCCDTracker::computeErrorAndInteractionMatrix()
     unsigned int normal_points_number = static_cast<unsigned int>(floor(m_ccdParameters.h / m_ccdParameters.delta_h));
 
 #ifdef VISP_HAVE_OPENMP
-#pragma omp for
+#pragma omp for nowait
 #endif
     for (unsigned int kk = 0; kk < m_controlPoints.size(); kk++) {
       const int i = kk;
@@ -838,6 +835,7 @@ void vpRBSilhouetteCCDTracker::computeErrorAndInteractionMatrix()
     m_LTL = 0;
     m_LTR = 0;
     std::cerr << "Inversion issues in CCD tracker" << std::endl;
+    std::cerr << e.what() << std::endl;
   }
 }
 

--- a/modules/tracker/rbt/src/vo/vpPointMap.cpp
+++ b/modules/tracker/rbt/src/vo/vpPointMap.cpp
@@ -126,25 +126,21 @@ void vpPointMap::getVisiblePoints(const unsigned int h, const unsigned int w, co
 void vpPointMap::getVisiblePoints(const unsigned int h, const unsigned int w, const vpCameraParameters &cam, const vpHomogeneousMatrix &cTw, const vpImage<float> &depth, std::list<int> &indices)
 {
   indices.clear();
-  vpColVector cX(3);
-  vpColVector oX(3);
   const vpRotationMatrix cRw = cTw.getRotationMatrix();
   const vpTranslationVector t = cTw.getTranslationVector();
+  const vpMatrix Xt = m_X.transpose();
+  vpMatrix cXt(Xt.getRows(), Xt.getCols());
+  vpMatrix::mult2Matrices(cRw, Xt, cXt);
 
   double u, v;
   for (unsigned int i = 0; i < m_X.getRows(); ++i) {
-    oX[0] = m_X[i][0];
-    oX[1] = m_X[i][1];
-    oX[2] = m_X[i][2];
+    const double Z = cXt[2][i] + t[2];
 
-    cX = cRw * oX;
-    cX += t;
-    const double Z = cX[2];
     if (Z <= 0.0) {
       continue;
     }
-
-    const double x = cX[0] / Z, y = cX[1] / Z;
+    const double X = cXt[0][i] + t[0], Y = cXt[1][i] + t[1];
+    const double x = X / Z, y = Y / Z;
     vpMeterPixelConversion::convertPointWithoutDistortion(cam, x, y, u, v);
     if (u < 0 || v < 0 || u >= w || v >= h) {
       continue;

--- a/modules/tracker/rbt/src/vo/vpRBVisualOdometryUtils.cpp
+++ b/modules/tracker/rbt/src/vo/vpRBVisualOdometryUtils.cpp
@@ -112,7 +112,8 @@ void vpRBVisualOdometryUtils::levenbergMarquardtKeypoints2D(const vpMatrix &poin
   if (points3d.getRows() != observations.getRows()) {
     throw vpException(vpException::dimensionError, "Expected number of 3D points and 2D observations to be the same");
   }
-
+  vpMatrix points3dTranspose = points3d.t();
+  vpMatrix cXt(points3d.getRows(), points3d.getCols());
   vpMatrix Id(6, 6);
   Id.eye();
   vpRobust robust;
@@ -122,16 +123,14 @@ void vpRBVisualOdometryUtils::levenbergMarquardtKeypoints2D(const vpMatrix &poin
   for (unsigned int iter = 0; iter < parameters.maxNumIters; ++iter) {
     const vpTranslationVector t = cTw.getTranslationVector();
     const vpRotationMatrix cRw = cTw.getRotationMatrix();
+    vpMatrix::mult2Matrices(cRw, points3dTranspose, cXt);
     // Project 3D points and compute interaction matrix
+#ifdef VISP_HAVE_OPENMP
+#pragma omp parallel for
+#endif
     for (unsigned int i = 0; i < points3d.getRows(); ++i) {
-      vpColVector cX(3), wX(3);
-      wX[0] = points3d[i][0]; wX[1] = points3d[i][1]; wX[2] = points3d[i][2];
-
-      cX = cRw * wX;
-      cX += t;
-
-      const double x = cX[0] / cX[2], y = cX[1] / cX[2];
-      const double Z = cX[2];
+      const double X = cXt[0][i] + t[0], Y = cXt[1][i] + t[1], Z = cXt[2][i] + t[2];;
+      const double x = X / Z, y = Y / Z;
       e[i * 2] = x - observations[i][0];
       e[i * 2 + 1] = y - observations[i][1];
 

--- a/tutorial/tracking/model-based/generic-apriltag/tutorial-mb-generic-tracker-apriltag-rs2.cpp
+++ b/tutorial/tracking/model-based/generic-apriltag/tutorial-mb-generic-tracker-apriltag-rs2.cpp
@@ -288,8 +288,8 @@ int main(int argc, const char **argv)
 #ifdef VISP_HAVE_OPENCV
     else if (std::string(argv[i]) == "--use-texture") {
       opt_use_texture = true;
-#endif
     }
+#endif
     else if (std::string(argv[i]) == "--use-depth") {
       opt_use_depth = true;
     }

--- a/tutorial/tracking/render-based/render-based-tutorial-utils.h
+++ b/tutorial/tracking/render-based/render-based-tutorial-utils.h
@@ -123,9 +123,11 @@ public:
       }
       vpIoTools::makeDirectory(folder);
       if (videoEnabled) {
+#ifdef VISP_HAVE_OPENCV
         videoWriter.setFramerate(framerate);
         videoWriter.setCodec(cv::VideoWriter::fourcc('P', 'I', 'M', '1'));
         videoWriter.setFileName(folder + vpIoTools::separator + "video.mp4");
+#endif
       }
     }
   }

--- a/tutorial/tracking/render-based/tutorial-rbt-realsense.cpp
+++ b/tutorial/tracking/render-based/tutorial-rbt-realsense.cpp
@@ -218,7 +218,7 @@ int main(int argc, const char **argv)
     {
       std::cout << "Convergence criterion reached:" << std::endl;
       std::cout << "- Num iterations: " << result.numIterations() << std::endl;
-      std::cout << "- Convergence criterion2: " << *(result.getConvergenceMetricValues().end() - 1) << std::endl;
+      std::cout << "- Convergence criterion: " << *(result.getConvergenceMetricValues().end() - 1) << std::endl;
       break;
     }
     case vpRBTrackingStoppingReason::MAX_ITERS:

--- a/tutorial/tracking/render-based/tutorial-rbt-realsense.cpp
+++ b/tutorial/tracking/render-based/tutorial-rbt-realsense.cpp
@@ -217,7 +217,7 @@ int main(int argc, const char **argv)
     case vpRBTrackingStoppingReason::CONVERGENCE_CRITERION:
     {
       std::cout << "Convergence criterion reached:" << std::endl;
-      std::cout << "- Num iterations: " << result.numIterations() << std::endl;
+      std::cout << "- Num iterations: " << result.getNumIterations() << std::endl;
       std::cout << "- Convergence criterion: " << *(result.getConvergenceMetricValues().end() - 1) << std::endl;
       break;
     }

--- a/tutorial/tracking/render-based/tutorial-rbt-realsense.cpp
+++ b/tutorial/tracking/render-based/tutorial-rbt-realsense.cpp
@@ -61,6 +61,7 @@ int main(int argc, const char **argv)
   vpRBTrackerTutorial::vpRBExperimentLogger logger;
   vpRBTrackerTutorial::vpRBExperimentPlotter plotter;
 
+
   vpJsonArgumentParser parser(
     "Tutorial showing the usage of the Render-Based tracker with a RealSense camera",
     "--config", "/"
@@ -193,9 +194,42 @@ int main(int argc, const char **argv)
 
     // Pose tracking
     double trackingStart = vpTime::measureTimeMs();
-    tracker.track(Id, Icol, depth);
+    vpRBTrackingResult result = tracker.track(Id, Icol, depth);
     double trackingEnd = vpTime::measureTimeMs();
     tracker.getPose(cMo);
+
+    switch (result.getStoppingReason()) {
+    case vpRBTrackingStoppingReason::EXCEPTION:
+    {
+      std::cout << "Encountered an exception during tracking, pose was not updated" << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::NOT_ENOUGH_FEATURES:
+    {
+      std::cout << "There were not enough feature to perform tracking" << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::OBJECT_NOT_IN_IMAGE:
+    {
+      std::cout << "Object is not in image" << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::CONVERGENCE_CRITERION:
+    {
+      std::cout << "Convergence criterion reached:" << std::endl;
+      std::cout << "- Num iterations: " << result.numIterations() << std::endl;
+      std::cout << "- Convergence criterion2: " << *(result.getConvergenceMetricValues().end() - 1) << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::MAX_ITERS:
+    {
+      break;
+    }
+    default:
+    {
+    }
+    }
+
     double displayStart = vpTime::measureTimeMs();
     if (baseArgs.display) {
       if (baseArgs.debugDisplay) {
@@ -208,6 +242,7 @@ int main(int argc, const char **argv)
       vpDisplay::display(Id);
       vpDisplay::display(Icol);
       tracker.display(Id, Icol, IdepthDisplay);
+
       vpDisplay::displayFrame(Icol, cMo, cam, 0.05, vpColor::none, 2);
       vpDisplay::displayText(Id, 20, 5, "Right click to exit", vpColor::red);
       vpMouseButton::vpMouseButtonType button;

--- a/tutorial/tracking/render-based/tutorial-rbt-sequence.cpp
+++ b/tutorial/tracking/render-based/tutorial-rbt-sequence.cpp
@@ -189,12 +189,46 @@ int main(int argc, const char **argv)
 
     // Pose tracking
     double trackingStart = vpTime::measureTimeMs();
+    vpRBTrackingResult trackingResult;
     if (depth.getSize() == 0) {
-      tracker.track(Id, Icol);
+      trackingResult = tracker.track(Id, Icol);
     }
     else {
-      tracker.track(Id, Icol, depth);
+      trackingResult = tracker.track(Id, Icol, depth);
     }
+
+    switch (trackingResult.getStoppingReason()) {
+    case vpRBTrackingStoppingReason::EXCEPTION:
+    {
+      std::cout << "Encountered an exception during tracking, pose was not updated" << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::NOT_ENOUGH_FEATURES:
+    {
+      std::cout << "There were not enough feature to perform tracking" << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::OBJECT_NOT_IN_IMAGE:
+    {
+      std::cout << "Object is not in image" << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::CONVERGENCE_CRITERION:
+    {
+      std::cout << "Convergence criterion reached:" << std::endl;
+      std::cout << "- Num iterations: " << trackingResult.numIterations() << std::endl;
+      std::cout << "- Convergence criterion: " << *(trackingResult.getConvergenceMetricValues().end() - 1) << std::endl;
+      break;
+    }
+    case vpRBTrackingStoppingReason::MAX_ITERS:
+    {
+      break;
+    }
+    default:
+    {
+    }
+    }
+
     std::cout << "Tracking took " << vpTime::measureTimeMs() - trackingStart << "ms" << std::endl;
 
     if (baseArgs.display) {

--- a/tutorial/tracking/render-based/tutorial-rbt-sequence.cpp
+++ b/tutorial/tracking/render-based/tutorial-rbt-sequence.cpp
@@ -216,7 +216,7 @@ int main(int argc, const char **argv)
     case vpRBTrackingStoppingReason::CONVERGENCE_CRITERION:
     {
       std::cout << "Convergence criterion reached:" << std::endl;
-      std::cout << "- Num iterations: " << trackingResult.numIterations() << std::endl;
+      std::cout << "- Num iterations: " << trackingResult.getNumIterations() << std::endl;
       std::cout << "- Convergence criterion: " << *(trackingResult.getConvergenceMetricValues().end() - 1) << std::endl;
       break;
     }


### PR DESCRIPTION
This PR introduces several changes to the RBT:
- [x]  calls to `vpRBTracker::track` now returns a result structure, containing tracking data (intermediate poses, odometry motion, velocities, jacobians) as well as the reason for stopping (Object not in the image, max iterations reached, etc.)
- [x] Changed the representation of points for the depth tracker, to leverage large matrix multiplication and simplify computations.
- [x] Optimizations on the Point map representation, following the same principle (as well as using better data structures).
- [x] Reflect changes on RBT tutorials.   