### PR TITLE
Resolve exit-in-shared-library lintian warning in emergency stop

### DIFF
--- a/modules/robot/src/real-robot/afma6/vpRobotAfma6.cpp
+++ b/modules/robot/src/real-robot/afma6/vpRobotAfma6.cpp
@@ -105,11 +105,13 @@ void emergencyStopAfma6(int signo)
 
   // Free allocated resources
   //  ShutDownConnection(); // Some times cannot exit here when Ctrl-C
-
-  fprintf(stdout, "Application ");
+  fprintf(stdout, "Application terminated.\n");
   fflush(stdout);
-  kill(getpid(), SIGKILL);
-  std::exit(EXIT_FAILURE);
+
+  // Reset the signal to its default behavior (which is to crash/exit)
+  signal(signo, SIG_DFL);
+  // Re-raise the signal to the current process for a clean termination by the OS
+  raise(signo);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/modules/robot/src/real-robot/bebop2/vpRobotBebop2.cpp
+++ b/modules/robot/src/real-robot/bebop2/vpRobotBebop2.cpp
@@ -1153,7 +1153,13 @@ void vpRobotBebop2::sighandler(int signo)
   if (m_deviceController != nullptr) {
     m_deviceController->aRDrone3->sendPilotingLanding(m_deviceController->aRDrone3);
   }
-  std::exit(EXIT_FAILURE);
+  fprintf(stdout, "Application terminated.\n");
+  fflush(stdout);
+
+  // Reset the signal to its default behavior (which is to crash/exit)
+  signal(signo, SIG_DFL);
+  // Re-raise the signal to the current process for a clean termination by the OS
+  raise(signo);
 }
 
 /*!
@@ -2009,5 +2015,5 @@ END_VISP_NAMESPACE
 #elif !defined(VISP_BUILD_SHARED_LIBS)
 // Work around to avoid warning: libvisp_robot.a(vpRobotBebop2.cpp.o) has
 // no symbols
-void dummy_vpRobotBebop2() { }
+void dummy_vpRobotBebop2() {}
 #endif // VISP_HAVE_ARSDK

--- a/modules/robot/src/real-robot/viper/vpRobotViper650.cpp
+++ b/modules/robot/src/real-robot/viper/vpRobotViper650.cpp
@@ -106,10 +106,13 @@ void emergencyStopViper650(int signo)
   // Free allocated resources
   //  ShutDownConnection(); // Some times cannot exit here when Ctrl-C
 
-  fprintf(stdout, "Application ");
+  fprintf(stdout, "Application terminated.\n");
   fflush(stdout);
-  kill(getpid(), SIGKILL);
-  std::exit(EXIT_FAILURE);
+
+  // Reset the signal to its default behavior (which is to crash/exit)
+  signal(signo, SIG_DFL);
+  // Re-raise the signal to the current process for a clean termination by the OS
+  raise(signo);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/modules/robot/src/real-robot/viper/vpRobotViper850.cpp
+++ b/modules/robot/src/real-robot/viper/vpRobotViper850.cpp
@@ -95,7 +95,7 @@ void emergencyStopViper850(int signo)
   case SIGQUIT:
     std::cout << "SIGQUIT " << std::endl;
     break;
-  default:
+    default\n:
     std::cout << signo << std::endl;
   }
   // std::cout << "Emergency stop called\n";
@@ -106,10 +106,13 @@ void emergencyStopViper850(int signo)
   // Free allocated resources
   //  ShutDownConnection(); // Some times cannot exit here when Ctrl-C
 
-  fprintf(stdout, "Application ");
+  fprintf(stdout, "Application terminated.\n");
   fflush(stdout);
-  kill(getpid(), SIGKILL);
-  std::exit(EXIT_FAILURE);
+
+  // Reset the signal to its default behavior (which is to crash/exit)
+  signal(signo, SIG_DFL);
+  // Re-raise the signal to the current process for a clean termination by the OS
+  raise(signo);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/modules/robot/src/real-robot/viper/vpRobotViper850.cpp
+++ b/modules/robot/src/real-robot/viper/vpRobotViper850.cpp
@@ -95,7 +95,7 @@ void emergencyStopViper850(int signo)
   case SIGQUIT:
     std::cout << "SIGQUIT " << std::endl;
     break;
-    default\n:
+  default:
     std::cout << signo << std::endl;
   }
   // std::cout << "Emergency stop called\n";


### PR DESCRIPTION
Replaced kill() and std::exit(EXIT_FAILURE) with signal(signo, SIG_DFL) followed by raise(signo)