### PR TITLE
Add missing cmath header for std::pow

### DIFF
--- a/modules/tracker/rbt/src/core/vpTemporalWeighting.cpp
+++ b/modules/tracker/rbt/src/core/vpTemporalWeighting.cpp
@@ -1,5 +1,7 @@
 #include <visp3/rbt/vpTemporalWeighting.h>
 
+#include <cmath>
+
 #if defined(VISP_HAVE_NLOHMANN_JSON)
 #include VISP_NLOHMANN_JSON(json.hpp)
 #endif


### PR DESCRIPTION
Build fails only on building new conda-package.