### PR TITLE
SKIP-CI ALL ENABLE-CI UBUNTU-DEP-SRC

### DIFF
--- a/.github/workflows/ubuntu-dep-src.yml
+++ b/.github/workflows/ubuntu-dep-src.yml
@@ -193,8 +193,10 @@ jobs:
 
     - name: Build libfranka from source
       # Since libfranka version 0.14.0 or later, you will need to install pinocchio and some more dependencies
+      # libfranka 0.18.1 doesn't build on ubuntu-22.04 (see issue https://github.com/frankarobotics/libfranka/issues/215)
       env:
         LD_LIBRARY_PATH: /opt/openrobots/lib
+      if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get install -y lsb-release curl
         sudo mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
Disable the build from source of libfranka 0.18.1 on ubuntu 22.04 
There is a build issue around tinyxml2 cmake detection 
See https://github.com/frankarobotics/libfranka/issues/215