### PR TITLE
Attempt to fix riscv64 ci build error make Cannot allocate memory

### DIFF
--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -76,9 +76,9 @@ jobs:
                    -DUSE_JPEG=OFF -DUSE_PNG=OFF -DUSE_X11=OFF -DUSE_XML2=OFF -DBUILD_JAVA=OFF -DUSE_BLAS/LAPACK=OFF
           cat ViSP-third-party.txt
 
-          if [[ $(nproc) -gt 2 ]]
+          if [[ $(nproc) -gt 3 ]]
           then
-            NB_PROC_TO_USE=`expr  $(nproc) - 1`
+            NB_PROC_TO_USE=`expr  $(nproc) - 2`
           else
             NB_PROC_TO_USE=1
           fi


### PR DESCRIPTION
Occurs when build on ubuntu:latest riscv64 (Little Endian) [ 48%] Built target testImageOwnership
3291  make[2]: *** Cannot allocate memory.  Stop.
3292  make[1]: *** [CMakeFiles/Makefile2:4149: modules/core/CMakeFiles/catchArray2D.dir/all] Error 2 3293  make[1]: *** Waiting for unfinished jobs.... 3294  [ 48%] Linking CXX executable testImagePrint 3295  [ 48%] Built target testImagePrint
3296  [ 48%] Linking CXX executable testRGBaToHSV
3297  [ 48%] Built target testRGBaToHSV
3298  make: *** [Makefile:146: all] Error 2
3299  Error: The process '/home/runner/work/_actions/uraimo/run-on-arch-action/v3/src/run-on-arch.sh' failed with exit code 2

On this riscv64 host we have
  System information:
    Number of CPU logical cores: 4
    Number of CPU physical cores: 1