### PR TITLE
Slight improvement of visp-read-rs-dataset

### DIFF
--- a/apps/rs-dataset/visp-read-rs-dataset.cpp
+++ b/apps/rs-dataset/visp-read-rs-dataset.cpp
@@ -295,7 +295,11 @@ bool readData(int cpt, const std::string &input_folder, const std::string &input
 #endif
 
   if (!vpIoTools::checkFilename(filename_color) && !vpIoTools::checkFilename(filename_depth) &&
-      !vpIoTools::checkFilename(filename_infra)) {
+      !vpIoTools::checkFilename(filename_infra)
+#if defined(VISP_HAVE_PCL) && defined(VISP_HAVE_PCL_COMMON)
+    && !vpIoTools::checkFilename(filename_pcl)
+#endif
+    ) {
     std::cerr << "End of sequence." << std::endl;
     return false;
   }


### PR DESCRIPTION
[CORE] ALlow visp-read-rs-dataset to have a sequence of .pcd files only