### PR TITLE
tests segfaults on Mac intel

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,10 +11,10 @@ concurrency:
 jobs:
   tests:
     name: "Nix build on ${{ matrix.os }}"
-    runs-on: "${{ matrix.os }}-latest"
+    runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu, macos]
+        os: ["ubuntu-24.04", "ubuntu-24.04-arm", "macos-13", "macos-14"]
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/default.nix
+++ b/default.nix
@@ -37,9 +37,10 @@
   xorg,
   zbar,
   zlib,
+  llvmPackages_15,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+llvmPackages_15.stdenv.mkDerivation (finalAttrs: {
   pname = "visp";
   version = "3.6.0";
 

--- a/default.nix
+++ b/default.nix
@@ -56,8 +56,9 @@ llvmPackages_15.stdenv.mkDerivation (finalAttrs: {
 
   buildInputs =
     [
+      atlas
       eigen
-      lapack
+      #lapack
       libdc1394
       libdmtx
       libglvnd

--- a/default.nix
+++ b/default.nix
@@ -8,13 +8,14 @@
 # visp>   315 |     if (!mRoot->showConfigDialog()) {
 # visp>       |          ~~~~~~~~~~~~~~~~~~~~~~~^~
 {
+  atlas,
   cmake,
   coin3d,
   darwin,
   doxygen,
   eigen,
   #fetchFromGitHub,
-  lapack,
+  #lapack,
   lib,
   libdc1394,
   libdmtx,

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716715802,
-        "narHash": "sha256-usk0vE7VlxPX8jOavrtpOqphdfqEQpf9lgedlY/r66c=",
+        "lastModified": 1746300365,
+        "narHash": "sha256-thYTdWqCRipwPRxWiTiH1vusLuAy0okjOyzRx4hLWh4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2dd4e18cc1c7314e24154331bae07df76eb582f",
+        "rev": "f21e4546e3ede7ae34d12a84602a22246b31f7e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Hello,

As found in https://github.com/NixOS/nixpkgs/pull/403603#issuecomment-2849001986, 57 tests out of 120 segfault on macos intel with nix.

This PR update the nix CI to test arm+intel / mac+ubuntu, to show it is still the case on master.
It probably should no be merged before those segfaults are sorted out :)

Or maybe this is already known, and mac intel platforms are considered out of scope / obsolete ?