### PR TITLE
Fix python pybind version check

### DIFF
--- a/modules/python/GenerateConfig.cmake
+++ b/modules/python/GenerateConfig.cmake
@@ -133,7 +133,4 @@ endif()
 
 string(JSON json_config_file SET ${json_config_file} "defines" ${json_defines})
 
-message(STATUS "-------------JSON CONFIG FILE --------------")
-message(STATUS "${json_config_file}")
-message(STATUS "-------------EOF  --------------")
 file(WRITE ${json_config_file_path} "${json_config_file}")

--- a/modules/python/generator/visp_python_bindgen/submodule.py
+++ b/modules/python/generator/visp_python_bindgen/submodule.py
@@ -160,6 +160,8 @@ class Submodule():
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
+#include <pybind11/details/common.h>
+
 #include <vector>
 #include <map>
 
@@ -177,8 +179,10 @@ namespace py = pybind11;
 
 void {self.generation_function_name()}(py::module_ &m) {{
 py::options options;
+// Only supported from pybind 2.10.2
+#if ((PYBIND11_VERSION_MAJOR >= 2) && (PYBIND11_VERSION_MINOR >= 10) && (PYBIND11_VERSION_MICRO >= 2))
 options.disable_enum_members_docstring();
-
+#endif
 /*
  * Submodule declaration
  */

--- a/modules/python/generator/visp_python_bindgen/submodule.py
+++ b/modules/python/generator/visp_python_bindgen/submodule.py
@@ -160,7 +160,7 @@ class Submodule():
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/functional.h>
-#include <pybind11/details/common.h>
+#include <pybind11/detail/common.h>
 
 #include <vector>
 #include <map>


### PR DESCRIPTION
Fixed an issue when building the bindings with pybind < 2.10.2, related to the call of `disable_enum_members_docstring()`