### PR TITLE
Add ROS CI workflow

### DIFF
--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -1,0 +1,127 @@
+name: ROS
+# cf:
+#  - https://github.com/AprilRobotics/apriltag/blob/master/.github/workflows/colcon-workspace.yml
+#  - https://github.com/ros-tooling/setup-ros
+
+# https://www.jeffgeerling.com/blog/2020/running-github-actions-workflow-on-schedule-and-other-events
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre#comment133398800_72408109
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  # build on Ubuntu docker images
+  build_linux:
+    name: "${{ matrix.docker_image }} (${{ matrix.ros_distribution }})"
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - docker_image: ubuntu:20.04
+            ros_distribution: noetic
+            ros_version: 1
+
+          - docker_image: ubuntu:22.04
+            ros_distribution: humble
+            ros_version: 2
+
+          - docker_image: ubuntu:24.04
+            ros_distribution: jazzy
+            ros_version: 2
+
+    container:
+      image: ${{ matrix.docker_image }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup ROS environment
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ matrix.ros_distribution }}
+
+      - name: Print ROS info
+        if: ${{ matrix.ros_version == 1 }}
+        shell: bash
+        run: |
+          ls /opt/ros/${{ matrix.ros_distribution }}
+          cat /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          rosrun --help
+          printenv | grep -i ROS
+
+      - name: Print ROS info
+        if: ${{ matrix.ros_version == 2 }}
+        shell: bash
+        run: |
+          ls /opt/ros/${{ matrix.ros_distribution }}
+          cat /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          ros2 run --help
+          printenv | grep -i ROS
+
+      - name: Print system information
+        run: lscpu
+
+      - name: Print OS information
+        run: lsb_release -a
+
+      - name: Print compiler information
+        run: dpkg --list | grep compiler
+
+      - name: Clone visp-images
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: |
+          git clone --depth 1 https://github.com/lagadic/visp-images ${HOME}/visp-images
+          echo "VISP_INPUT_IMAGE_PATH=$HOME/visp-images" >> $GITHUB_ENV
+          echo ${VISP_INPUT_IMAGE_PATH}
+
+      - name: Configure CMake
+        shell: bash
+        run: |
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          pwd
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          cat ViSP-third-party.txt
+
+      - name: Compile
+        working-directory: build
+        shell: bash
+        run: |
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          make -j$(nproc) install
+
+      - name: Run unit tests
+        working-directory: build
+        shell: bash
+        run: |
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          ctest -j$(nproc) --output-on-failure
+
+      - name: Print ROS info 2
+        if: ${{ matrix.ros_version == 1 }}
+        shell: bash
+        run: |
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          rosrun --help
+          printenv | grep -i ROS
+          rospack list-names
+
+      - name: Print ROS info 2
+        if: ${{ matrix.ros_version == 2 }}
+        shell: bash
+        run: |
+          source /opt/ros/${{ matrix.ros_distribution }}/setup.bash
+          ros2 run --help
+          printenv | grep -i ROS
+          ros2 pkg list


### PR DESCRIPTION
See:
- https://github.com/ros-tooling/setup-ros
- https://github.com/AprilRobotics/apriltag/blob/1e98edb64eadb012f1ed029a85dbf36770b0d819/.github/workflows/colcon-workspace.yml

This does not mimic the same environment compared to https://build.ros2.org/job/Hdev__visp__ubuntu_jammy_amd64/

There are already lots of CI runners, feel free to close this PR if you think it is redundant.