### PR TITLE
Add workflow for staled issues

### DIFF
--- a/.github/workflows/stale-github-issues.yml
+++ b/.github/workflows/stale-github-issues.yml
@@ -1,0 +1,23 @@
+name: Stale inactive issues
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 6:00 AM UTC (8:00 AM CET)
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 30
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As discussed in our last dev meeting, this workflow will stale issues according to the following policy:
- Mark as "staled" and comment any issue that had no activity for 30 days
- Comment and close any issue that had no activity for 30 days since it has been marked as "staled"

This GH action has also features for PRs, but they are not enabled yet.