### PR TITLE
Canny memory management

### DIFF
--- a/modules/core/src/image/vpCannyEdgeDetection.cpp
+++ b/modules/core/src/image/vpCannyEdgeDetection.cpp
@@ -305,7 +305,9 @@ vpCannyEdgeDetection::step3to5(const unsigned int &height, const unsigned int &w
   m_activeEdgeCandidates.clear();
   m_edgePointsCandidates.resize(m_dIx.getRows(), m_dIx.getCols(), NOT_EDGE);
   m_edgePointsList.clear();
-  m_edgePointsList.reserve(m_dIx.getSize() / 2);
+  if (m_storeListEdgePoints) {
+    m_edgePointsList.reserve(m_dIx.getSize() / 8);
+  }
 
   performEdgeThinning(lowerThreshold);
 


### PR DESCRIPTION
- Reserve memory only if asked to store the edge list
- Reserve a smaller amount of memory