### PR TITLE
Update the Android AprilTag app

### DIFF
--- a/doc/tutorial/android/tutorial-android-getting-started.dox
+++ b/doc/tutorial/android/tutorial-android-getting-started.dox
@@ -69,7 +69,7 @@ Open Android Studio.
   sources are located in the `sdk` folder. As shown in the next image, you should add the following lines:
 \code
 include ':visp'
-project(':visp').projectDir = new File('../sdk')
+project(':visp').projectDir = new File('sdk')
 \endcode
 \image html 05-editing-global.jpg
 

--- a/modules/java/generator/android/java/org/visp/android/CameraBridgeViewBase.java
+++ b/modules/java/generator/android/java/org/visp/android/CameraBridgeViewBase.java
@@ -425,10 +425,10 @@ public abstract class CameraBridgeViewBase extends SurfaceView implements Surfac
 
                 if (mScale != 0) {
                     canvas.drawBitmap(mCacheBitmap, new Rect(0,0,mCacheBitmap.getWidth(), mCacheBitmap.getHeight()),
-                         new Rect(static_cast<int>((canvas.getWidth() - mScale*mCacheBitmap.getWidth()) / 2),
-                         static_cast<int>((canvas.getHeight() - mScale*mCacheBitmap.getHeight()) / 2),
-                         static_cast<int>((canvas.getWidth() - mScale*mCacheBitmap.getWidth()) / 2 + mScale*mCacheBitmap.getWidth()),
-                         static_cast<int>((canvas.getHeight() - mScale*mCacheBitmap.getHeight()) / 2 + mScale*mCacheBitmap.getHeight())), null);
+                         new Rect(Math.round((canvas.getWidth() - mScale*mCacheBitmap.getWidth()) / 2),
+                         Math.round((canvas.getHeight() - mScale*mCacheBitmap.getHeight()) / 2),
+                         Math.round((canvas.getWidth() - mScale*mCacheBitmap.getWidth()) / 2 + mScale*mCacheBitmap.getWidth()),
+                         Math.round((canvas.getHeight() - mScale*mCacheBitmap.getHeight()) / 2 + mScale*mCacheBitmap.getHeight())), null);
                 } else {
                      canvas.drawBitmap(mCacheBitmap, new Rect(0,0,mCacheBitmap.getWidth(), mCacheBitmap.getHeight()),
                          new Rect((canvas.getWidth() - mCacheBitmap.getWidth()) / 2,

--- a/modules/java/misc/detection/gen_dict.json
+++ b/modules/java/misc/detection/gen_dict.json
@@ -204,13 +204,18 @@
           "//javadoc: VpDetectorAprilTag::getTagsCorners()\n",
           "public java.util.List<java.util.List<org.visp.core.VpImagePoint>> getTagsCorners()",
           "{",
-          "   long[][] matrix = getTagsCorners(nativeObj);",
-          "   return org.visp.utils.Converters.Array_Array_to_vector_vector_vpImagePoint(matrix);",
+          "   java.lang.Object[] matrix_ = getTagsCorners(nativeObj);",
+          "   long[][] tags_corners = new long[matrix_.length][];",
+          "   for (int idx = 0; idx < matrix_.length; idx++) {",
+          "       tags_corners[idx] = (long[]) matrix_[idx];",
+          "   }",
+          "",
+          "   return org.visp.utils.Converters.Array_Array_to_vector_vector_vpImagePoint(tags_corners);",
           "}"
         ],
         "jn_code": [
           "// C++: std::vector<std::vector<vpImagePoint> > getTagsCorners()",
-          "private static native long[][] getTagsCorners(long address);"
+          "private static native java.lang.Object[] getTagsCorners(long address);"
         ],
         "cpp_code": [
           "//",

--- a/samples/android/app/src/main/AndroidManifest.xml
+++ b/samples/android/app/src/main/AndroidManifest.xml
@@ -3,10 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.CAMERA" />
-
-    <uses-feature
-        android:name="android.hardware.camera"
-        android:required="true" />
+    <uses-permission android:name="android.permission.FLASHLIGHT" />
+    <uses-feature android:name="android.hardware.camera" android:required="true" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.flash" android:required="false" />
 
     <application
         android:allowBackup="true"
@@ -26,6 +26,9 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity android:name=".SettingsPanelActivity">
+            <!-- Optionally, you can define launch modes or other configurations here -->
         </activity>
     </application>
 

--- a/samples/android/app/src/main/java/com/example/apriltagdetection/CameraPreviewActivity.java
+++ b/samples/android/app/src/main/java/com/example/apriltagdetection/CameraPreviewActivity.java
@@ -3,25 +3,33 @@ package com.example.apriltagdetection;
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
+import android.graphics.Color;
 import android.os.Bundle;
 
+import android.graphics.PixelFormat;
 import android.hardware.Camera;
-import android.view.View;
+import android.util.Log;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
 import android.widget.FrameLayout;
-import android.widget.ImageView;
+import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
+import android.view.View;
 
-import com.google.android.material.snackbar.Snackbar;
+import org.visp.core.VpCameraParameters;
+import org.visp.core.VpHomogeneousMatrix;
+import org.visp.core.VpImagePoint;
+import org.visp.core.VpPoint;
 
-import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Displays a {@link CameraPreview} of the first {@link Camera}.
@@ -32,73 +40,387 @@ import java.nio.ByteBuffer;
  * permissions API.
  * <p>
  * Implementation is based directly on the documentation at
- * http://developer.android.com/guide/topics/media/camera.html
+ * https://developer.android.com/media/camera/camera-deprecated/camera-api
  */
 public class CameraPreviewActivity extends MainActivity  {
-
     /**
      * Id of the camera to access. 0 is the first camera.
      */
     private static final int CAMERA_ID = 0;
+    private static final String TAG = "CameraPreviewActivity";
+    private static final int SETTINGS_REQUEST_CODE = 1;
 
+    Camera.CameraInfo mCameraInfo;
     private Camera mCamera;
-    // public static ImageView resultImageView;
-    static int w,h;
-    static TextView resultInfo;
+    private int mW, mH;
+    static TextView mResultInfo;
+    static DisplaySurfaceView mLineSurface;
+    private Spinner mSpinner;
+    FrameLayout mFrameLayout;
+    private CameraPreview mPreview;
+    private Button mBtnSettings;
+    private boolean mCameraFlash;
+    private double mFocalLength;
+    private double mTagSize;
+    private Button mBtnAutoFocus;
+    private boolean mUpdatedFocal;
+    private boolean mUpdatedTagSize;
+    private boolean mDisplayTagFrame;
+    private double mTagFrameDisplayRatio;
+    private int mAprilTagSelectionPosition;
+    private int mAprilTagQuadDecimate;
+    private int mAprilTagDecisionMargin;
+    private int mAprilTagNbThreads;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        Log.d(TAG, "CameraPreviewActivity::onCreate()");
         super.onCreate(savedInstanceState);
 
+        // Arbitrary value for the request code? --> https://stackoverflow.com/a/36653669 ?
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.CAMERA}, 100);
+        }
+
+        mUpdatedFocal = false;
+        mUpdatedTagSize = false;
+        init();
+    }
+
+    private void init() {
         // Open an instance of the first camera and retrieve its info.
+        mCameraInfo = new Camera.CameraInfo();
+        mCameraFlash = false;
         mCamera = getCameraInstance(CAMERA_ID);
-        Camera.CameraInfo cameraInfo = new Camera.CameraInfo();
-        Camera.getCameraInfo(CAMERA_ID, cameraInfo);
 
         if (mCamera == null) {
             // Camera is not available, display error message
             Toast.makeText(this, "Camera is not available.", Toast.LENGTH_SHORT).show();
             setContentView(R.layout.camera_unavailable);
-        } else {
-            setContentView(R.layout.activity_camera_preview);
 
-            resultInfo = findViewById(R.id.resultTV);
-            // resultImageView = findViewById(R.id.resultImage);
+            return;
+        }
 
-            // init the byte array
-            w = mCamera.getParameters().getPreviewSize().width;
-            h = mCamera.getParameters().getPreviewSize().height;
+        Camera.getCameraInfo(CAMERA_ID, mCameraInfo);
+        setContentView(R.layout.activity_camera_preview);
 
-            // Get the rotation of the screen to adjust the preview image accordingly.
-            final int displayRotation = getWindowManager().getDefaultDisplay()
-                    .getRotation();
+        mBtnSettings = findViewById(R.id.btnSettings);
+        mBtnSettings.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Camera.Parameters params = mCamera.getParameters();
+                // the focal length. Returns -1.0 when the device doesn't report focal length information.
+                float focalLength_mm = params.getFocalLength();
+                Camera.Size size = params.getPictureSize();
 
-            // Create the Preview view and set it as the content of this Activity.
-            CameraPreview mPreview = new CameraPreview(this, mCamera, cameraInfo, displayRotation);
-            FrameLayout preview = findViewById(R.id.camera_preview);
-            preview.addView(mPreview);
+                // Physical sensor size
+                // See: https://stackoverflow.com/a/41032402/6055233
+                // "horizontal angle of view. Returns -1.0 when the device doesn't report view angle information."
+                float horizontalViewAngle = params.getHorizontalViewAngle();
+                // "vertical angle of view. Returns -1.0 when the device doesn't report view angle information."
+                float verticalViewAngle = params.getVerticalViewAngle();
+                double sensorWidth = focalLength_mm * 2*Math.tan(Math.toRadians(horizontalViewAngle/2));
+                double sensorHeight = focalLength_mm * 2*Math.tan(Math.toRadians(verticalViewAngle/2));
+
+                mCamera.setPreviewCallback(null);
+                mFrameLayout.removeView(mPreview);
+                mPreview = null;
+                releaseCamera();
+
+                Intent intent = new Intent(CameraPreviewActivity.this, SettingsPanelActivity.class);
+
+                intent.putExtra("camera_flash", mCameraFlash);
+
+                intent.putExtra("camera_focal_mm", focalLength_mm);
+                intent.putExtra("camera_native_w", size.width);
+                intent.putExtra("camera_native_h", size.height);
+                intent.putExtra("camera_hfov", horizontalViewAngle);
+                intent.putExtra("camera_vfov", verticalViewAngle);
+                intent.putExtra("camera_sensor_w", sensorWidth);
+                intent.putExtra("camera_sensor_h", sensorHeight);
+
+                intent.putExtra("image_w", mW);
+                intent.putExtra("image_h", mH);
+
+                intent.putExtra("focal", mFocalLength);
+                intent.putExtra("tag_size", mTagSize);
+
+                intent.putExtra("display_tag_frame", mDisplayTagFrame);
+                intent.putExtra("display_tag_frame_ratio", mTagFrameDisplayRatio);
+
+                intent.putExtra("aprilTag_selection_position", mAprilTagSelectionPosition);
+                intent.putExtra("aprilTag_quad_decimate", mAprilTagQuadDecimate);
+                intent.putExtra("aprilTag_decision_margin", mAprilTagDecisionMargin);
+                intent.putExtra("aprilTag_nb_threads", mAprilTagNbThreads);
+
+                startActivityForResult(intent, SETTINGS_REQUEST_CODE);
+            }
+        });
+
+        mBtnAutoFocus = findViewById(R.id.btnAutoFocus);
+        // Set up the autofocus button
+        mBtnAutoFocus.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mCamera != null) {
+                    mCamera.autoFocus(new Camera.AutoFocusCallback() {
+                        @Override
+                        public void onAutoFocus(boolean success, Camera camera) {
+                            if (!success) {
+                                Toast.makeText(CameraPreviewActivity.this, "Cannot perform camera autofocus",
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        }
+                    });
+                }
+            }
+        });
+
+        mSpinner = findViewById(R.id.spinner);
+        String[] items = {
+                "TAG_36h11", "TAG_25h9", "TAG_25h7", "TAG_16h5", "TAG_CIRCLE21h7",
+                "TAG_ARUCO_4x4", "TAG_ARUCO_5x5", "TAG_ARUCO_6x6", "TAG_ARUCO_MIP_36h12"
+        };
+
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, items);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        mSpinner.setAdapter(adapter);
+        mAprilTagSelectionPosition = 0;
+        mSpinner.setSelection(mAprilTagSelectionPosition);
+
+        mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parentView, View selectedItemView, int position, long id) {
+                String selectedItem = parentView.getItemAtPosition(position).toString();
+                Toast.makeText(CameraPreviewActivity.this, "Selected: " + selectedItem, Toast.LENGTH_SHORT).show();
+
+                mAprilTagSelectionPosition = position;
+                mPreview.setAprilTagMethod(position);
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parentView) {
+                Toast.makeText(CameraPreviewActivity.this, "No item selected", Toast.LENGTH_SHORT).show();
+            }
+        });
+
+        mResultInfo = findViewById(R.id.resultTV);
+        mLineSurface = findViewById(R.id.surfaceView);
+        mLineSurface.setZOrderOnTop(true);
+        mLineSurface.getHolder().setFormat(PixelFormat.TRANSLUCENT);
+
+        // init the byte array
+        mW = mCamera.getParameters().getPreviewSize().width;
+        mH = mCamera.getParameters().getPreviewSize().height;
+
+        // Get the rotation of the screen to adjust the preview image accordingly.
+        final int displayRotation = getWindowManager().getDefaultDisplay().getRotation();
+
+        // Create the Preview view and set it as the content of this Activity.
+        mPreview = new CameraPreview(this, mCamera, mCameraInfo, displayRotation, mDisplayTagFrame, mTagFrameDisplayRatio);
+        mFrameLayout = findViewById(R.id.camera_preview);
+        mFrameLayout.addView(mPreview);
+
+        if (!mUpdatedFocal) {
+            Camera.Parameters params = mCamera.getParameters();
+            float focalLength_mm = params.getFocalLength();
+            Camera.Size size = params.getPictureSize();
+
+            float horizontalViewAngle = params.getHorizontalViewAngle();
+            if (horizontalViewAngle > 0) {
+                double sensorWidth = focalLength_mm * 2*Math.tan(Math.toRadians(horizontalViewAngle/2));
+
+                // Focal length computed from sensor specs
+                mFocalLength = focalLength_mm / (sensorWidth / size.width);
+                // Scale the focal length wrt. the current image resolution
+                mFocalLength = mFocalLength * mW / size.width;
+            } else {
+                mFocalLength = 600;
+            }
+
+            mPreview.setCameraFocal(mFocalLength);
+        }
+        if (!mUpdatedTagSize) {
+            mTagSize = 0.1;
+            mPreview.setTagSize(mTagSize);
+        }
+
+        mDisplayTagFrame = false;
+        mTagFrameDisplayRatio = 0.5;
+
+        mAprilTagSelectionPosition = 0;
+        mAprilTagQuadDecimate = 2;
+        mPreview.setAprilTagQuadDecimate(mAprilTagQuadDecimate);
+        mAprilTagDecisionMargin = 50;
+        mPreview.setAprilTagMarginThreshold(mAprilTagDecisionMargin);
+        mAprilTagNbThreads = 1;
+        mPreview.setAprilTagNbThreads(mAprilTagNbThreads);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        init();
+
+        if (requestCode == SETTINGS_REQUEST_CODE && resultCode == RESULT_OK) {
+            String cameraFlash_str = data.getStringExtra("cameraFlashChecked");
+            if (cameraFlash_str != null) {
+                mCameraFlash = Boolean.parseBoolean(cameraFlash_str);
+
+                // Camera flash
+                Camera.Parameters cam_params = mCamera.getParameters();
+                if (mCameraFlash && cam_params != null) {
+                    if (cam_params.getSupportedFlashModes() != null && cam_params.getSupportedFlashModes().contains(Camera.Parameters.FLASH_MODE_TORCH)) {
+                        cam_params.setFlashMode(Camera.Parameters.FLASH_MODE_TORCH);
+                        mCamera.setParameters(cam_params);
+                    } else {
+                        Toast.makeText(this, "Camera flash is not available.", Toast.LENGTH_SHORT).show();
+                    }
+                }
+            }
+
+            String cameraFocalValue_str = data.getStringExtra("cameraFocalValue");
+            if (cameraFocalValue_str != null) {
+                mFocalLength = Double.parseDouble(cameraFocalValue_str);
+                mPreview.setCameraFocal(mFocalLength);
+
+                mUpdatedFocal = true;
+            }
+
+            String tagSizeValue_str = data.getStringExtra("tagSizeValue");
+            if (tagSizeValue_str != null) {
+                mTagSize = Double.parseDouble(tagSizeValue_str);
+                mPreview.setTagSize(mTagSize);
+
+                mUpdatedTagSize = true;
+            }
+
+            String displayTagFrame_str = data.getStringExtra("displayFrameChecked");
+            if (displayTagFrame_str != null) {
+                mDisplayTagFrame = Boolean.parseBoolean(displayTagFrame_str);
+                mPreview.setDisplayTagFrame(mDisplayTagFrame);
+
+                String tagFrameSizeRatio_str = data.getStringExtra("tagFrameRatio");
+                if (tagFrameSizeRatio_str != null) {
+                    mTagFrameDisplayRatio = Double.parseDouble(tagFrameSizeRatio_str) > 0 ? Double.parseDouble(tagFrameSizeRatio_str) : mTagFrameDisplayRatio;
+                    mPreview.setDisplayTagFrameRatio(mTagFrameDisplayRatio);
+                }
+            }
+
+            // Set the AprilTag method selection to the correct value
+            String aprilTagSelectionPosition_str = data.getStringExtra("aprilTagSelectionPosition");
+            if (aprilTagSelectionPosition_str != null) {
+                mAprilTagSelectionPosition = Integer.parseInt(aprilTagSelectionPosition_str);
+                mSpinner.setSelection(mAprilTagSelectionPosition);
+                mPreview.setAprilTagMethod(mAprilTagSelectionPosition);
+            }
+
+            String aprilTagQuadDecimate_str = data.getStringExtra("aprilTagQuadDecimate");
+            if (aprilTagQuadDecimate_str != null) {
+                mAprilTagQuadDecimate = Integer.parseInt(aprilTagQuadDecimate_str);
+                mPreview.setAprilTagQuadDecimate(mAprilTagQuadDecimate);
+            }
+
+            String aprilTagDecisionMargin_str = data.getStringExtra("aprilTagDecisionMargin");
+            if (aprilTagDecisionMargin_str != null) {
+                mAprilTagDecisionMargin = Integer.parseInt(aprilTagDecisionMargin_str);
+                mPreview.setAprilTagMarginThreshold(mAprilTagDecisionMargin);
+            }
+
+            String aprilTagNbThreads_str = data.getStringExtra("aprilTagNbThreads");
+            if (aprilTagNbThreads_str != null) {
+                mAprilTagNbThreads = Integer.parseInt(aprilTagNbThreads_str);
+                mPreview.setAprilTagNbThreads(mAprilTagNbThreads);
+            }
         }
     }
 
-    public static void updateResult(byte[] Src, String s){
-        // byte [] Bits = new byte[Src.length*4]; //That's where the RGBA array goes.
-        // int i;
-        // for(i=0;i<Src.length;i++){
-        //    Bits[i*4] = Bits[i*4+1] = Bits[i*4+2] = Src[i]; //Invert the source bits
-        //    Bits[i*4+3] = -1;//0xff, that's the alpha.
-        // }
+    public static void updateResults(List<List<VpImagePoint>> cornersList, int strokeWidth, int[] ids, List<VpHomogeneousMatrix> cMoList,
+                                     String s, int orientation, int w, int h, boolean displayTagFrame, double tagFrameRatio,
+                                     double tagSize, VpCameraParameters cam) {
+        int RED = Color.RED;        // -65536
+        int GREEN = Color.GREEN;    // -16711936
+        int YELLOW = Color.YELLOW;  // -256
+        int BLUE = Color.BLUE;      // -16776961
 
-        // //Now put these nice RGBA pixels into a Bitmap object
-        // Bitmap bm = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
-        // bm.copyPixelsFromBuffer(ByteBuffer.wrap(Bits));
+        int[] color_ = {RED, GREEN, YELLOW, BLUE};
+        int[] strokeWidth_ = {strokeWidth, strokeWidth, strokeWidth, strokeWidth};
 
-        // resultImageView.setImageBitmap(bm);
-        resultInfo.setText(s);
+        List<double[]> list_startX = new ArrayList<>(cornersList.size());
+        List<double[]> list_startY = new ArrayList<>(cornersList.size());
+        List<double[]> list_stopX = new ArrayList<>(cornersList.size());
+        List<double[]> list_stopY = new ArrayList<>(cornersList.size());
+
+        mLineSurface.clear();
+
+        List<Double> centerX = new ArrayList<>(cornersList.size());
+        List<Double> centerY = new ArrayList<>(cornersList.size());
+        for (List<VpImagePoint> corners : cornersList) {
+            double[] startX_ = {corners.get(0).get_u(), corners.get(0).get_u(), corners.get(1).get_u(), corners.get(2).get_u()};
+            double[] startY_ = {corners.get(0).get_v(), corners.get(0).get_v(), corners.get(1).get_v(), corners.get(2).get_v()};
+            double[] stopX_ = {corners.get(1).get_u(), corners.get(3).get_u(), corners.get(2).get_u(), corners.get(3).get_u()};
+            double[] stopY_ = {corners.get(1).get_v(), corners.get(3).get_v(), corners.get(2).get_v(), corners.get(3).get_v()};
+
+            list_startX.add(startX_);
+            list_startY.add(startY_);
+            list_stopX.add(stopX_);
+            list_stopY.add(stopY_);
+
+            centerX.add( (corners.get(0).get_u() + corners.get(1).get_u() + corners.get(2).get_u() + corners.get(3).get_u()) / 4 );
+            centerY.add( (corners.get(0).get_v() + corners.get(1).get_v() + corners.get(2).get_v() + corners.get(3).get_v()) / 4 );
+        }
+
+        List<Double> tagDistances = new ArrayList<>(cMoList.size());
+        List<double[]> list_oX = new ArrayList<>(cornersList.size());
+        List<double[]> list_oY = new ArrayList<>(cornersList.size());
+        for (VpHomogeneousMatrix cMo : cMoList) {
+            double[] cMo_array = new double[16];
+
+            String[] cMo_array_str = cMo.toString().split("\\s+");
+            cMo_array = Arrays.stream(cMo_array_str)
+                    .mapToDouble(Double::parseDouble)
+                    .toArray();
+
+            double tx = cMo_array[3];
+            double ty = cMo_array[7];
+            double tz = cMo_array[11];
+
+            double dist = Math.sqrt(tx*tx + ty*ty + tz*tz);
+            tagDistances.add(dist);
+
+            // Tag frame
+            VpPoint origin = new VpPoint(0, 0, 0);
+            VpImagePoint im_origin = project(cMo, origin, cam);
+
+            VpPoint oX = new VpPoint(tagSize * tagFrameRatio, 0, 0);
+            VpImagePoint im_ox = project(cMo, oX, cam);
+
+            VpPoint oY = new VpPoint(0, tagSize * tagFrameRatio, 0);
+            VpImagePoint im_oy = project(cMo, oY, cam);
+
+            VpPoint oZ = new VpPoint(0, 0, tagSize * tagFrameRatio);
+            VpImagePoint im_oz = project(cMo, oZ, cam);
+
+            list_oX.add(new double[] {im_origin.get_u(), im_ox.get_u(), im_oy.get_u(), im_oz.get_u()} );
+            list_oY.add(new double[] {im_origin.get_v(), im_ox.get_v(), im_oy.get_v(), im_oz.get_v()} );
+        }
+
+        mLineSurface.drawLines(list_startX, list_startY, list_stopX, list_stopY, color_, strokeWidth_, centerX, centerY, ids,
+                tagDistances.stream().mapToDouble(Double::valueOf).toArray(), orientation, w, h, displayTagFrame, list_oX, list_oY);
+
+        mResultInfo.setText(s);
     }
 
-//    public static void updateResult(String s){
-//        resultInfo.setText(s);
-//    }
+    private static VpImagePoint project(VpHomogeneousMatrix cMo, VpPoint obj, VpCameraParameters cam) {
+        obj.changeFrame(cMo);
+        obj.projection();
+        double px = cam.get_px(), py = cam.get_py(), u0 = cam.get_u0(), v0 = cam.get_v0();
+        double u = px * obj.get_x() + u0;
+        double v = py * obj.get_y() + v0;
+
+        return new VpImagePoint(v, u);
+    }
 
     @Override
     public void onPause() {
@@ -107,12 +429,29 @@ public class CameraPreviewActivity extends MainActivity  {
         releaseCamera();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (mCamera == null) {
+            try {
+                mCamera = getCameraInstance(CAMERA_ID);
+            } catch (Exception e) {
+                Log.e(TAG, "CameraPreviewActivity::onResume() ; Error opening camera: " + e.getMessage());
+            }
+        }
+
+        if (mPreview == null) {
+            init();
+        }
+    }
+
     /** A safe way to get an instance of the Camera object. */
     private Camera getCameraInstance(int cameraId) {
         Camera c = null;
         try {
             c = Camera.open(cameraId); // attempt to get a Camera instance
         } catch (Exception e) {
+            Log.e(TAG, "CameraPreviewActivity::getCameraInstance() ; Camera " + cameraId + " is not available: " + e.getMessage());
             // Camera is not available (in use or does not exist)
             Toast.makeText(this, "Camera " + cameraId + " is not available: " + e.getMessage(),
                     Toast.LENGTH_SHORT).show();
@@ -122,7 +461,8 @@ public class CameraPreviewActivity extends MainActivity  {
 
     private void releaseCamera() {
         if (mCamera != null) {
-            mCamera.release();        // release the camera for other applications
+            mCamera.stopPreview();
+            mCamera.release();
             mCamera = null;
         }
     }

--- a/samples/android/app/src/main/java/com/example/apriltagdetection/DisplaySurfaceView.java
+++ b/samples/android/app/src/main/java/com/example/apriltagdetection/DisplaySurfaceView.java
@@ -1,0 +1,181 @@
+package com.example.apriltagdetection;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.util.AttributeSet;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
+
+import java.util.List;
+import java.util.Locale;
+
+public class DisplaySurfaceView extends SurfaceView implements SurfaceHolder.Callback {
+    private static final String TAG = "DisplaySurfaceView";
+    private SurfaceHolder mSurfaceHolder;
+
+    public DisplaySurfaceView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    private void init() {
+        mSurfaceHolder = getHolder();
+        mSurfaceHolder.addCallback(this);
+    }
+
+    @Override
+    public void surfaceCreated(SurfaceHolder holder) {
+    }
+
+    public void clear() {
+        Canvas canvas = mSurfaceHolder.lockCanvas();
+        if (canvas != null) {
+            // https://stackoverflow.com/a/9035709
+            canvas.drawColor( 0, PorterDuff.Mode.CLEAR );
+            mSurfaceHolder.unlockCanvasAndPost(canvas);
+        }
+    }
+
+    public void drawLines(List<double[]> list_startX, List<double[]> list_startY, List<double[]> list_stopX, List<double[]> list_stopY,
+                          int[] color_, int[] strokeWidth_, List<Double> centerX, List<Double> centerY, int[] ids_, double[] dist_,
+                          int orientation, int width, int height, boolean draw_frame, List<double[]> list_frameX, List<double[]> list_frameY) {
+        Canvas canvas = mSurfaceHolder.lockCanvas();
+
+        if (canvas != null) {
+            float view_w = getWidth();
+            float view_h = getHeight();
+
+            for (int i = 0; i < list_startX.size(); i++) {
+                for (int j = 0; j < list_startX.get(i).length; j++) {
+                    double startX = list_startX.get(i)[j];
+                    double stopX = list_stopX.get(i)[j];
+                    double startY = list_startY.get(i)[j];
+                    double stopY = list_stopY.get(i)[j];
+
+                    int color = color_[j];
+                    int strokeWidth = strokeWidth_[j];
+
+                    Paint paint = new Paint();
+                    paint.setColor(color);
+                    paint.setStrokeWidth(strokeWidth);
+
+                    canvasDrawLine(canvas, startX, startY, stopX, stopY, orientation, width, height, paint);
+                }
+
+                // Draw id
+                Paint paint = new Paint();
+                paint.setColor(Color.parseColor("aqua"));
+                paint.setStrokeWidth(8);
+                paint.setTextSize(50);
+                paint.setTextAlign(Paint.Align.CENTER);
+
+                Paint paint2 = new Paint(paint);
+                paint2.setColor(Color.parseColor("fuchsia"));
+
+                int offset_dist = 50;
+                if (orientation == 0) {
+                    float scaleX = view_w / width;
+                    float scaleY = view_h / height;
+
+                    canvas.drawText(String.valueOf(ids_[i]), scaleX * centerX.get(i).floatValue(), scaleY * centerY.get(i).floatValue(), paint);
+
+                    canvas.drawText(String.format(Locale.US, "%.2f", dist_[i]) + " m", scaleX * centerX.get(i).floatValue(),
+                            scaleY * centerY.get(i).floatValue() + offset_dist, paint2);
+                } else if (orientation == 90) {
+                    float scaleX = view_w / height;
+                    float scaleY = view_h / width;
+
+                    canvas.drawText(String.valueOf(ids_[i]), scaleX * (view_w - centerY.get(i).floatValue()), scaleY * (centerX.get(i).floatValue()), paint);
+                    canvas.drawText(String.format(Locale.US, "%.2f", dist_[i]) + " m", scaleX * (view_w - centerY.get(i).floatValue()),
+                            scaleY * (centerX.get(i).floatValue()) + offset_dist, paint2);
+                } else {
+                    // 180°
+                    float scaleX = view_w / width;
+                    float scaleY = view_h / height;
+
+                    canvas.drawText(String.valueOf(ids_[i]), scaleX * (width - centerX.get(i).floatValue()), scaleY * (height - centerY.get(i).floatValue()), paint);
+                    canvas.drawText(String.format(Locale.US, "%.2f", dist_[i]) + " m", scaleX * (width - centerX.get(i).floatValue()),
+                            scaleY * (height - centerY.get(i).floatValue()) + offset_dist, paint2);
+                }
+
+                // Draw tag frame
+                if (draw_frame) {
+                    Paint paint_frame = new Paint();
+                    paint_frame.setStrokeWidth(8);
+
+                    // oX
+                    {
+                        paint_frame.setColor(Color.parseColor("red"));
+                        double startX = list_frameX.get(i)[0];
+                        double stopX = list_frameX.get(i)[1];
+                        double startY = list_frameY.get(i)[0];
+                        double stopY = list_frameY.get(i)[1];
+
+                        canvasDrawLine(canvas, startX, startY, stopX, stopY, orientation, width, height, paint_frame);
+                    }
+                    // oY
+                    {
+                        paint_frame.setColor(Color.parseColor("green"));
+
+                        double startX = list_frameX.get(i)[0];
+                        double stopX = list_frameX.get(i)[2];
+                        double startY = list_frameY.get(i)[0];
+                        double stopY = list_frameY.get(i)[2];
+
+                        canvasDrawLine(canvas, startX, startY, stopX, stopY, orientation, width, height, paint_frame);
+                    }
+                    // oZ
+                    {
+                        paint_frame.setColor(Color.parseColor("blue"));
+
+                        double startX = list_frameX.get(i)[0];
+                        double stopX = list_frameX.get(i)[3];
+                        double startY = list_frameY.get(i)[0];
+                        double stopY = list_frameY.get(i)[3];
+
+                        canvasDrawLine(canvas, startX, startY, stopX, stopY, orientation, width, height, paint_frame);
+                    }
+                }
+            }
+
+            mSurfaceHolder.unlockCanvasAndPost(canvas);
+        }
+    }
+
+    private void canvasDrawLine(Canvas canvas, double startX, double startY, double stopX, double stopY, int orientation, int width, int height, Paint paint) {
+        float view_w = getWidth();
+        float view_h = getHeight();
+
+        if (orientation == 0) {
+            double scaleX = view_w / width;
+            double scaleY = view_h / height;
+
+            canvas.drawLine((float) (scaleX * startX), (float) (scaleY * startY),
+                    (float) (scaleX * stopX), (float) (scaleY * stopY), paint);
+        } else if (orientation == 90) {
+            double scaleX = view_w / height;
+            double scaleY = view_h / width;
+
+            canvas.drawLine((float) (scaleX * (view_w - startY)), (float) (scaleY * startX),
+                    (float) (scaleX * (view_w - stopY)), (float) (scaleY * stopX), paint);
+        } else {
+            // 180°
+            double scaleX = view_w / width;
+            double scaleY = view_h / height;
+
+            canvas.drawLine((float) (scaleX * (width - startX)), (float) (scaleY * (height - startY)),
+                    (float) (scaleX * (width - stopX)), (float) (scaleY * (height - stopY)), paint);
+        }
+    }
+
+    @Override
+    public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+    }
+
+    @Override
+    public void surfaceDestroyed(SurfaceHolder holder) {
+    }
+}

--- a/samples/android/app/src/main/java/com/example/apriltagdetection/MainActivity.java
+++ b/samples/android/app/src/main/java/com/example/apriltagdetection/MainActivity.java
@@ -8,18 +8,13 @@ import com.google.android.material.snackbar.Snackbar ;
 import androidx.core.app.ActivityCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 
-import org.visp.core.VpImageUChar;
-
 
 public class MainActivity extends AppCompatActivity implements ActivityCompat.OnRequestPermissionsResultCallback {
-
     private static final int PERMISSION_REQUEST_CAMERA = 0;
     private View mLayout;
-
 
     // Used to load the 'native-lib' library on application startup.
     static {

--- a/samples/android/app/src/main/java/com/example/apriltagdetection/SettingsPanelActivity.java
+++ b/samples/android/app/src/main/java/com/example/apriltagdetection/SettingsPanelActivity.java
@@ -1,0 +1,164 @@
+package com.example.apriltagdetection;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.method.LinkMovementMethod;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.SeekBar;
+import android.widget.Spinner;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.util.Map;
+
+public class SettingsPanelActivity extends AppCompatActivity {
+    private static final String TAG = "SettingsPanelActivity";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        TextView originalCreditDesc = findViewById(R.id.originalCreditDesc);
+        originalCreditDesc.setMovementMethod(LinkMovementMethod.getInstance());
+
+        TextView apriltagDesc = findViewById(R.id.apriltagDesc);
+        apriltagDesc.setMovementMethod(LinkMovementMethod.getInstance());
+
+        TextView onlineMarkers = findViewById(R.id.onlineMarkers);
+        onlineMarkers.setMovementMethod(LinkMovementMethod.getInstance());
+
+        // Update values
+        Intent intent = getIntent();
+
+        // Flash
+        CheckBox cameraFlashInput = findViewById(R.id.cameraFlash);
+        boolean camera_flash = intent.getBooleanExtra("camera_flash", false);
+        cameraFlashInput.setChecked(camera_flash);
+
+        // Camera specs
+        float camera_focal_mm = intent.getFloatExtra("camera_focal_mm", 0);
+        TextView camera_focal_mm_value = findViewById(R.id.camera_lens_focal_mm_value);
+        camera_focal_mm_value.setText(camera_focal_mm + " mm");
+
+        int camera_native_resolution_w = intent.getIntExtra("camera_native_w", 0);
+        int camera_native_resolution_h = intent.getIntExtra("camera_native_h", 0);
+        TextView camera_native_resolution_value = findViewById(R.id.camera_native_resolution_value);
+        camera_native_resolution_value.setText(camera_native_resolution_w + " X " + camera_native_resolution_h);
+
+        float camera_hfov = intent.getFloatExtra("camera_hfov", 0);
+        float camera_wfov = intent.getFloatExtra("camera_wfov", 0);
+        TextView camera_fov_value = findViewById(R.id.camera_fov_value);
+        camera_fov_value.setText(camera_hfov + "° (hfov) " + camera_wfov + "° (vfov)");
+
+        double camera_sensor_w = intent.getDoubleExtra("camera_sensor_w", 0);
+        double camera_sensor_h = intent.getDoubleExtra("camera_sensor_h", 0);
+        TextView camera_sensor_size_value = findViewById(R.id.camera_sensor_size_value);
+        camera_sensor_size_value.setText(String.format("%.3f", camera_sensor_w) + " mm X " + String.format("%.3f", camera_sensor_h) + " mm");
+
+        int image_w = intent.getIntExtra("image_w", 0);
+        int image_h = intent.getIntExtra("image_h", 0);
+        TextView image_resolution_value = findViewById(R.id.image_resolution_value);
+        image_resolution_value.setText(image_w + " X " + image_h);
+
+        EditText cameraFocalInput = findViewById(R.id.cameraFocalInput);
+        double focalLength = intent.getDoubleExtra("focal", 0);
+        cameraFocalInput.setText(String.valueOf(focalLength));
+
+        EditText tagSizeInput = findViewById(R.id.tagSizeInput);
+        double tagSize = intent.getDoubleExtra("tag_size", 0);
+        tagSizeInput.setText(String.valueOf(tagSize));
+
+        CheckBox displayFrameInput = findViewById(R.id.displayMarkerFrame);
+        boolean display_frame = intent.getBooleanExtra("display_tag_frame", false);
+        displayFrameInput.setChecked(display_frame);
+
+        EditText frameSizeRatioInput = findViewById(R.id.markerFrameSizeRatio);
+        double frame_size_ratio = intent.getDoubleExtra("display_tag_frame_ratio", 0.5);
+        frameSizeRatioInput.setText(String.valueOf(frame_size_ratio));
+
+        // AprilTag
+
+        // selection position
+        int apriltag_selection = intent.getIntExtra("aprilTag_selection_position", 0);
+
+        // quad_decimate
+        Spinner quad_decimate_spinner = findViewById(R.id.aprilTagQuadDecimate);
+        Integer[] quad_decimate_options = {1, 2, 3, 4, 6, 8};
+        ArrayAdapter<Integer> quad_decimate_adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, quad_decimate_options);
+        quad_decimate_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        quad_decimate_spinner.setAdapter(quad_decimate_adapter);
+        Map<Integer, Integer> quad_decimate_options_map = Map.of(
+                1, 0,
+                2, 1,
+                3, 2,
+                4, 3,
+                6, 4,
+                8, 5
+        );
+        quad_decimate_spinner.setSelection(quad_decimate_options_map.get(intent.getIntExtra("aprilTag_quad_decimate", 1)));
+
+        // decision_margin
+        SeekBar decision_margin_seekBar = findViewById(R.id.aprilTagDecisionMargin);
+        TextView decision_margin_value = findViewById(R.id.aprilTagDecisionMarginValue);
+        decision_margin_seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                decision_margin_value.setText(String.valueOf(progress));
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+                Toast.makeText(SettingsPanelActivity.this, "Margin value: " + decision_margin_seekBar.getProgress(), Toast.LENGTH_SHORT).show();
+            }
+        });
+        decision_margin_seekBar.setProgress(intent.getIntExtra("aprilTag_decision_margin", 50));
+
+
+        // nb threads
+        Spinner nb_threads_spinner = findViewById(R.id.aprilTagNbThreads);
+        Integer[] nb_threads_options = {1, 2, 3, 4};
+        ArrayAdapter<Integer> nb_threads_adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, nb_threads_options);
+        nb_threads_adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        nb_threads_spinner.setAdapter(nb_threads_adapter);
+        nb_threads_spinner.setSelection(intent.getIntExtra("aprilTag_nb_threads", 1) - 1);
+
+        Button validate = findViewById(R.id.btnValidateSettings);
+        validate.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                String cameraFocalInput_str = cameraFocalInput.getText().toString();
+                String tagSizeInput_str = tagSizeInput.getText().toString();
+                String tagFrameRatioInput_str = frameSizeRatioInput.getText().toString();
+                String aprilTagSelectionPosition_str = String.valueOf(apriltag_selection);
+                String aprilTagQuadDecimate_str = quad_decimate_spinner.getSelectedItem().toString();
+                String aprilTagMargin_str = String.valueOf(decision_margin_seekBar.getProgress());
+                String aprilTagNbThreads_str = nb_threads_spinner.getSelectedItem().toString();
+
+                Intent resultIntent = new Intent();
+                resultIntent.putExtra("cameraFlashChecked", String.valueOf(cameraFlashInput.isChecked()));
+                resultIntent.putExtra("cameraFocalValue", cameraFocalInput_str);
+                resultIntent.putExtra("tagSizeValue", tagSizeInput_str);
+                resultIntent.putExtra("displayFrameChecked", String.valueOf(displayFrameInput.isChecked()));
+                resultIntent.putExtra("tagFrameRatio", tagFrameRatioInput_str);
+                resultIntent.putExtra("aprilTagSelectionPosition", aprilTagSelectionPosition_str);
+                resultIntent.putExtra("aprilTagQuadDecimate", aprilTagQuadDecimate_str);
+                resultIntent.putExtra("aprilTagDecisionMargin", aprilTagMargin_str);
+                resultIntent.putExtra("aprilTagNbThreads", aprilTagNbThreads_str);
+                setResult(RESULT_OK, resultIntent);
+
+                finish();
+            }
+        });
+    }
+}

--- a/samples/android/app/src/main/res/layout/activity_camera_preview.xml
+++ b/samples/android/app/src/main/res/layout/activity_camera_preview.xml
@@ -4,15 +4,49 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    tools:context="example.vispapriltag.CameraPreviewActivity">
+    tools:context="com.example.apriltagdetection.CameraPreviewActivity">
 
     <FrameLayout
         android:id="@+id/camera_preview"
         android:layout_width="match_parent"
         android:layout_weight="0.1"
-        android:layout_height="fill_parent" />
-        
-   <TextView
+        android:layout_height="fill_parent">
+
+        <com.example.apriltagdetection.DisplaySurfaceView
+            android:id="@+id/surfaceView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <!-- Settings Button -->
+        <Button
+            android:id="@+id/btnSettings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/camera_preview_settings" />
+
+        <!-- Autofocus Button -->
+        <Button
+            android:id="@+id/btnAutoFocus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/camera_preview_auto_focus" />
+
+        <!-- Spinner (ComboBox) -->
+        <Spinner
+            android:id="@+id/spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+    <TextView
         android:id="@+id/resultTV"
         android:layout_width="wrap_content"
         android:layout_weight="0.9"

--- a/samples/android/app/src/main/res/layout/activity_settings.xml
+++ b/samples/android/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,406 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center">
+
+    <!-- Top spacer -->
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="0.25" />
+
+    <!-- Camera sensor characteristics -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <!-- Focal length mm -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_lens_focal_mm"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+            <TextView
+                android:id="@+id/camera_lens_focal_mm_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+        </LinearLayout>
+
+        <!-- Native resolution -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_native_resolution"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+            <TextView
+                android:id="@+id/camera_native_resolution_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+        </LinearLayout>
+
+        <!-- Camera fov -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_fov"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+            <TextView
+                android:id="@+id/camera_fov_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+        </LinearLayout>
+
+        <!-- Camera sensor size -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_sensor_size"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+            <TextView
+                android:id="@+id/camera_sensor_size_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+        </LinearLayout>
+
+        <!-- Processed image resolution -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/image_resolution"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+            <TextView
+                android:id="@+id/image_resolution_value"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:textSize="16sp"/>
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="0.25" />
+
+    <!-- Camera flash -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="start">
+
+        <CheckBox android:id="@+id/cameraFlash"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/camera_flash" />
+
+    </LinearLayout>
+
+    <!-- Camera focal length -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/camera_focal"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/cameraFocalInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:inputType="phone"
+            android:text="@string/camera_focal_default"
+            android:maxLines="1"
+            android:padding="10dp" />
+
+    </LinearLayout>
+
+    <!-- Tag size -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/tag_size"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/tagSizeInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:inputType="phone"
+            android:text="@string/tag_size_default"
+            android:maxLines="1"
+            android:padding="10dp" />
+
+    </LinearLayout>
+
+    <!-- Display the marker frame -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="start">
+
+        <CheckBox android:id="@+id/displayMarkerFrame"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/display_frame_text" />
+
+    </LinearLayout>
+
+    <!-- Marker frame size -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/frame_size_ratio"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="16sp" />
+
+        <EditText
+            android:id="@+id/markerFrameSizeRatio"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:inputType="phone"
+            android:text="@string/frame_size_ratio_default"
+            android:maxLines="1"
+            android:padding="10dp" />
+
+    </LinearLayout>
+
+    <!-- Spacer between Camera input and AprilTag -->
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="0.25" />
+
+    <!-- AprilTag -->
+    <!-- quad_decimate -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/apriltag_quad_decimate"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="16sp" />
+
+        <Spinner
+            android:id="@+id/aprilTagQuadDecimate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+    <!-- decision_margin_threshold -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/apriltag_decision_margin"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="16sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <SeekBar
+                android:id="@+id/aprilTagDecisionMargin"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:max="255"
+                android:progress="50"  />
+
+            <!-- TextView to show the slider value -->
+            <TextView
+                android:id="@+id/aprilTagDecisionMarginValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/apriltag_decision_margin_default"
+                android:textSize="14sp"
+                android:layout_gravity="center" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+    <!-- nb threads -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/apriltag_nb_threads"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="16sp" />
+
+        <Spinner
+            android:id="@+id/aprilTagNbThreads"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+    <!-- Spacer between AprilTag input and credit text -->
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="0.25" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <TextView
+            android:id="@+id/originalCreditDesc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/original_credit_desc"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="14sp"
+            android:layout_marginBottom="8dp"/>
+
+        <TextView
+            android:id="@+id/apriltagDesc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/apriltag_desc"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="14sp"
+            android:layout_marginBottom="8dp"/>
+
+        <TextView
+            android:id="@+id/onlineMarkers"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/online_markers"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:textSize="14sp"
+            android:layout_marginBottom="10dp"/>
+
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/btnValidateSettings"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/button_validate" />
+
+</LinearLayout>

--- a/samples/android/app/src/main/res/values/strings.xml
+++ b/samples/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,42 @@
     <string name="app_created_by_akshay_sharma"><u>App Created by Akshay Sharma</u></string>
     <string name="tag_description">AprilTag is a visual fiducial system, useful for a wide variety of tasks including augmented reality, robotics, and camera calibration. This app computes the precise 3D position, orientation, and identity of the tags relative to the camera. \n\n The original AprilTag library is implemented in C with no external dependencies. This example uses an Android SDK which I developed as a part of my GSoC Project with focus on real-time performance </string>
     <string name="description2"><u>Link to my GSoC Project</u></string>
+
+    <!-- Camera preview panel -->
+    <string name="camera_preview_settings">Settings</string>
+    <string name="camera_preview_auto_focus">Auto Focus</string>
+
+    <!-- Settings panel -->
+    <string name="camera_flash">Turn on the camera flash?</string>
+    <!-- Sensor characteristics -->
+    <string name="camera_lens_focal_mm">Camera focal lens:</string>
+    <string name="camera_native_resolution">Camera native resolution:</string>
+    <string name="camera_fov">Camera fov:</string>
+    <string name="camera_sensor_size">Camera sensor size:</string>
+    <string name="image_resolution">Image resolution:</string>
+    <!-- Intrinsic parameters -->
+    <string name="camera_focal">Camera focal:</string>
+    <string name="camera_focal_default">600</string>
+    <!-- Tag -->
+    <string name="tag_size">Tag size (m):</string>
+    <string name="tag_size_default">0.1</string>
+    <!-- Frame size -->
+    <string name="display_frame_text">Display the marker frame?</string>
+    <string name="frame_size_ratio">Frame size ratio:</string>
+    <string name="frame_size_ratio_default">0.5</string>
+    <!-- AprilTag -->
+    <string name="apriltag_quad_decimate">AprilTag quad_decimate:</string>
+    <string name="apriltag_quad_decimate_default">2</string>
+    <string name="apriltag_decision_margin">AprilTag decision_margin:</string>
+    <string name="apriltag_decision_margin_default">50</string>
+    <string name="apriltag_nb_threads">AprilTag nb threads:</string>
+    <string name="apriltag_nb_threads_default">1</string>
+    <!-- Bottom -->
+    <string name="button_validate">Validate</string>
+    <string name="original_credit_desc">This app is derived from the works of Akshay Sharma produced during the <a href="https://summerofcode.withgoogle.com/archive/2018/projects/5711312218750976">GSoC 2018</a> project and <a href="https://visp.inria.fr">ViSP.</a></string>
+    <string name="apriltag_desc">The underlying detection method is based on the code from the <a href="https://github.com/AprilRobotics/apriltag">AprilTag 3</a> GitHub repository.</string>
+    <string name="online_markers">You can generate fiducial markers using the following <a href="https://chev.me/arucogen">online tool.</a></string>
+
+    https://github.com/AprilRobotics/apriltag
+
 </resources>


### PR DESCRIPTION
I had to update the `gen_dict.json` file to be able to use `detector.getTagsCorners();`, need to double check why it was needed:
- see the commit https://github.com/lagadic/visp/commit/e3afa2a50200f6aecd7395859f97a0660e2d435d
- corresponding issue: https://github.com/lagadic/visp/issues/1773
- why the fix is needed, the Java code seems to work before: https://github.com/lagadic/visp/blob/af3e8a3918dc60e932053c6b926c3ee0a77a31fe/tutorial/java/tag-detection/ApriltagDetection.java#L150-L160

---

Video captures:

- should be quad_decimate=2, nthreads=1 

https://github.com/user-attachments/assets/1380a254-abaf-4ed2-ac03-5fda6a4223e5

- should be quad_decimate=4, nthreads=4

https://github.com/user-attachments/assets/2bf01bd5-6cf5-4be0-a591-a8edb04adfff 

---

The settings panel:

<img width="320" src="https://github.com/user-attachments/assets/79f5963c-2dd6-4dcf-9968-960bf71de1da" />

- the camera intrinsic parameters are automatically computed from the hardware specs
- don't know what happens if these info are not available, if the app crashes
- with autofocus, the computed focal length can be slightly off

---

The issues are:
- flickering display / drawing of the primitives, most likely a separated thread for drawing is needed
- the app will crash after a certain amount of time
- some possible memory leak
- some code come from ChatGPT, so not sure if it is the correct approach wrt. the Android environment
- the state machines process behind is not totally handled correctly for the camera:
  - corresponding error: "java.lang.RuntimeException: Camera is being used after Camera.release() was called"
  - same when resuming the app, etc.
- handling of the landscape mode: the image is distorted
- the current code uses the obsolete Camera API (instead of Camera2)
- ...

---

App logo after tweaking the results from ChatGPT:

|   |  |
| -------- | ------- |
| <img width="256" src="https://github.com/user-attachments/assets/6b9e5c0d-3378-48e3-9462-9f80dfe8e0b5" /> |  <img width="256" src="https://github.com/user-attachments/assets/847a9c23-fcf2-4179-985d-80bcca3c41f7" /> |

