### PR TITLE
Fix skip python detection cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ else()
 endif()
 
 # --- Python Support ---
-if(NOT IOS)
+if(NOT IOS AND NOT VISP_PYTHON_SKIP_DETECTION)
   # Make sure to refresh the python interpreter every time we rerun cmake
   # If we don't do this, we may use an old or invalid python when installing the bindings
   # that was cached by a previous attempt at building


### PR DESCRIPTION
`VISP_PYTHON_SKIP_DETECTION` CMake option was only checked in `VISPDetectPython.cmake`, which is only include when CMake version is less than 3.15.0. So for any CMake >= 3.15.0, the option was discarded.
This option is necessary for the new release of ViSP Conda package which will split C++ part from Python bindings.