### PR TITLE
Bump macos CI from macos-13 to macos-14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-14, macos-latest]
 
     steps:
     - name: Checkout repository
@@ -38,7 +38,9 @@ jobs:
       run: |
         brew install libpng libjpeg-turbo libdc1394 opencv pcl librealsense zbar pkg-config nlohmann-json
 
-    - name: Install dependencies on macos-13
+    - name: Install dependencies on macos-14
+      # XXX Testing this on macos-14
+      # ----------------
       # On macos-13 we need to do a specific action
       # ==> Pouring python@3.12--3.12.1_1.ventura.bottle.tar.gz
       # Error: The `brew link` step did not complete successfully
@@ -52,7 +54,9 @@ jobs:
       #   brew link --overwrite python@3.12
       #
       # Fix proposed in https://github.com/actions/runner-images/issues/6817
-      if: matrix.os == 'macos-13'
+      # ----------------
+      # TODO Might be merged with macos-latest deps installation if succeed
+      if: matrix.os == 'macos-14'
       run: |
         brew update
         brew upgrade || true


### PR DESCRIPTION
As discussed in dev meeting, macos-13 will be soon be removed from GH actions ( https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ ).
Our macos CI based on macos-13 is failing since few days. However, this may not be related to macos-13 runners to be removed from Github as jobs should start falling from 4th November.
Also, let's try to run the CI on macos-14 if it solves the problem as the error message on macos-13 CI was quite explicit:
```
Error: You are using macOS 13.
We (and Apple) do not provide support for this old version.
```