### PR TITLE
Computing the trace of a vpMatrix

### DIFF
--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -409,6 +409,14 @@ public:
   */
   static void conv2(const vpMatrix &M, const vpMatrix &kernel, vpMatrix &res, const std::string &mode);
 
+  /**
+   * \brief Compute the trace of the matrix, i.e. the sum of its diagonal elements \f$ tr(M) \sum_i M[i][i] \f$.
+   * \warning It works only for square matrix.
+   *
+   * \return double The trace of the matrix.
+   *
+  */
+  double trace() const;
   // return the determinant of the matrix.
   double det(vpDetMethod method = LU_DECOMPOSITION) const;
   double detByLU() const;

--- a/modules/core/include/visp3/core/vpMatrix.h
+++ b/modules/core/include/visp3/core/vpMatrix.h
@@ -188,7 +188,7 @@ public:
     Basic constructor of a matrix of double. Number of columns and rows are
     zero.
   */
-  vpMatrix() : vpArray2D<double>(0, 0) { }
+  vpMatrix() : vpArray2D<double>(0, 0) {}
 
   /*!
     Constructor that initialize a matrix of double with 0.
@@ -196,7 +196,7 @@ public:
     \param r : Matrix number of rows.
     \param c : Matrix number of columns.
   */
-  vpMatrix(unsigned int r, unsigned int c) : vpArray2D<double>(r, c) { }
+  vpMatrix(unsigned int r, unsigned int c) : vpArray2D<double>(r, c) {}
 
   /*!
     Constructor that initialize a matrix of double with \e val.
@@ -205,7 +205,7 @@ public:
     \param c : Matrix number of columns.
     \param val : Each element of the matrix is set to \e val.
   */
-  vpMatrix(unsigned int r, unsigned int c, double val) : vpArray2D<double>(r, c, val) { }
+  vpMatrix(unsigned int r, unsigned int c, double val) : vpArray2D<double>(r, c, val) {}
   vpMatrix(const vpMatrix &M, unsigned int r, unsigned int c, unsigned int nrows, unsigned int ncols);
 
   /*!
@@ -220,8 +220,8 @@ public:
     vpMatrix M(R);
     \endcode
    */
-  VP_EXPLICIT vpMatrix(const vpArray2D<double> &A) : vpArray2D<double>(A) { }
-  vpMatrix(const vpMatrix &A) : vpArray2D<double>(A) { }
+  VP_EXPLICIT vpMatrix(const vpArray2D<double> &A) : vpArray2D<double>(A) {}
+  vpMatrix(const vpMatrix &A) : vpArray2D<double>(A) {}
   VP_EXPLICIT vpMatrix(const vpHomogeneousMatrix &R);
   VP_EXPLICIT vpMatrix(const vpRotationMatrix &R);
   VP_EXPLICIT vpMatrix(const vpVelocityTwistMatrix &V);
@@ -410,7 +410,7 @@ public:
   static void conv2(const vpMatrix &M, const vpMatrix &kernel, vpMatrix &res, const std::string &mode);
 
   /**
-   * \brief Compute the trace of the matrix, i.e. the sum of its diagonal elements \f$ tr(M) \sum_i M[i][i] \f$.
+   * \brief Compute the trace of the matrix, i.e. the sum of its diagonal elements \f$ tr(M) = \sum_i M[i][i] \f$.
    * \warning It works only for square matrix.
    *
    * \return double The trace of the matrix.
@@ -1099,7 +1099,7 @@ public:
      \deprecated Only provided for compatibility with ViSP previous releases.
      This function does nothing.
    */
-  VP_DEPRECATED void init() { }
+  VP_DEPRECATED void init() {}
 
   /*!
      \deprecated You should rather use stack(const vpMatrix &A)

--- a/modules/core/src/math/matrix/vpMatrix_operations.cpp
+++ b/modules/core/src/math/matrix/vpMatrix_operations.cpp
@@ -1127,4 +1127,17 @@ void vpMatrix::conv2(const vpMatrix &M, const vpMatrix &kernel, vpMatrix &res, c
     }
   }
 }
+
+double vpMatrix::trace()const
+{
+  double trace = 0;
+  const unsigned int nbRows = getRows(), nbCols = getCols(), size = this->size();
+  if (nbRows != nbCols) {
+    throw(vpException(vpException::dimensionError, "The trace of a matrix is defined only for a square matrix"));
+  }
+  for (unsigned int idx = 0; idx < size; idx += nbCols + 1) {
+    trace += this->data[idx];
+  }
+  return trace;
+}
 END_VISP_NAMESPACE

--- a/modules/core/test/math/testMatrix.cpp
+++ b/modules/core/test/math/testMatrix.cpp
@@ -761,6 +761,36 @@ int main(int argc, char *argv[])
 
     {
       std::cout << "\n------------------------" << std::endl;
+      std::cout << "--- TEST vpMatrix::trace()" << std::endl;
+      std::cout << "------------------------" << std::endl;
+
+      const unsigned int rows = 5, cols = 5;
+      vpMatrix M1(rows, cols);
+      // Reference
+      double reference = 0.;
+      for (unsigned int i = 0; i < rows; i++) {
+        for (unsigned int j = 0; j < cols; j++) {
+          double val = static_cast<double>(i  *cols + j);
+          M1[i][j] = val;
+          if (i == j) {
+            reference += val;
+          }
+        }
+      }
+
+      std::cout << "M1:\n" << M1 << std::endl;
+      double trace = M1.trace();
+      std::cout << "\tRes:" << trace << std::endl;
+      std::cout << "\tRef:c" << reference << std::endl;
+
+      if (!vpMath::equal(trace, reference)) {
+        std::cerr << "Error with trace" << std::endl;
+        return EXIT_FAILURE;
+      }
+    }
+
+    {
+      std::cout << "\n------------------------" << std::endl;
       std::cout << "--- TEST vpMatrix::stackColums()" << std::endl;
       std::cout << "------------------------" << std::endl;
       vpMatrix M(3, 5);


### PR DESCRIPTION
[CORE] Added a vpMatrix::trace() method. Chose not to use OpenMP because it would require the matrix to be huge to gain benefice from the multithreading. This could be changed if we feel the need for it..