### PR TITLE
Attempt to fix catchParseArgv (Exit code 0xc0000374) on Windows

### DIFF
--- a/modules/io/src/tools/vpParseArgv.cpp
+++ b/modules/io/src/tools/vpParseArgv.cpp
@@ -387,7 +387,7 @@ void vpParseArgv::printUsage(vpArgvInfo *argTable, int flags)
         continue;
       }
       FPRINTF(stderr, "\n %s:", infoPtr->key);
-      numSpaces = ((width + 1) >= strlen(infoPtr->key) ? width + 1 - strlen(infoPtr->key) : 0);
+      numSpaces = ((width + 1) >= strlen(infoPtr->key) ? ((width + 1) - strlen(infoPtr->key)) : 0);
       while (numSpaces > 0) {
         if (numSpaces >= NUM_SPACES) {
           FPRINTF(stderr, "%s", spaces);

--- a/modules/io/test/parser/catchParseArgv.cpp
+++ b/modules/io/test/parser/catchParseArgv.cpp
@@ -91,9 +91,11 @@ public:
     for (auto &s : m_storage) {
       m_ptrs.push_back(s.c_str());
     }
+
+    m_ptrs.push_back(nullptr); // A conventional C argv array is normally terminated with a null pointer
   }
 
-  int argc() const { return static_cast<int>(m_ptrs.size()); }
+  int argc() const { return (static_cast<int>(m_ptrs.size()) - 1); /* minus one not to count the nullptr*/ }
   const char **argv() { return m_ptrs.data(); }
 
 private:


### PR DESCRIPTION
Might be a problem of order of operations on Windows