### PR TITLE
Remove appveyor CI uwp target

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   matrix:
     - TARGET: mingw
     # - TARGET: msvc
-    - TARGET: uwp
+    #- TARGET: uwp
     - TARGET: visp_sample
 
 # Scripts that are called at very beginning, before repo cloning


### PR DESCRIPTION
It seems that UWP is no more supported:
```
md C:\projects\visp\build
cd C:\projects\visp\build
if "%TARGET%"=="mingw" cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=%configuration% ..\visp if "%TARGET%"=="mingw" cmake --build . --config %configuration% --target install -- -j2 if "%TARGET%"=="mingw" dir C:\projects\visp\build\install if "%TARGET%"=="mingw" dir %VISP_DLL_DIR%
if "%TARGET%"=="mingw" ctest --output-on-failure -j2 if "%TARGET%"=="msvc" cmake -G "Visual Studio 17 2022" -A %platform% ..\visp if "%TARGET%"=="msvc" cmake --build . --config %configuration% --target install -- /m:2 if "%TARGET%"=="msvc" dir C:\projects\visp\build\install if "%TARGET%"=="msvc" dir %VISP_DLL_DIR%
if "%TARGET%"=="msvc" ctest --output-on-failure -j2 if "%TARGET%"=="uwp" cmake -G "Visual Studio 17 2022" -A %platform% -DCMAKE_SYSTEM_NAME="WindowsStore" -DCMAKE_SYSTEM_VERSION="10.0" -DBUILD_DEMOS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_TUTORIALS=OFF ..\visp CMake Error at CMakeLists.txt:128 (project):
  A Windows Store component with CMake requires both the Windows Desktop SDK
  as well as the Windows Store '10.0' SDK.  Please make sure that you have
  both installed
-- Configuring incomplete, errors occurred!
Command exited with code 1
```