### PR TITLE
Remove riscv64 platform from GHA

### DIFF
--- a/.github/workflows/other-arch-isolated.yml
+++ b/.github/workflows/other-arch-isolated.yml
@@ -57,10 +57,10 @@ jobs:
           # - arch: aarch64
           #   distro: ubuntu:latest
           #   endianness: (Little Endian)
-          - arch: riscv64
-            distro: ubuntu:latest
-            target: RISC-V
-            endianness: (Little Endian)
+          #- arch: riscv64
+          #  distro: ubuntu:latest
+          #  target: RISC-V
+          #  endianness: (Little Endian)
           - arch: ppc64le
             distro: ubuntu:latest
             target: POWER8


### PR DESCRIPTION
It produces the following issue during cmake configuration 6
```
  -- Could NOT find CUDA (missing: CUDA_TOOLKIT_ROOT_DIR CUDA_NVCC_EXECUTABLE CUDA_INCLUDE_DIRS CUDA_CUDART_LIBRARY)
  -- Some or all of the gtk libraries were not found. (missing: GTK2_GTK_LIBRARY GTK2_GTK_INCLUDE_DIR GTK2_GDK_INCLUDE_DIR GTK2_GDKCONFIG_INCLUDE_DIR GTK2_GDK_LIBRARY GTK2_GLIB_INCLUDE_DIR GTK2_GLIBCONFIG_INCLUDE_DIR GTK2_GLIB_LIBRARY)
  -- Performing Test HAVE_FUNC_ISNAN
  -- Performing Test HAVE_FUNC_ISNAN - Success
  -- Performing Test HAVE_FUNC_STD_ISNAN
  -- Performing Test HAVE_FUNC_STD_ISNAN - Success
  -- Performing Test HAVE_FUNC__ISNAN
  -- Performing Test HAVE_FUNC__ISNAN - Failed
  -- Performing Test HAVE_FUNC_ISINF
  -- Performing Test HAVE_FUNC_ISINF - Success
  -- Performing Test HAVE_FUNC_STD_ISINF
   /home/runner/work/_actions/uraimo/run-on-arch-action/v3/src/run-on-arch-commands.sh: line 11:    58 Illegal instruction        (core dumped) cmake .. -DBUILD_DEMOS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TUTORIALS=OFF -DBUILD_JAVA=OFF -DUSE_JPEG=OFF -DUSE_PNG=OFF -DUSE_X11=OFF -DUSE_XML2=OFF -DBUILD_JAVA=OFF -DUSE_BLAS/LAPACK=OFF -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-keep-memory"
```
An issue was opened here: https://github.com/uraimo/run-on-arch-action/issues/174