### PR TITLE
Fix vpMbTracker::loadCAOModel() to consider a parent .cao file that only loads other .cao files

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -139,6 +139,7 @@ ViSP 3.x.x (Version in development)
     . [#1711] CMake error around nlohmann_json detection on FreeBSD
     . [#1713] CMake error with PCL 1.15.0 and VTK 9.5.0 on FreeBSD 14.2
     . [#1718] SEGFAULT in vpMbtMeEllipse
+    . [#1723] Unable to use a .cao model that only loads other .cao files
 ----------------------------------------------
 ViSP 3.6.0 (released September 22, 2023)
   - Contributors:

--- a/modules/tracker/mbt/src/vpMbTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbTracker.cpp
@@ -638,8 +638,7 @@ void vpMbTracker::loadInitFile(const std::string &init_file, std::vector<std::st
   finit.get(c);
   finit.unget();
   bool header = false;
-  bool end_of_file = false;
-  while (!end_of_file && (c == 'l' || c == 'L')) {
+  while ((c == 'l') || (c == 'L')) {
     getline(finit, line);
 
     if (!line.compare(0, prefix_load.size(), prefix_load)) {
@@ -653,7 +652,6 @@ void vpMbTracker::loadInitFile(const std::string &init_file, std::vector<std::st
       for (size_t i = 0; i < params.size(); i++) {
         params[i] = vpIoTools::trim(params[i]);
       }
-      std::cout << "-- DEBUG FS param is empty ? " << params.empty() << std::endl;
       if (!params.empty()) {
         // Get the loaded model pathname
         std::string headerPathRead = params[0];
@@ -770,8 +768,7 @@ void vpMbTracker::loadInitFile(const std::string &init_file, std::vector<std::st
     }
     catch (...) {
       if (finit.eof()) {
-        end_of_file = true;
-        //return;
+        return;
       }
     }
     finit.get(c);
@@ -1975,7 +1972,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
     fileId.get(c);
     fileId.unget();
     bool header = false;
-    while (c == 'l' || c == 'L') {
+    while ((c == 'l') || (c == 'L')) {
       getline(fileId, line);
 
       if (!line.compare(0, prefix_load.size(), prefix_load)) {
@@ -2101,8 +2098,14 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
           }
         }
       }
-
-      removeComment(fileId);
+      try {
+        removeComment(fileId);
+      }
+      catch (...) {
+        if (fileId.eof()) {
+          return;
+        }
+      }
       fileId.get(c);
       fileId.unget();
     }
@@ -2399,8 +2402,7 @@ void vpMbTracker::loadCAOModel(const std::string &modelFile, std::vector<std::st
     try {
       removeComment(fileId);
 
-      if (fileId.eof()) { // check if not at the end of the file (for old
-                          // style files)
+      if (fileId.eof()) { // check if not at the end of the file (for old style files)
         return;
       }
 


### PR DESCRIPTION
It is now possible to have a `parent.cao` file with only the following lines 
```
V1
load("object-1.cao", R=[0; 0; 1; 1; 0; 0; 0; 1; 0]) 
load("object-2.cao", R=[0; 0; 1; 1; 0; 0; 0; 1; 0])
```