### PR TITLE
Fix rbt deterministic

### DIFF
--- a/modules/tracker/rbt/src/features/vpRBDenseDepthTracker.cpp
+++ b/modules/tracker/rbt/src/features/vpRBDenseDepthTracker.cpp
@@ -68,20 +68,27 @@ void vpRBDenseDepthTracker::extractFeatures(const vpRBFeatureTrackerInput &frame
   m_depthPoints.reserve(static_cast<size_t>(bb.getArea() / (m_step * m_step * 2)));
 
   std::vector<std::vector<vpDepthPoint>> pointsPerThread;
-#ifdef VISP_HAVE_OPENMP
-  const unsigned int numThreads = omp_get_num_threads();
-#else
-  const unsigned int numThreads = 1;
-#endif
-  pointsPerThread.resize(numThreads);
+
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel
 #endif
   {
 #ifdef VISP_HAVE_OPENMP
+#pragma omp single
+    {
+      unsigned int numThreads = omp_get_num_threads();
+      pointsPerThread.resize(numThreads);
+    }
+#else
+    {
+      pointsPerThread.resize(1);
+    }
+#endif
+
+#ifdef VISP_HAVE_OPENMP
     unsigned int threadIdx = omp_get_thread_num();
 #else
-    unsigned int threadIdx = 1;
+    unsigned int threadIdx = 0;
 #endif
     vpDepthPoint point;
     vpColVector cameraRay(3);
@@ -195,7 +202,7 @@ void vpRBDenseDepthTracker::computeVVSIter(const vpRBFeatureTrackerInput &/*fram
     std::cerr << "Normals camera" << std::endl;
     std::cerr << m_depthPointSet.getNormalsCamera() << std::endl;
     throw vpException(vpException::badValue, "Invalid values in depth tracker");
-  }
+}
 #endif
 
   //m_weights = 0.0;

--- a/modules/tracker/rbt/src/features/vpRBSilhouetteCCDTracker.cpp
+++ b/modules/tracker/rbt/src/features/vpRBSilhouetteCCDTracker.cpp
@@ -167,16 +167,23 @@ void vpRBSilhouetteCCDTracker::extractFeatures(const vpRBFeatureTrackerInput &fr
   const vpHomogeneousMatrix oMc = cMo.inverse();
 
   std::vector<std::vector<vpRBSilhouetteControlPoint>> pointsPerThread;
-#ifdef VISP_HAVE_OPENMP
-  pointsPerThread.resize(omp_get_num_threads());
-#else
-  pointsPerThread.resize(1);
-#endif
+
 
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel
 #endif
   {
+#ifdef VISP_HAVE_OPENMP
+#pragma omp single
+    {
+      unsigned int numThreads = omp_get_num_threads();
+      pointsPerThread.resize(numThreads);
+    }
+#else
+    {
+      pointsPerThread.resize(1);
+    }
+#endif
 #ifdef VISP_HAVE_OPENMP
     unsigned int threadIdx = omp_get_thread_num();
 #else
@@ -819,21 +826,28 @@ void vpRBSilhouetteCCDTracker::computeErrorAndInteractionMatrix()
   }
   std::vector<vpColVector> gradientPerThread;
   std::vector<vpMatrix> hessianPerThread;
-#ifdef VISP_HAVE_OPENMP
-  unsigned int numThreads = omp_get_num_threads();
-#else
-  unsigned int numThreads = 1;
-#endif
-
-  gradientPerThread.resize(omp_get_num_threads());
-  hessianPerThread.resize(omp_get_num_threads());
-
   m_gradient = 0.0;
   m_hessian = 0.0;
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel
 #endif
   {
+#ifdef VISP_HAVE_OPENMP
+#pragma omp single
+    {
+      unsigned int numThreads = omp_get_num_threads();
+      gradientPerThread.resize(numThreads);
+      hessianPerThread.resize(numThreads);
+    }
+#else
+    {
+      gradientPerThread.resize(1);
+      hessianPerThread.resize(1);
+    }
+#endif
+
+
+
 #ifdef VISP_HAVE_OPENMP
     unsigned int threadIdx = omp_get_thread_num();
 #else

--- a/modules/tracker/rbt/src/features/vpRBSilhouetteCCDTracker.cpp
+++ b/modules/tracker/rbt/src/features/vpRBSilhouetteCCDTracker.cpp
@@ -837,7 +837,7 @@ void vpRBSilhouetteCCDTracker::computeErrorAndInteractionMatrix()
 #ifdef VISP_HAVE_OPENMP
     unsigned int threadIdx = omp_get_thread_num();
 #else
-    unsigned int threadIdx = 1;
+    unsigned int threadIdx = 0;
 #endif
     vpColVector localGradient(m_gradient.getRows(), 0.0);
     vpMatrix localHessian(m_hessian.getRows(), m_hessian.getCols(), 0.0);

--- a/modules/tracker/rbt/src/vo/vpPointMap.cpp
+++ b/modules/tracker/rbt/src/vo/vpPointMap.cpp
@@ -145,7 +145,7 @@ void vpPointMap::getVisiblePoints(const unsigned int h, const unsigned int w, co
 #ifdef VISP_HAVE_OPENMP
     unsigned int threadIdx = omp_get_thread_num();
 #else
-    unsigned int threadIdx = 1;
+    unsigned int threadIdx = 0;
 #endif
     std::vector<int> localIndices;
     double u, v;

--- a/modules/tracker/rbt/src/vo/vpPointMap.cpp
+++ b/modules/tracker/rbt/src/vo/vpPointMap.cpp
@@ -131,17 +131,25 @@ void vpPointMap::getVisiblePoints(const unsigned int h, const unsigned int w, co
   vpMatrix::mult2Matrices(m_X, cRw.t(), cX);
 
   std::vector<std::vector<int>> indicesPerThread;
-#ifdef VISP_HAVE_OPENMP
-  const unsigned int numThreads = omp_get_num_threads();
-#else
-  const unsigned int numThreads = 1;
-#endif
-  indicesPerThread.resize(numThreads);
+
 
 #ifdef VISP_HAVE_OPENMP
 #pragma omp parallel
 #endif
   {
+
+#ifdef VISP_HAVE_OPENMP
+#pragma omp single
+    {
+      unsigned int numThreads = omp_get_num_threads();
+      indicesPerThread.resize(numThreads);
+    }
+#else
+    {
+      indicesPerThread.resize(1);
+    }
+#endif
+
 #ifdef VISP_HAVE_OPENMP
     unsigned int threadIdx = omp_get_thread_num();
 #else


### PR DESCRIPTION
This PR reworks how OpenMP is used in the RBT features so that the results are deterministic.
Indeed, critical sections are not executed in any specific order, so the reduction/fusion operation may happen in any order.
As we apply floating point operations afterwards (eg summing feature gradients etc.) this may impact results.