### PR TITLE
Fix build issue introduced in PR #1720 and detected by centos 7.2 ci

### DIFF
--- a/modules/io/src/video/vpDiskGrabber.cpp
+++ b/modules/io/src/video/vpDiskGrabber.cpp
@@ -186,7 +186,7 @@ void vpDiskGrabber::acquire(vpImage<float> &I)
   std::string extension = vpIoTools::toLowerCase(vpIoTools::getFileExtension(m_image_name, true));
 
   if (extension.find("npy") != std::string::npos) {
-#if defined (VISP_HAVE_MINIZ) && (VISP_CXX_STANDARD > VISP_CXX_STANDARD_98)
+#if defined(VISP_HAVE_MINIZ) && defined(VISP_HAVE_WORKING_REGEX)
     visp::cnpy::NpyArray array = visp::cnpy::npy_load(m_image_name);
     float *data = array.data<float>();
     I.init(data, array.shape[0], array.shape[1], true);


### PR DESCRIPTION
```
modules/io/src/video/vpDiskGrabber.cpp line 190 (https://cdash-ci.irisa.fr/viewBuildError.php?type=0&amp;buildid=157044 /.../visp-master-code/modules/io/src/video/vpDiskGrabber.cpp:190:11: error: ‘visp::cnpy’ has not been declared
     visp::cnpy::NpyArray array = visp::cnpy::npy_load(m_image_name);
           ^

        modules/io/src/video/vpDiskGrabber.cpp line 190 (https://cdash-ci.irisa.fr/viewBuildError.php?type=0&amp;buildid=157044
/.../visp-master-code/modules/io/src/video/vpDiskGrabber.cpp:190:26: error: expected ‘;’ before ‘array’
     visp::cnpy::NpyArray array = visp::cnpy::npy_load(m_image_name);
                          ^

        modules/io/src/video/vpDiskGrabber.cpp line 191 (https://cdash-ci.irisa.fr/viewBuildError.php?type=0&amp;buildid=157044
/.../visp-master-code/modules/io/src/video/vpDiskGrabber.cpp:191:19: error: ‘array’ was not declared in this scope
     float *data = array.data<float>();
                   ^

        modules/io/src/video/vpDiskGrabber.cpp line 191 (https://cdash-ci.irisa.fr/viewBuildError.php?type=0&amp;buildid=157044
/.../visp-master-code/modules/io/src/video/vpDiskGrabber.cpp:191:30: error: expected primary-expression before ‘float’
     float *data = array.data<float>();
```