### PR TITLE
Experimentation to try to improve the Dementhon planar pose estimation

### DIFF
--- a/modules/detection/src/tag/vpDetectorAprilTag.cpp
+++ b/modules/detection/src/tag/vpDetectorAprilTag.cpp
@@ -79,6 +79,7 @@ extern "C" {
 #include <visp3/core/vpDisplay.h>
 #include <visp3/core/vpIoTools.h>
 #include <visp3/core/vpPixelMeterConversion.h>
+#include <visp3/core/vpMeterPixelConversion.h>
 #include <visp3/core/vpPoint.h>
 #include <visp3/detection/vpDetectorAprilTag.h>
 #include <visp3/vision/vpPose.h>
@@ -1013,6 +1014,23 @@ public:
     }
 
 #if defined(VISP_HAVE_APRILTAG_POSE_FCT)
+    apriltag_detection_t *det_copy = NULL;
+    if ((m_poseEstimationMethod == HOMOGRAPHY) ||
+        (m_poseEstimationMethod == HOMOGRAPHY_VIRTUAL_VS) ||
+        (m_poseEstimationMethod == HOMOGRAPHY_ORTHOGONAL_ITERATION) ||
+        (m_poseEstimationMethod == BEST_RESIDUAL_VIRTUAL_VS)) {
+      det_copy = (apriltag_detection_t *)calloc(1, sizeof(apriltag_detection_t));
+      apriltag_detection_copy(det, det_copy);
+
+      if (cam.get_projModel() != vpCameraParameters::perspectiveProjWithoutDistortion) {
+        for (int cpt = 0; cpt < 4; cpt++) {
+          double x, y;
+          vpPixelMeterConversion::convertPoint(cam, det_copy->p[cpt][0], det_copy->p[cpt][1], x, y);
+          vpMeterPixelConversion::convertPoint(cam, x, y, det_copy->p[cpt][0], det_copy->p[cpt][1]);
+        }
+      }
+    }
+
     // In AprilTag3, estimate_pose_for_tag_homography() and estimate_tag_pose() have been added.
     // They use a tag frame aligned with the camera frame
     // Before the release of AprilTag3, convention used was to define the z-axis of the tag going upward.
@@ -1025,7 +1043,7 @@ public:
       double cx = cam.get_u0(), cy = cam.get_v0();
 
       apriltag_detection_info_t info;
-      info.det = det;
+      info.det = det_copy;
       info.tagsize = tagSize;
       info.fx = fx;
       info.fy = fy;
@@ -1044,7 +1062,7 @@ public:
       double cx = cam.get_u0(), cy = cam.get_v0();
 
       apriltag_detection_info_t info;
-      info.det = det;
+      info.det = det_copy;
       info.tagsize = tagSize;
       info.fx = fx;
       info.fy = fy;
@@ -1062,6 +1080,7 @@ public:
 
       cMo_homography = cMo;
     }
+    apriltag_detection_destroy(det_copy);
 #endif
 
     // Add marker object points
@@ -1613,7 +1632,7 @@ vpDetectorAprilTag::vpPoseEstimationMethod vpDetectorAprilTag::poseMethodFromStr
     throw(vpException(vpException::badValue, "Could not find a pose estimation method that corresponds to the name '%s'", name.c_str()));
   }
   return res;
-  }
+}
 
 std::string vpDetectorAprilTag::getAvailablePoseMethod(const std::string &prefix, const std::string &sep, const std::string &suffix)
 {
@@ -1633,7 +1652,7 @@ std::string vpDetectorAprilTag::getAvailablePoseMethod(const std::string &prefix
 #endif
   modes += poseMethodToString(candidate) + suffix;
   return modes;
-  }
+}
 
 #ifdef VISP_HAVE_NLOHMANN_JSON
 void to_json(nlohmann::json &j, const vpDetectorAprilTag &detector)

--- a/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
@@ -305,8 +305,16 @@ int vpPose::calculArbreDementhon(vpMatrix &Ap, vpColVector &U, vpHomogeneousMatr
 
     calculTwoSolutionsDementhonPlan(I04, J04, U, cMo1, cMo2);
     vpPose pose_vvs = *this;
-    pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo1);
-    pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo2);
+    vpHomogeneousMatrix cMo1_vvs = cMo1;
+    vpHomogeneousMatrix cMo2_vvs = cMo2;
+    pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo1_vvs);
+    pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo2_vvs);
+    if (computeResidualDementhon(cMo1_vvs) < computeResidualDementhon(cMo1)) {
+      cMo1 = cMo1_vvs;
+    }
+    if (computeResidualDementhon(cMo2_vvs) < computeResidualDementhon(cMo2)) {
+      cMo2 = cMo2_vvs;
+    }
 
     // test if all points are in front of the camera for cMo1 and cMo2
     int erreur1 = 0;
@@ -458,8 +466,16 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
   vpHomogeneousMatrix cMo1, cMo2;
   calculTwoSolutionsDementhonPlan(I04, J04, U, cMo1, cMo2);
   vpPose pose_vvs = *this;
-  pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo1);
-  pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo2);
+  vpHomogeneousMatrix cMo1_vvs = cMo1;
+  vpHomogeneousMatrix cMo2_vvs = cMo2;
+  pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo1_vvs);
+  pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo2_vvs);
+  if (computeResidualDementhon(cMo1_vvs) < computeResidualDementhon(cMo1)) {
+    cMo1 = cMo1_vvs;
+  }
+  if (computeResidualDementhon(cMo2_vvs) < computeResidualDementhon(cMo2)) {
+    cMo2 = cMo2_vvs;
+  }
 
   int erreur1 = calculArbreDementhon(Ap, U, cMo1);
   int erreur2 = calculArbreDementhon(Ap, U, cMo2);

--- a/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
+++ b/modules/vision/src/pose-estimation/vpPoseDementhon.cpp
@@ -304,6 +304,9 @@ int vpPose::calculArbreDementhon(vpMatrix &Ap, vpColVector &U, vpHomogeneousMatr
     J04 = Ap * yprim;
 
     calculTwoSolutionsDementhonPlan(I04, J04, U, cMo1, cMo2);
+    vpPose pose_vvs = *this;
+    pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo1);
+    pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo2);
 
     // test if all points are in front of the camera for cMo1 and cMo2
     int erreur1 = 0;
@@ -454,6 +457,9 @@ void vpPose::poseDementhonPlan(vpHomogeneousMatrix &cMo)
 
   vpHomogeneousMatrix cMo1, cMo2;
   calculTwoSolutionsDementhonPlan(I04, J04, U, cMo1, cMo2);
+  vpPose pose_vvs = *this;
+  pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo1);
+  pose_vvs.computePose(vpPose::VIRTUAL_VS, cMo2);
 
   int erreur1 = calculArbreDementhon(Ap, U, cMo1);
   int erreur2 = calculArbreDementhon(Ap, U, cMo2);


### PR DESCRIPTION
Code for experimentation.

---

Original issue:
- when using Dementhon to compute the planar pose for AprilTag detection, in some configurations it is easy to observe "pose flipping" issue
 
When adding VVS after each estimated pose inside the Dementhon pipeline, it greatly improves the pose estimation:
- no more "pose flipping" has been observed from the quick tests
- to test, the easiest thing is to add in "tutorial/detection/tag/tutorial-apriltag-detector-live.cpp" a second `vpDetectorAprilTag detector2(opt_tag_family);` and to duplicate everything to have side-by-side the two displays (e.g. Dementhon vs Lagrange or Dementhon vs Homography VVS, etc.)

For Lagrange:
- "pose flipping" is less frequent compared to Dementhon
- but I have managed to trigger it when aligning the tag frame such as having the tag x-axis pointing downward, the y-axis pointing to the right and to rotate around the x-axis
- and when the tag is small and at the border of the image, e.g. bottom right
- but I think it is more how I grasp the tag with my hand (which impacts the corner locations extraction) rather then a specific configuration compared to the Dementhon issue which is easy to trigger with my tests

---

Currently, distortion is not handled when using the AprilTag pose estimation methods.
But I think the code modification to support it is quite easy, such as in the PR code. 

---

https://github.com/lagadic/visp/blob/f339e926690a172253d37108f6a1f1a25f94180c/modules/detection/src/tag/vpDetectorAprilTag.cpp#L1170-L1179

Currently, the second pose is set to `-1` when it is not possible to compute it, but maybe it should be set to `INF`/`HUGE_VAL`.
I don't know if it is possible to have a second reprojection error inferior to the first one. But this would avoid issue if the poses are sorted and consistent with the AprilTag library (the second pose cannot always be computed for instance):

https://github.com/lagadic/visp/blob/f339e926690a172253d37108f6a1f1a25f94180c/3rdparty/apriltag/apriltag_pose.c#L509-L517