### PR TITLE
Fixing the Python binding of vpColor

### DIFF
--- a/modules/core/include/visp3/core/vpColor.h
+++ b/modules/core/include/visp3/core/vpColor.h
@@ -153,7 +153,11 @@ BEGIN_VISP_NAMESPACE
   \endcode
 
 */
-class VISP_EXPORT vpColor final : public vpRGBa
+class VISP_EXPORT vpColor
+#if (VISP_CXX_STANDARD > VISP_CXX_STANDARD_98)
+  final
+#endif
+  : public vpRGBa
 {
 public:
   /*! Predefined colors identifier. */

--- a/modules/core/include/visp3/core/vpColor.h
+++ b/modules/core/include/visp3/core/vpColor.h
@@ -153,7 +153,7 @@ BEGIN_VISP_NAMESPACE
   \endcode
 
 */
-class VISP_EXPORT vpColor : public vpRGBa
+class VISP_EXPORT vpColor final : public vpRGBa
 {
 public:
   /*! Predefined colors identifier. */
@@ -224,9 +224,6 @@ public:
   /*! Default destructor. */
 #if (VISP_CXX_STANDARD > VISP_CXX_STANDARD_98)
   vpColor(const vpColor &) = default;
-  virtual ~vpColor() = default;
-#else
-  virtual ~vpColor() { }
 #endif
   /*!
     Construct a color from its RGB values.


### PR DESCRIPTION
[FIX] Fixing issue #2000  reporting inconsistent behavior of visp.coreColor

The problem comes from the fact that vpColor had a virtual destructor and not vpRGBa. Due to that, vpColor had a vtable but not vpRGBa, which led to a wrong memory access by Pybind11