### PR TITLE
Fix tutorial-panda3d-renderer

### DIFF
--- a/modules/ar/src/panda3d-simulator/vpPanda3DGeometryRenderer.cpp
+++ b/modules/ar/src/panda3d-simulator/vpPanda3DGeometryRenderer.cpp
@@ -214,7 +214,7 @@ void vpPanda3DGeometryRenderer::getRender(vpImage<vpRGBf> &normals, vpImage<floa
   }
 
   int rowIncrement = normals.getWidth() * 4;
-  // rowIncrement = -rowIncrement;
+
   if (!m_fast) {
     using T = float;
     T *data = (T *)(&(m_normalDepthTexture->get_ram_image().front()));


### PR DESCRIPTION
Fixed a segfault that appeared when using vpPanda3DGeometryRenderer::getRender