### PR TITLE
Fix parsing for Python bindings

### DIFF
--- a/cmake/templates/vpConfig.h.in
+++ b/cmake/templates/vpConfig.h.in
@@ -761,8 +761,13 @@ namespace vp = VISP_NAMESPACE_NAME;
 #endif
 
 // Allows to fix warning with clang-cl : declaration requires an exit-time destructor [-Wexit-time-destructors]
+
+#ifndef VISP_PYTHON_PREPROCESSOR_RUNNING
 #if __has_cpp_attribute(clang::no_destroy)
 #  define VP_ATTRIBUTE_NO_DESTROY [[clang::no_destroy]]
+#else
+#  define VP_ATTRIBUTE_NO_DESTROY
+#endif
 #else
 #  define VP_ATTRIBUTE_NO_DESTROY
 #endif

--- a/modules/python/generator/visp_python_bindgen/doc_parser.py
+++ b/modules/python/generator/visp_python_bindgen/doc_parser.py
@@ -335,7 +335,14 @@ class DocumentationHolder(object):
               for method_def in method_defs:
                 is_const = False if method_def.const == 'no' else True
                 is_static = False if method_def.static == 'no' else True
-                ret_type = ''.join(process_mixed_container(c, 0, escape_rst=False) for c in method_def.type_.content_).replace('VP_DEPRECATED', '').replace('VISP_EXPORT', '')
+
+                removed_macros_return = [
+                  'VP_DEPRECATED', 'VISP_EXPORT', 'VP_NORETURN'
+                ]
+                ret_type = ''.join(process_mixed_container(c, 0, escape_rst=False) for c in method_def.type_.content_)
+                for macro in removed_macros_return:
+                  ret_type = ret_type.replace(macro, '')
+
                 param_types = []
                 for param in method_def.get_param():
                   t = ''.join(process_mixed_container(c, 0, escape_rst=False) for c in param.type_.content_)

--- a/modules/python/generator/visp_python_bindgen/generator_config.py
+++ b/modules/python/generator/visp_python_bindgen/generator_config.py
@@ -116,8 +116,11 @@ FORBIDDEN_FUNCTION_NAMES_REGEXS = [
 class GeneratorConfig(object):
   pcpp_config: Final[PreprocessorConfig] = PreprocessorConfig(
     defines={
+      'VISP_PYTHON_PREPROCESSOR_RUNNING': '', # Mark that this is the python preprocessor that is running
       'VISP_EXPORT': '', # remove symbol as it messes up the cxxheaderparsing
       'VP_DEPRECATED': '', # remove symbol as it messes up the cxxheaderparsing
+      'VP_NORETURN': '', # remove symbol as it messes up the cxxheaderparsing
+      'VP_NOEXCEPT': '', # remove symbol as it messes up the cxxheaderparsing
       'DOXYGEN_SHOULD_SKIP_THIS': None, # Do not generate methods that do not appear in public api doc
       'NLOHMANN_JSON_SERIALIZE_ENUM(a,...)': 'void ignored() {}', # Remove json enum serialization as it cnanot correctly be parsed
       'CV_OUT': '', # In vpKeyPoint, this appears and breaks parsing
@@ -161,7 +164,6 @@ class GeneratorConfig(object):
     assert path.exists(), f'Main config file {path} was not found'
     with open(path, 'r') as main_config_file:
       main_config = json.load(main_config_file)
-      print(json.dumps(main_config, indent=2))
       logging.info('Updating the generator config from dict: ', main_config)
       GeneratorConfig.pcpp_config.include_directories = main_config['include_dirs']
 


### PR DESCRIPTION
The introduction of new macros in the most recent PRs messed up the Python bindings generation:
- The introduction of VP_NORETURN led to errors when parsing doxygen doc (doxygen leaves thoses macros in the documentation)
- The Python preprocessor seems to have issues when parsing `clang::no_destroy`, due to the `:` character. I introduced a macro `VISP_PYTHON_PREPROCESSOR_RUNNING`, which is only defined when the Python preprocessor is running so that this definition block is ignored. This macro could further be used if other code appears to be problematic for parsing.
