### PR TITLE
Use memcpy in vpImageConvert::YUV420ToGrey()

### DIFF
--- a/modules/core/src/image/vpImageConvert_yuv.cpp
+++ b/modules/core/src/image/vpImageConvert_yuv.cpp
@@ -800,10 +800,7 @@ void vpImageConvert::YUV420ToRGB(unsigned char *yuv, unsigned char *rgb, unsigne
 */
 void vpImageConvert::YUV420ToGrey(unsigned char *yuv, unsigned char *grey, unsigned int size)
 {
-  for (unsigned int i = 0; i < size; ++i) {
-    *grey++ = *yuv;
-    ++yuv;
-  }
+  memcpy(grey, yuv, size);
 }
 
 /*!

--- a/tutorial/detection/tag/tutorial-apriltag-detector-live-T265-realsense.cpp
+++ b/tutorial/detection/tag/tutorial-apriltag-detector-live-T265-realsense.cpp
@@ -291,6 +291,7 @@ int main(int argc, const char **argv)
     detector.setDisplayTag(opt_display_tag, opt_color_id < 0 ? vpColor::none : vpColor::getColor(opt_color_id), opt_thickness);
     detector.setZAlignedWithCameraAxis(opt_tag_z_align_frame);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
     //! [AprilTag detector settings]
 
     std::vector<double> time_vec;

--- a/tutorial/detection/tag/tutorial-apriltag-detector-live-rgbd-realsense.cpp
+++ b/tutorial/detection/tag/tutorial-apriltag-detector-live-rgbd-realsense.cpp
@@ -296,6 +296,7 @@ int main(int argc, const char **argv)
     detector.setDisplayTag(opt_display_tag, opt_color_id < 0 ? vpColor::none : vpColor::getColor(opt_color_id), opt_thickness);
     detector.setZAlignedWithCameraAxis(opt_tag_z_align_frame);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
     //! [AprilTag detector settings]
     std::vector<double> time_vec, time_vec_detection;
     for (;;) {

--- a/tutorial/detection/tag/tutorial-apriltag-detector-live-rgbd-structure-core.cpp
+++ b/tutorial/detection/tag/tutorial-apriltag-detector-live-rgbd-structure-core.cpp
@@ -291,6 +291,7 @@ int main(int argc, const char **argv)
     detector.setDisplayTag(opt_display_tag, opt_color_id < 0 ? vpColor::none : vpColor::getColor(opt_color_id), opt_thickness);
     detector.setZAlignedWithCameraAxis(opt_tag_z_align_frame);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
     //! [AprilTag detector settings]
     std::vector<double> time_vec;
     for (;;) {

--- a/tutorial/detection/tag/tutorial-apriltag-detector.cpp
+++ b/tutorial/detection/tag/tutorial-apriltag-detector.cpp
@@ -286,6 +286,7 @@ int main(int argc, const char **argv)
     detector.setDisplayTag(opt_display_tag, opt_color_id < 0 ? vpColor::none : vpColor::getColor(opt_color_id), opt_thickness);
     detector.setZAlignedWithCameraAxis(opt_tag_z_align_frame);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
     //! [AprilTag detector settings]
 
     vpDisplay::display(I);

--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-2D-half-vs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-2D-half-vs.cpp
@@ -277,6 +277,7 @@ int main(int argc, const char **argv)
     detector.setAprilTagNbThreads(opt_tag_nThreads);
     detector.setDisplayTag(display_tag);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
 
     vpServo task;
     vpAdaptiveGain lambda;

--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-ibvs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-ibvs.cpp
@@ -276,6 +276,7 @@ int main(int argc, const char **argv)
     detector.setAprilTagQuadDecimate(opt_tag_quad_decimate);
     detector.setAprilTagNbThreads(opt_tag_nThreads);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
 #ifdef VISP_HAVE_DISPLAY
     detector.setDisplayTag(display_tag);
 #endif

--- a/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-pbvs.cpp
+++ b/tutorial/robot/mbot/raspberry/visp/mbot-apriltag-pbvs.cpp
@@ -268,6 +268,7 @@ int main(int argc, const char **argv)
     detector.setAprilTagNbThreads(opt_tag_nThreads);
     detector.setDisplayTag(display_tag);
     detector.setAprilTagDecisionMarginThreshold(opt_tag_decision_margin_threshold);
+    detector.setAprilTagHammingDistanceThreshold(opt_tag_hamming_distance_threshold);
 
     vpServo task;
     vpAdaptiveGain lambda;


### PR DESCRIPTION
- call to `setAprilTagHammingDistanceThreshold()` seems to be missing in some files
- when looking at the `vpImageConvert::YUV420ToGrey()` source code, the for loop can be replace by a `memcpy`