### PR TITLE
Fix warning [-Wmaybe-uninitialized] in catchJsonArgumentParser.cpp

### DIFF
--- a/modules/io/test/catchJsonArgumentParser.cpp
+++ b/modules/io/test/catchJsonArgumentParser.cpp
@@ -157,7 +157,7 @@ SCENARIO("Parsing arguments from JSON file", "[json]")
       THEN("Calling the parser with only the JSON file works")
       {
         const int argc = 3;
-        bool ret;
+        bool ret = false;
         const char *argv[] = {
           "program",
           "--config",
@@ -361,7 +361,7 @@ SCENARIO("Parsing arguments from JSON file", "[json]")
       }
       THEN("Calling the parser with --help argument works")
       {
-        bool ret;
+        bool ret = true;
         const int argc = 2;
         const char *argv[] = {
           "ProgramString",
@@ -373,7 +373,7 @@ SCENARIO("Parsing arguments from JSON file", "[json]")
       }
       THEN("Calling the parser with -h argument works")
       {
-        bool ret;
+        bool ret = true;
         const int argc = 2;
         const char *argv[] = {
           "ProgramString",


### PR DESCRIPTION
With `gcc 13.3.0`:

```bash
In file included from <>/visp/modules/io/test/catchJsonArgumentParser.cpp:47: In constructor ‘constexpr Catch::BinaryExpr<LhsT, RhsT>::BinaryExpr(bool, LhsT, Catch::StringRef, RhsT) [with LhsT = bool; RhsT = bool]’,
    inlined from ‘constexpr std::enable_if_t<std::conjunction<Catch::Detail::is_eq_comparable<LhsT, RhsT, void>, Catch::capture_by_value<RhsT> >::value, Catch::BinaryExpr<LhsT, RhsT> > Catch::operator==(ExprLhs<LhsT>&&, RhsT) [with RhsT = bool; LhsT = bool]’ at <>/visp/3rdparty/catch2/catch_amalgamated.hpp:5471:9,
    inlined from ‘void CATCH2_INTERNAL_TEST_0()’ at <>/visp/modules/io/test/catchJsonArgumentParser.cpp:167:9:
<>/visp/3rdparty/catch2/catch_amalgamated.hpp:5339:13: warning: ‘ret’ may be used uninitialized [-Wmaybe-uninitialized]
 5339 |             m_lhs( lhs ),
      |             ^~~~~~~~~~~~
<>/visp/modules/io/test/catchJsonArgumentParser.cpp: In function ‘void CATCH2_INTERNAL_TEST_0()’:
<>/visp/modules/io/test/catchJsonArgumentParser.cpp:160:14: note: ‘ret’ was declared here
  160 |         bool ret;
      |              ^~~
In constructor ‘constexpr Catch::BinaryExpr<LhsT, RhsT>::BinaryExpr(bool, LhsT, Catch::StringRef, RhsT) [with LhsT = bool; RhsT = bool]’,
    inlined from ‘constexpr std::enable_if_t<std::conjunction<Catch::Detail::is_eq_comparable<LhsT, RhsT, void>, Catch::capture_by_value<RhsT> >::value, Catch::BinaryExpr<LhsT, RhsT> > Catch::operator==(ExprLhs<LhsT>&&, RhsT) [with RhsT = bool; LhsT = bool]’ at <>/visp/3rdparty/catch2/catch_amalgamated.hpp:5471:9,
    inlined from ‘void CATCH2_INTERNAL_TEST_0()’ at <>/visp/modules/io/test/catchJsonArgumentParser.cpp:372:9:
<>/visp/3rdparty/catch2/catch_amalgamated.hpp:5339:13: warning: ‘ret’ may be used uninitialized [-Wmaybe-uninitialized]
 5339 |             m_lhs( lhs ),
      |             ^~~~~~~~~~~~
<>/visp/modules/io/test/catchJsonArgumentParser.cpp: In function ‘void CATCH2_INTERNAL_TEST_0()’:
<>/visp/modules/io/test/catchJsonArgumentParser.cpp:364:14: note: ‘ret’ was declared here
  364 |         bool ret;
      |              ^~~
In constructor ‘constexpr Catch::BinaryExpr<LhsT, RhsT>::BinaryExpr(bool, LhsT, Catch::StringRef, RhsT) [with LhsT = bool; RhsT = bool]’,
    inlined from ‘constexpr std::enable_if_t<std::conjunction<Catch::Detail::is_eq_comparable<LhsT, RhsT, void>, Catch::capture_by_value<RhsT> >::value, Catch::BinaryExpr<LhsT, RhsT> > Catch::operator==(ExprLhs<LhsT>&&, RhsT) [with RhsT = bool; LhsT = bool]’ at <>/visp/3rdparty/catch2/catch_amalgamated.hpp:5471:9,
    inlined from ‘void CATCH2_INTERNAL_TEST_0()’ at <>/visp/modules/io/test/catchJsonArgumentParser.cpp:384:9:
<>/visp/3rdparty/catch2/catch_amalgamated.hpp:5339:13: warning: ‘ret’ may be used uninitialized [-Wmaybe-uninitialized]
 5339 |             m_lhs( lhs ),
      |             ^~~~~~~~~~~~
<>/visp/modules/io/test/catchJsonArgumentParser.cpp: In function ‘void CATCH2_INTERNAL_TEST_0()’:
<>/visp/modules/io/test/catchJsonArgumentParser.cpp:376:14: note: ‘ret’ was declared here
  376 |         bool ret;
      |              ^~~
```