### PR TITLE
Fix mbt L null row size consideration

### DIFF
--- a/modules/tracker/mbt/src/vpMbGenericTracker.cpp
+++ b/modules/tracker/mbt/src/vpMbGenericTracker.cpp
@@ -490,7 +490,6 @@ void vpMbGenericTracker::computeVVS(std::map<std::string, const vpImage<unsigned
         tracker->ctTc0 = c_curr_tTc_curr0;
       }
 #endif
-
       // Update cMo
       for (std::map<std::string, TrackerWrapper *>::const_iterator it = m_mapOfTrackers.begin();
         it != m_mapOfTrackers.end(); ++it) {
@@ -585,10 +584,12 @@ void vpMbGenericTracker::computeVVSInteractionMatrixAndResidu(
 
     tracker->computeVVSInteractionMatrixAndResidu(mapOfImages[it->first]);
 
-    m_L.insert(tracker->m_L * mapOfVelocityTwist[it->first], start_index, 0);
-    m_error.insert(start_index, tracker->m_error);
+    if (tracker->m_L.getRows() > 0) {
+      m_L.insert(tracker->m_L * mapOfVelocityTwist[it->first], start_index, 0);
+      m_error.insert(start_index, tracker->m_error);
 
-    start_index += tracker->m_error.getRows();
+      start_index += tracker->m_error.getRows();
+    }
   }
 }
 
@@ -7306,8 +7307,8 @@ void vpMbGenericTracker::TrackerWrapper::setPose(const vpImage<unsigned char> *c
         downScale(i);
         vpMbEdgeTracker::initMovingEdge(*Ipyramid[i], cMo);
         upScale(i);
-  }
-} while (i != 0);
+      }
+    } while (i != 0);
 
     cleanPyramid(Ipyramid);
   }


### PR DESCRIPTION
Avoid stacking L matrix when the number of features is 0 
Allows to fix the following issue for example occuring in `testGenericTracker.cpp` when GSL is used.

Occurs on the followings ci machines: Fedora 25 with GSL 2.1 and centos 7.2 with GSL 1.15
```
./testGenericTracker
trackerType_image: 1
useScanline: 0
use_depth: 0
use_mask: 0
use_color_image: 0
Load config file for camera 1: /builds/visp-ws/visp-images/mbt-depth/Castle-simu/Config/chateau.xml Load config file for camera 2: /builds/visp-ws/visp-images/mbt-depth/Castle-simu/Config/chateau_depth.xml
 *********** Parsing XML for ME projection error ************
projection_error : sample_step : 10 (default)
projection_error : kernel_size : 5x5 (default)
 *********** Parsing XML for Edge Model-Based Tracker ************
me : mask : size : 5
me : mask : nb_mask : 180
me : range : tracking : 8
me : range : init range : 0 (default)
me : sample : sample_step : 5
me : contrast : threshold type 1
me : contrast : threshold 5
me : contrast : min threshold -1 (default)
me : contrast : threshold margin ratio -1 (default) me : contrast : mu1 0.5
me : contrast : mu2 0.5
camera : u0 : 320
camera : v0 : 240
camera : px : 700
camera : py : 700
face : Angle Appear : 85
face : Angle Disappear : 89
face : Near Clipping : 0.01
face : Far Clipping : 2
face : Fov Clipping : True
lod : use lod : 0 (default)
lod : min line length threshold : 50 (default)
lod : min polygon area threshold : 2500 (default)
 *********** Parsing XML for ME projection error ************
projection_error : sample_step : 10 (default)
projection_error : kernel_size : 5x5 (default)
 *********** Parsing XML for Depth Dense Model-Based Tracker ************
depth dense : sampling_step : step_X : 4
depth dense : sampling_step : step_Y : 4
camera : u0 : 320
camera : v0 : 240
camera : px : 700
camera : py : 700
face : Angle Appear : 85
face : Angle Disappear : 89
face : Near Clipping : 0.01
face : Far Clipping : 2
face : Fov Clipping : True
lod : use lod : 0 (default)
lod : min line length threshold : 50 (default)
lod : min polygon area threshold : 2500 (default)
> 14 points
> 0 lines
> 0 polygon lines
> 5 polygon points
> 0 cylinders
> 0 circles
> 14 points
> 0 lines
> 0 polygon lines
> 5 polygon points
> 0 cylinders
> 0 circles
> 10 points
> 0 lines
> 0 polygon lines
> 4 polygon points
> 0 cylinders
> 10 points
> 0 lines
> 0 polygon lines
> 4 polygon points
> 0 cylinders
gsl: view_source.c:63: ERROR: matrix dimension n1 must be positive integer Default GSL error handler invoked.
```