### PR TITLE
Fix display of visible contours in mbt where some parts of visible contour are not drawn

### DIFF
--- a/modules/tracker/mbt/src/edge/vpMbtMeLine.cpp
+++ b/modules/tracker/mbt/src/edge/vpMbtMeLine.cpp
@@ -124,7 +124,7 @@ void vpMbtMeLine::initTracking(const vpImage<unsigned char> &I, const vpImagePoi
   expecteddensity = static_cast<double>(m_meList.size());
 
   if (!doNoTrack) {
-    vpMeLine::track(I);
+    vpMeTracker::track(I);
   }
 }
 


### PR DESCRIPTION
Revert commit 6439e1d6f7e57ba294302369d608c6270f82d35a
Author: LAGNEAU Romain <romain.lagneau@inria.fr>
Date:   Wed May 21 10:11:00 2025 +0200

    [FIX] Fixed tracker divergence due to calling vpMeTracker::track instead of vpMeLine::track