### PR TITLE
Add missing header to RBTFeatureTracker

### DIFF
--- a/modules/tracker/rbt/include/visp3/rbt/vpRBFeatureTracker.h
+++ b/modules/tracker/rbt/include/visp3/rbt/vpRBFeatureTracker.h
@@ -35,6 +35,8 @@
 #ifndef VP_RB_FEATURE_TRACKER_H
 #define VP_RB_FEATURE_TRACKER_H
 
+#include <array>
+
 #include <visp3/core/vpConfig.h>
 #include <visp3/core/vpMatrix.h>
 #include <visp3/core/vpColVector.h>


### PR DESCRIPTION
Fix missing std array header in RBTFeatureTracker.h.
Build fails on conda package build.