### PR TITLE
Fixing CDash warning in vpHSV class

### DIFF
--- a/modules/core/include/visp3/core/vpHSV.h
+++ b/modules/core/include/visp3/core/vpHSV.h
@@ -163,10 +163,8 @@ public:
 
   /**
    * \brief Default copy constructor.
-   *
-   * \param[in] other
    */
-  vpHSV(const vpHSV<T, useFullScale> &other) = default;
+  vpHSV(const vpHSV<T, useFullScale> &) = default;
 
 #ifndef VISP_PYTHON_PREPROCESSOR_RUNNING
 /**


### PR DESCRIPTION
[CLEAN] Fix warning in vpHSV due to defaulted copy constructor