### PR TITLE
Display memcheck results in valgrind Github workflow.

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -52,4 +52,6 @@ jobs:
 
     - name: Run unit tests with Valgrind
       working-directory: build
-      run: ctest -j$(nproc) -T memcheck
+      run: |
+        ctest -j$(nproc) --output-on-failure -T memcheck
+        tail -v -n +1 Testing/Temporary/MemoryChecker*.log


### PR DESCRIPTION
Example https://github.com/lagadic/visp/actions/runs/18655109672/job/53182177710 gives:

```txt
304/308 MemCheck: #304: templateTrackerPyramidal-MIInverseCompositional-Translation .......   Defects: 282
305/308 MemCheck: #305: templateTrackerPyramidal-MIInverseCompositional-RT ................   Defects: 282
306/308 MemCheck: #306: videoReader .......................................................   Defects: 292
307/308 MemCheck: #308: wireframeSimulator ................................................   Defects: 263
308/308 MemCheck: #307: imageSequenceReader ...............................................   Defects: 4140
MemCheck log files can be found here: (<#> corresponds to test number)
/home/runner/work/visp/visp/build/Testing/Temporary/MemoryChecker.<#>.log
Memory checking results:
Potential Memory Leak - 146315
Uninitialized Memory Conditional - 273
Uninitialized Memory Read - 6
```

This PR should display the full log files.