### PR TITLE
Extending vpDiskGrabber capabilities for float images

### DIFF
--- a/example/device/framegrabber/CMakeLists.txt
+++ b/example/device/framegrabber/CMakeLists.txt
@@ -44,6 +44,7 @@ set(example_cpp
   grab1394Two.cpp
   grab1394CMU.cpp
   grabDisk.cpp
+  grabDiskFloat.cpp
   grabV4l2.cpp
   grabDirectShow.cpp
   grabDirectShowMulti.cpp

--- a/example/device/framegrabber/grabDiskFloat.cpp
+++ b/example/device/framegrabber/grabDiskFloat.cpp
@@ -1,0 +1,382 @@
+/****************************************************************************
+ *
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2023 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See https://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Read an image sequence from the disk and display it.
+ *
+*****************************************************************************/
+
+/*!
+  \file grabDisk.cpp
+
+  \brief Example of image sequence reading from the disk using vpDiskGrabber
+  class.
+
+  The sequence is made of separate images. Each image corresponds to a PGM
+  file.
+*/
+
+#include <stdlib.h>
+#include <visp3/core/vpConfig.h>
+#include <visp3/core/vpDebug.h>
+#if defined(VISP_HAVE_DISPLAY)
+
+#include <visp3/core/vpDisplay.h>
+#include <visp3/core/vpImage.h>
+#include <visp3/core/vpIoTools.h>
+#include <visp3/core/vpTime.h>
+#include <visp3/gui/vpDisplayFactory.h>
+#include <visp3/io/vpDiskGrabber.h>
+#include <visp3/io/vpParseArgv.h>
+
+// List of allowed command line options
+#define GETOPTARGS "b:de:f:g:hi:l:s:z:"
+
+#ifdef ENABLE_VISP_NAMESPACE
+using namespace VISP_NAMESPACE_NAME;
+#endif
+
+/*
+
+  Print the program options.
+
+  \param name : Program name.
+  \param badparam : Bad parameter name.
+  \param ipath : Input image path.
+  \param basename : Input image base name.
+  \param ext : Input image extension.
+  \param first : First image number to read.
+  \param last : Number of images to read.
+  \param step : Step between two successive images to read.
+  \param nzero : Number of zero for the image number coding.
+
+ */
+void usage(const char *name, const char *badparam, std::string ipath, std::string basename, std::string ext, std::string genericname, long first,
+           long last, long step, unsigned int nzero)
+{
+  fprintf(stdout, "\n\
+Read an image sequence from the disk. Display it using X11 or GTK.\n\
+The sequence is made of separate images. Each image corresponds\n\
+to a PGM file.\n\
+\n\
+SYNOPSIS\n\
+  %s [-i <input image path>] [-b <base name>] [-e <extension>] \n\
+   [-f <first frame>] [-g <generic name>] [-l <last image> [-s <step>] \n\
+   [-z <number of zero>] [-d] [-h]\n",
+          name);
+
+  fprintf(stdout, "\n\
+OPTIONS:                                               Default\n\
+  -i <input image path>                                     %s\n\
+     Set image input path.\n\
+     From this path read \"cube/image.%%04d.%s\"\n\
+     images.\n\
+     Setting the VISP_INPUT_IMAGE_PATH environment\n\
+     variable produces the same behaviour than using\n\
+     this option.\n\
+\n\
+  -b <base name>                                 %s\n\
+     Specify the base name of the files of the sequence\n\
+     containing the images to process. \n\
+     By image sequence, we mean one file per image.\n\
+     The format is selected by analysing the filename extension.\n\
+\n\
+  -e <extension>                                            %s\n\
+     Specify the extension of the files.\n\
+     Not taken into account for the moment. Will be a\n\
+     future feature...\n\
+\n\
+  -f <first frame>                                          %ld\n\
+     First frame number of the sequence.\n\
+\n\
+  -g <generic name>                                            %s\n\
+     Specify the generic name of the files.\n\
+     A generic name of file is for example myfile_\%04d\n\
+\n\
+  -l <last image      >                                     %ld\n\
+     Last frame number of the sequence.\n\
+\n\
+  -s <step>                                                 %ld\n\
+     Step between two images.\n\
+\n\
+  -z <number of zero>                                       %u\n\
+     Number of digits to encode the image number.\n\
+\n\
+  -d \n\
+     Turn off the display.\n\
+\n\
+  -h \n\
+     Print the help.\n\n",
+          ipath.c_str(), ext.c_str(), basename.c_str(), ext.c_str(), genericname.c_str(), first, last, step, nzero);
+
+  if (badparam)
+    fprintf(stdout, "\nERROR: Bad parameter [%s]\n", badparam);
+}
+/*!
+
+  Set the program options.
+
+  \param argc : Command line number of parameters.
+  \param argv : Array of command line parameters.
+  \param ipath : Input image path.
+  \param basename : Input image base name.
+  \param genericname : Generic name for the images.
+  \param ext : Input image extension.
+  \param first : First image number to read.
+  \param last : Last images to read.
+  \param step : Step between two successive images to read.
+  \param nzero : Number of zero for the image number coding.
+  \param display : Display activation.
+
+  \return false if the program has to be stopped, true otherwise.
+
+*/
+bool getOptions(int argc, const char **argv, std::string &ipath, std::string &basename, std::string &ext, std::string &genericname, long &first,
+                long &last, long &step, unsigned int &nzero, bool &display)
+{
+  const char *optarg_;
+  int c;
+  while ((c = vpParseArgv::parse(argc, argv, GETOPTARGS, &optarg_)) > 1) {
+
+    switch (c) {
+    case 'b':
+      basename = optarg_;
+      break;
+    case 'd':
+      display = false;
+      break;
+    case 'e':
+      ext = optarg_;
+      break;
+    case 'f':
+      first = atol(optarg_);
+      break;
+    case 'g':
+      genericname = optarg_;
+      break;
+    case 'i':
+      ipath = optarg_;
+      break;
+    case 'l':
+      last = std::atol(optarg_);
+      break;
+    case 's':
+      step = atol(optarg_);
+      break;
+    case 'z':
+      nzero = static_cast<unsigned int>(atoi(optarg_));
+      break;
+    case 'h':
+      usage(argv[0], nullptr, ipath, basename, ext, genericname, first, last, step, nzero);
+      return false;
+
+    default:
+      usage(argv[0], optarg_, ipath, basename, ext, genericname, first, last, step, nzero);
+      return false;
+    }
+  }
+
+  if ((c == 1) || (c == -1)) {
+    // standalone param or error
+    usage(argv[0], nullptr, ipath, basename, ext, genericname, first, last, step, nzero);
+    std::cerr << "ERROR: " << std::endl;
+    std::cerr << "  Bad argument " << optarg_ << std::endl << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+void convertDepthImageToDisplayImage(const vpImage<float> &Idepth, vpImage<unsigned char> &Idisp)
+{
+  float max, min;
+  Idepth.getMinMaxValue(min, max);
+  Idisp.resize(Idepth.getHeight(), Idepth.getWidth());
+  float a = 255. / (min - max);
+  float b = 255. - a * min;
+  int size = Idepth.getSize();
+#ifdef VISP_HAVE_OPENMP
+#pragma omp parallel for
+#endif
+  for (int i = 0; i < size; ++i) {
+    Idisp.bitmap[i] = a * Idepth.bitmap[i] + b;
+  }
+}
+
+/*!
+  \example grabDisk.cpp
+
+  Example of image sequence reading from the disk using vpDiskGrabber class.
+
+  Read an image sequence from the disk. The sequence is made of separate
+  images. Each image corresponds to a PGM file. Display these images using X11
+  or GTK.
+*/
+int main(int argc, const char **argv)
+{
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
+  vpDisplay *display = nullptr;
+#endif
+  try {
+    std::string opt_ipath;
+    std::string opt_basename = "cube/image.";
+    std::string opt_genericname = "";
+#if defined(VISP_HAVE_DATASET)
+#if VISP_HAVE_DATASET_VERSION >= 0x030600
+    std::string opt_ext("png");
+#else
+    std::string opt_ext("pgm");
+#endif
+#else
+    // We suppose that the user will download a recent dataset
+    std::string opt_ext("png");
+#endif
+
+    bool opt_display = true;
+
+    long opt_first = 5;
+    long opt_last = 70;
+    long opt_step = 1;
+    unsigned int opt_nzero = 4;
+
+    // Read the command line options
+    if (getOptions(argc, argv, opt_ipath, opt_basename, opt_ext, opt_genericname, opt_first, opt_last, opt_step, opt_nzero,
+                   opt_display) == false) {
+      return EXIT_FAILURE;
+    }
+
+    // Declare an image, this is a gray level image (unsigned char)
+    // it size is not defined yet, it will be defined when the image will
+    // read on the disk
+    vpImage<float> I;
+    vpImage<unsigned char> Idisp;
+
+    // Declare a framegrabber able to read a sequence of successive
+    // images from the disk
+    vpDiskGrabber g;
+
+    if (opt_genericname.empty()) {
+      if (!opt_ipath.empty()) {
+      // Set the path to the directory containing the sequence
+        g.setDirectory(opt_ipath.c_str());
+      }
+      // Set the image base name. The directory and the base name constitute
+      // the constant part of the full filename
+      g.setBaseName(opt_basename.c_str());
+    }
+    else {
+      if (!opt_ipath.empty()) {
+        // Set the path to the directory containing the sequence
+        opt_genericname = vpIoTools::createFilePath(opt_ipath, opt_genericname);
+      }
+      std::cout << "Generic name:= " << opt_genericname << std::endl;
+      g.setGenericName(opt_genericname);
+    }
+    // Set the step between two images of the sequence
+    g.setStep(opt_step);
+    // Set the number of digits to build the image number
+    g.setNumberOfZero(opt_nzero);
+    // Set the first frame number of the sequence
+    g.setImageNumber(opt_first);
+    // Set the image extension
+    g.setExtension(opt_ext.c_str());
+
+    // Open the framegrabber by loading the first image of the sequence
+    g.open(I);
+    Idisp.init(I.getHeight(), I.getWidth());
+    convertDepthImageToDisplayImage(I, Idisp);
+    std::cout << "Image size: width : " << I.getWidth() << " height: " << I.getHeight() << std::endl;
+
+    // We open a window using either of the display library.
+    // Its size is automatically defined by the image (I) size
+#if (VISP_CXX_STANDARD >= VISP_CXX_STANDARD_11)
+    std::shared_ptr<vpDisplay> display = vpDisplayFactory::createDisplay();
+#else
+    vpDisplay *display = vpDisplayFactory::allocateDisplay();
+#endif
+
+    if (opt_display) {
+      display->init(Idisp, 100, 100, "Disk Framegrabber");
+
+      // display the image
+      // The image class has a member that specify a pointer toward
+      // the display that has been initialized in the display declaration
+      // therefore is is no longer necessary to make a reference to the
+      // display variable.
+      vpDisplay::display(Idisp);
+      vpDisplay::flush(Idisp);
+    }
+
+    // this is the loop over the image sequence
+    while (g.getImageNumber() < opt_last) {
+      double tms = vpTime::measureTimeMs();
+      // read the image and then increment the image counter so that the next
+      // call to acquire(I) will get the next image
+      g.acquire(I);
+      if (opt_display) {
+        convertDepthImageToDisplayImage(I, Idisp);
+        // Display the image
+        vpDisplay::display(Idisp);
+        // Flush the display
+        vpDisplay::flush(Idisp);
+      }
+      // Synchronise the loop to 40 ms
+      vpTime::wait(tms, 40);
+    }
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
+    if (display != nullptr) {
+      delete display;
+    }
+#endif
+    return EXIT_SUCCESS;
+  }
+  catch (const vpException &e) {
+    std::cout << "Catch an exception: " << e << std::endl;
+#if (VISP_CXX_STANDARD < VISP_CXX_STANDARD_11)
+    if (display != nullptr) {
+      delete display;
+    }
+#endif
+    return EXIT_FAILURE;
+  }
+}
+
+#else
+int main()
+{
+  std::cout << "You do not have X11, or GDI (Graphical Device Interface) functionalities to display images..."
+    << std::endl;
+  std::cout << "Tip if you are on a unix-like system:" << std::endl;
+  std::cout << "- Install X11, configure again ViSP using cmake and build again this example" << std::endl;
+  std::cout << "Tip if you are on a windows-like system:" << std::endl;
+  std::cout << "- Install GDI, configure again ViSP using cmake and build again this example" << std::endl;
+  return EXIT_SUCCESS;
+}
+#endif

--- a/modules/io/include/visp3/io/vpImageIo.h
+++ b/modules/io/include/visp3/io/vpImageIo.h
@@ -116,11 +116,12 @@ private:
     FORMAT_PBM,
     FORMAT_RASTER,
     FORMAT_JPEG2000,
+    FORMAT_EXR,
+    FORMAT_PFM,
     FORMAT_UNKNOWN
   } vpImageFormatType;
 
   static vpImageFormatType getFormat(const std::string &filename);
-  static std::string getExtension(const std::string &filename);
 
 public:
   //! Image IO backend for only jpeg and png formats image loading and saving
@@ -135,6 +136,7 @@ public:
 
   static void read(vpImage<unsigned char> &I, const std::string &filename, int backend = IO_DEFAULT_BACKEND);
   static void read(vpImage<vpRGBa> &I, const std::string &filename, int backend = IO_DEFAULT_BACKEND);
+  static void read(vpImage<float> &I, const std::string &filename);
 
   static void write(const vpImage<unsigned char> &I, const std::string &filename, int backend = IO_DEFAULT_BACKEND);
   static void write(const vpImage<vpRGBa> &I, const std::string &filename, int backend = IO_DEFAULT_BACKEND);

--- a/modules/io/src/image/private/vpImageIoOpenCV.cpp
+++ b/modules/io/src/image/private/vpImageIoOpenCV.cpp
@@ -133,11 +133,11 @@ void readOpenCV(vpImage<float> &I, const std::string &filename)
 {
 #if defined(VISP_HAVE_OPENCV)
 #if VISP_HAVE_OPENCV_VERSION >= 0x030200
-  int flags = cv::IMREAD_COLOR | cv::IMREAD_IGNORE_ORIENTATION;
+  int flags = cv::IMREAD_ANYDEPTH | cv::IMREAD_IGNORE_ORIENTATION;
 #elif VISP_HAVE_OPENCV_VERSION >= 0x030000
-  int flags = cv::IMREAD_COLOR;
+  int flags = cv::IMREAD_ANYDEPTH;
 #else
-  int flags = CV_LOAD_IMAGE_COLOR;
+  int flags = CV_LOAD_IMAGE_ANYDEPTH;
 #endif
   cv::Mat Ip = cv::imread(filename.c_str(), flags);
   if (!Ip.empty())

--- a/modules/io/src/image/vpImageIo.cpp
+++ b/modules/io/src/image/vpImageIo.cpp
@@ -47,72 +47,41 @@ using namespace VISP_NAMESPACE_NAME;
 
 vpImageIo::vpImageFormatType vpImageIo::getFormat(const std::string &filename)
 {
-  std::string ext = vpImageIo::getExtension(filename);
+  std::string ext = vpIoTools::toLowerCase(vpIoTools::getFileExtension(filename));
 
-  if (ext.compare(".PGM") == 0)
+  if (ext.compare("pgm") == 0)
     return FORMAT_PGM;
-  else if (ext.compare(".pgm") == 0)
-    return FORMAT_PGM;
-  else if (ext.compare(".PPM") == 0)
+  else if (ext.compare("ppm") == 0)
     return FORMAT_PPM;
-  else if (ext.compare(".ppm") == 0)
-    return FORMAT_PPM;
-  else if (ext.compare(".JPG") == 0)
+  else if (ext.compare("jpg") == 0)
     return FORMAT_JPEG;
-  else if (ext.compare(".jpg") == 0)
+  else if (ext.compare("jpeg") == 0)
     return FORMAT_JPEG;
-  else if (ext.compare(".JPEG") == 0)
-    return FORMAT_JPEG;
-  else if (ext.compare(".jpeg") == 0)
-    return FORMAT_JPEG;
-  else if (ext.compare(".PNG") == 0)
-    return FORMAT_PNG;
-  else if (ext.compare(".png") == 0)
+  else if (ext.compare("png") == 0)
     return FORMAT_PNG;
   // Formats supported by opencv
-  else if (ext.compare(".TIFF") == 0)
+  else if (ext.compare("tiff") == 0)
     return FORMAT_TIFF;
-  else if (ext.compare(".tiff") == 0)
+  else if (ext.compare("tif") == 0)
     return FORMAT_TIFF;
-  else if (ext.compare(".TIF") == 0)
-    return FORMAT_TIFF;
-  else if (ext.compare(".tif") == 0)
-    return FORMAT_TIFF;
-  else if (ext.compare(".BMP") == 0)
+  else if (ext.compare("bmp") == 0)
     return FORMAT_BMP;
-  else if (ext.compare(".bmp") == 0)
-    return FORMAT_BMP;
-  else if (ext.compare(".DIB") == 0)
+  else if (ext.compare("dib") == 0)
     return FORMAT_DIB;
-  else if (ext.compare(".dib") == 0)
-    return FORMAT_DIB;
-  else if (ext.compare(".PBM") == 0)
+  else if (ext.compare("pbm") == 0)
     return FORMAT_PBM;
-  else if (ext.compare(".pbm") == 0)
-    return FORMAT_PBM;
-  else if (ext.compare(".SR") == 0)
+  else if (ext.compare("sr") == 0)
     return FORMAT_RASTER;
-  else if (ext.compare(".sr") == 0)
+  else if (ext.compare("ras") == 0)
     return FORMAT_RASTER;
-  else if (ext.compare(".RAS") == 0)
-    return FORMAT_RASTER;
-  else if (ext.compare(".ras") == 0)
-    return FORMAT_RASTER;
-  else if (ext.compare(".JP2") == 0)
+  else if (ext.compare("jp2") == 0)
     return FORMAT_JPEG2000;
-  else if (ext.compare(".jp2") == 0)
-    return FORMAT_JPEG2000;
+  else if (ext.compare("exr") == 0)
+    return FORMAT_EXR;
+  else if (ext.compare("pfm") == 0)
+    return FORMAT_PFM;
   else
     return FORMAT_UNKNOWN;
-}
-
-// return the extension of the file including the dot
-std::string vpImageIo::getExtension(const std::string &filename)
-{
-  // extract the extension
-  size_t dot = filename.find_last_of(".");
-  std::string ext = filename.substr(dot, filename.size() - 1);
-  return ext;
 }
 
 /*!
@@ -179,6 +148,9 @@ void vpImageIo::read(vpImage<unsigned char> &I, const std::string &filename, int
   case FORMAT_UNKNOWN:
     try_opencv_reader = true;
     break;
+  case FORMAT_EXR:
+  case FORMAT_PFM:
+    throw(vpException(vpException::badValue, "vpImage<uchar> cannot be used with file '%s' extension does not match", final_filename.c_str()));
   }
 
   if (try_opencv_reader) {
@@ -256,6 +228,75 @@ void vpImageIo::read(vpImage<vpRGBa> &I, const std::string &filename, int backen
   case FORMAT_UNKNOWN:
     try_opencv_reader = true;
     break;
+  default:
+    throw(vpException(vpException::badValue, "vpImage<vpRGBa> cannot be used with file '%s', extension does not match.", final_filename.c_str()));
+  }
+
+  if (try_opencv_reader) {
+#if defined(VISP_HAVE_OPENCV) && \
+    (((VISP_HAVE_OPENCV_VERSION >= 0x030000) && defined(HAVE_OPENCV_IMGCODECS)) || \
+     ((VISP_HAVE_OPENCV_VERSION < 0x030000) && defined(HAVE_OPENCV_HIGHGUI) && defined(HAVE_OPENCV_IMGPROC)))
+    readOpenCV(I, filename);
+#else
+    const std::string message = "Cannot read file \"" + filename + "\": No backend able to support this image format";
+    throw(vpImageException(vpImageException::ioError, message));
+#endif
+  }
+}
+
+/*!
+  Read the contents of the image filename, allocate memory for the
+  corresponding floating-point image, update its content, and return a reference to
+  the image.
+
+  If the image has been already initialized, memory allocation is done
+  only if the new image size is different, else we re-use the same
+  memory space.
+
+  Supported formats are:
+  - portable float map: `*.pfm` file
+
+  If ViSP is build with OpenCV support, additional formats are considered:
+  - `*.tiff`, `*.tif`, `*.exr` files.
+
+  \param I : Image to set with the \e filename content.
+  \param filename : Name of the file containing the image.
+
+ */
+void vpImageIo::read(vpImage<float> &I, const std::string &filename)
+{
+  bool exist = vpIoTools::checkFilename(filename);
+  if (!exist) {
+    const std::string message = "Cannot read file: \"" + std::string(filename) + "\" doesn't exist";
+    throw(vpImageException(vpImageException::ioError, message));
+  }
+
+  // Allows to use ~ symbol or env variables in path
+  std::string final_filename = vpIoTools::path(filename);
+
+  bool try_opencv_reader = false;
+
+  switch (getFormat(final_filename)) {
+  case FORMAT_EXR:
+#ifdef VISP_HAVE_OPENCV
+    try_opencv_reader = true;
+#else
+#if defined(VISP_HAVE_TINYEXR)
+    readEXRTiny(I, filename);
+#else
+    throw(vpException(vpException::ioError, "Trying to read EXR files when neither OpenCV nor Tiny EXR is installed"));
+#endif
+#endif
+    break;
+  case FORMAT_PFM:
+    readPFM(I, filename);
+    break;
+  case FORMAT_TIFF:
+  case FORMAT_UNKNOWN:
+    try_opencv_reader = true;
+    break;
+  default:
+    throw(vpException(vpException::ioError, "Extension of file %s does not match a valid format for vpImage<float>", final_filename.c_str()));
   }
 
   if (try_opencv_reader) {
@@ -316,6 +357,7 @@ void vpImageIo::write(const vpImage<unsigned char> &I, const std::string &filena
   case FORMAT_RASTER:
   case FORMAT_JPEG2000:
   case FORMAT_UNKNOWN:
+  default:
     try_opencv_writer = true;
     break;
   }
@@ -378,6 +420,7 @@ void vpImageIo::write(const vpImage<vpRGBa> &I, const std::string &filename, int
   case FORMAT_RASTER:
   case FORMAT_JPEG2000:
   case FORMAT_UNKNOWN:
+  default:
     try_opencv_writer = true;
     break;
   }

--- a/modules/io/src/image/vpImageIo.cpp
+++ b/modules/io/src/image/vpImageIo.cpp
@@ -49,36 +49,36 @@ vpImageIo::vpImageFormatType vpImageIo::getFormat(const std::string &filename)
 {
   std::string ext = vpIoTools::toLowerCase(vpIoTools::getFileExtension(filename));
 
-  if (ext.compare("pgm") == 0)
+  if (ext.find("pgm") != std::string::npos)
     return FORMAT_PGM;
-  else if (ext.compare("ppm") == 0)
+  else if (ext.find("ppm") != std::string::npos)
     return FORMAT_PPM;
-  else if (ext.compare("jpg") == 0)
+  else if (ext.find("jpg") != std::string::npos)
     return FORMAT_JPEG;
-  else if (ext.compare("jpeg") == 0)
+  else if (ext.find("jpeg") != std::string::npos)
     return FORMAT_JPEG;
-  else if (ext.compare("png") == 0)
+  else if (ext.find("png") != std::string::npos)
     return FORMAT_PNG;
   // Formats supported by opencv
-  else if (ext.compare("tiff") == 0)
+  else if (ext.find("tiff") != std::string::npos)
     return FORMAT_TIFF;
-  else if (ext.compare("tif") == 0)
+  else if (ext.find("tif") != std::string::npos)
     return FORMAT_TIFF;
-  else if (ext.compare("bmp") == 0)
+  else if (ext.find("bmp") != std::string::npos)
     return FORMAT_BMP;
-  else if (ext.compare("dib") == 0)
+  else if (ext.find("dib") != std::string::npos)
     return FORMAT_DIB;
-  else if (ext.compare("pbm") == 0)
+  else if (ext.find("pbm") != std::string::npos)
     return FORMAT_PBM;
-  else if (ext.compare("sr") == 0)
+  else if (ext.find("sr") != std::string::npos)
     return FORMAT_RASTER;
-  else if (ext.compare("ras") == 0)
+  else if (ext.find("ras") != std::string::npos)
     return FORMAT_RASTER;
-  else if (ext.compare("jp2") == 0)
+  else if (ext.find("jp2") != std::string::npos)
     return FORMAT_JPEG2000;
-  else if (ext.compare("exr") == 0)
+  else if (ext.find("exr") != std::string::npos)
     return FORMAT_EXR;
-  else if (ext.compare("pfm") == 0)
+  else if (ext.find("pfm") != std::string::npos)
     return FORMAT_PFM;
   else
     return FORMAT_UNKNOWN;

--- a/modules/io/src/video/vpDiskGrabber.cpp
+++ b/modules/io/src/video/vpDiskGrabber.cpp
@@ -185,7 +185,7 @@ void vpDiskGrabber::acquire(vpImage<float> &I)
 
   std::string extension = vpIoTools::toLowerCase(vpIoTools::getFileExtension(m_image_name, true));
 
-  if (extension == "npy") {
+  if (extension.find("npy") != std::string::npos) {
 #ifdef VISP_HAVE_MINIZ
     visp::cnpy::NpyArray array = visp::cnpy::npy_load(m_image_name);
     float *data = array.data<float>();

--- a/modules/io/src/video/vpDiskGrabber.cpp
+++ b/modules/io/src/video/vpDiskGrabber.cpp
@@ -183,7 +183,20 @@ void vpDiskGrabber::acquire(vpImage<float> &I)
 
   m_image_number_next += m_image_step;
 
-  vpImageIo::readPFM(I, m_image_name);
+  std::string extension = vpIoTools::toLowerCase(vpIoTools::getFileExtension(m_image_name, true));
+
+  if (extension == "npy") {
+#ifdef VISP_HAVE_MINIZ
+    visp::cnpy::NpyArray array = visp::cnpy::npy_load(m_image_name);
+    float *data = array.data<float>();
+    I.init(data, array.shape[0], array.shape[1], true);
+#else
+    throw(vpException(vpException::ioError, "Miniz is not installed, npy files cannot be read"));
+#endif
+  }
+  else {
+    vpImageIo::read(I, m_image_name);
+  }
 
   width = I.getWidth();
   height = I.getHeight();

--- a/modules/io/src/video/vpDiskGrabber.cpp
+++ b/modules/io/src/video/vpDiskGrabber.cpp
@@ -186,7 +186,7 @@ void vpDiskGrabber::acquire(vpImage<float> &I)
   std::string extension = vpIoTools::toLowerCase(vpIoTools::getFileExtension(m_image_name, true));
 
   if (extension.find("npy") != std::string::npos) {
-#ifdef VISP_HAVE_MINIZ
+#if defined (VISP_HAVE_MINIZ) && (VISP_CXX_STANDARD > VISP_CXX_STANDARD_98)
     visp::cnpy::NpyArray array = visp::cnpy::npy_load(m_image_name);
     float *data = array.data<float>();
     I.init(data, array.shape[0], array.shape[1], true);


### PR DESCRIPTION
- `vpDiskGrabber` now handles also `npy` and `tiff` files
- `vpImageIo ` has now a generic method `read` that handles float images.