### PR TITLE
Python stubs mypy

### DIFF
--- a/modules/python/bindings/setup.py.in
+++ b/modules/python/bindings/setup.py.in
@@ -62,7 +62,7 @@ else:
 base_path = Path(__file__).parent.absolute()
 
 
-packages = ['', 'visp', 'visp.apps']
+packages = ['visp', 'visp.apps', 'visp.python']
 
 
 apps_folder = base_path / package_name / 'apps'

--- a/modules/python/config/sensor.json
+++ b/modules/python/config/sensor.json
@@ -1,5 +1,7 @@
 {
-  "ignored_headers": ["vpForceTorqueAtiNetFTSensor.h"],
+  "ignored_headers": [
+    "vpForceTorqueAtiNetFTSensor.h"
+  ],
   "classes": {
     "vp1394TwoGrabber": {
       "methods": [

--- a/modules/python/generator/visp_python_bindgen/enum_binding.py
+++ b/modules/python/generator/visp_python_bindgen/enum_binding.py
@@ -196,6 +196,10 @@ def get_enum_bindings(root_scope: NamespaceScope, mapping: Dict, submodule: Subm
   for enum_repr in final_reprs:
     name_segments = enum_repr.name.split('::')
     py_name = name_segments[-1].replace('vp', '')
+    # A name cannot start with a digit
+    # But we strip vp prefix from enum names, so we readd if required
+    if py_name[0].isdigit():
+      py_name = f'vp{py_name}'
     # If an owner class is ignored, don't export this enum
     parent_ignored = False
     ignored_parent_name = None

--- a/modules/python/generator/visp_python_bindgen/header.py
+++ b/modules/python/generator/visp_python_bindgen/header.py
@@ -256,9 +256,15 @@ class HeaderFile():
       '''
       Generate the bindings of a single class, handling a potential template specialization.
       '''
+
       python_ident = f'py{name_python}' if owner == 'submodule' else f'py{owner}{name_python}'
       name_cpp = get_typename(cls.class_decl.typename, owner_specs, header_env.mapping)
       class_doc = None
+
+      # A name cannot start with a digit
+      # But we strip vp prefix from class names, so we readd if required
+      if name_python[0].isdigit():
+        name_python = f'vp{name_python}'
 
       methods_dict: Dict[str, List[MethodBinding]] = {}
       def add_to_method_dict(key: str, value: MethodBinding):

--- a/modules/python/stubs/CMakeLists.txt
+++ b/modules/python/stubs/CMakeLists.txt
@@ -39,9 +39,9 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py.in" "${CMAKE_CURRENT_BINARY
 
 add_custom_target( visp_python_bindings_stubs
   COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/visp-stubs"
-  COMMAND ${PYTHON3_EXECUTABLE} -m pip install  ${_pip_args} pybind11-stubgen
-  COMMAND ${PYTHON3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_stub_generator.py --output-root ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND ${PYTHON3_EXECUTABLE} -m pip install  ${_pip_args} mypy
+  COMMAND ${PYTHON3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_stub_generator.py --output-root ${CMAKE_CURRENT_BINARY_DIR}/gen
   COMMAND ${PYTHON3_EXECUTABLE} -m pip install  ${_pip_args} "${CMAKE_CURRENT_BINARY_DIR}"
-  COMMENT "Generating Python stubs with pybind11-stubgen..."
+  COMMENT "Generating Python stubs..."
   DEPENDS visp_python_bindings_install
 )

--- a/modules/python/stubs/setup.py.in
+++ b/modules/python/stubs/setup.py.in
@@ -36,17 +36,31 @@
 from pathlib import Path
 from setuptools import setup
 
+package_data_list = []
+def package_data(module: Path, l):
+  for submodule_path in module.iterdir():
+    if submodule_path.name.endswith('.pyi'):
+      l.append(str(submodule_path.absolute()))
+    elif submodule_path.is_dir():
+      package_data(submodule_path, l)
+    else:
+      print(f'Found file {submodule_path} but it will not be added to package data!')
+
+base_path = Path(__file__).parent.absolute() / 'visp'
+
+package_data(base_path, package_data_list)
+
 setup(
   name='visp-stubs',
   version='@VISP_PYTHON_VERSION@',
-  packages=['visp-stubs'],
+  packages=['visp'],
   author="Samuel Felton",
   author_email="samuel.felton@irisa.fr",
   description="Python stubs for the ViSP wrapper",
   zip_safe=False,
   #include_package_data=True,
   package_data = {
-    'visp-stubs': ['*.pyi']
+    'visp': package_data_list
   },
   python_requires=">=3.7",
 )


### PR DESCRIPTION
This PR improves the stub generation process:

* [x] import visp.core is now correctly resolves by IDEs
* [x] Replaced pybind11_stubgen by mypy, which is a larger scale typing project. This allows to generate stubs for Python source files and should also be better supported.
* [ ] Implement build isolation, so that mypy is not installed in the user's environment.