### PR TITLE
Beginning the Python bindings of vpImageFilter

### DIFF
--- a/modules/python/bindings/include/core.hpp
+++ b/modules/python/bindings/include/core.hpp
@@ -37,6 +37,7 @@
 #include "core/utils.hpp"
 #include "core/arrays.hpp"
 #include "core/images.hpp"
+#include "core/image_filter.hpp"
 #include "core/pixel_meter.hpp"
 #include "core/image_conversions.hpp"
 #include "core/display.hpp"

--- a/modules/python/bindings/include/core/image_filter.hpp
+++ b/modules/python/bindings/include/core/image_filter.hpp
@@ -34,6 +34,7 @@
 #ifndef VISP_PYTHON_CORE_IMAGE_FILTER_HPP
 #define VISP_PYTHON_CORE_IMAGE_FILTER_HPP
 #include <visp3/core/vpConfig.h>
+#include <visp3/core/vpArray2D.h>
 #include <visp3/core/vpImage.h>
 #include <visp3/core/vpImageFilter.h>
 #include <visp3/core/vpRGBa.h>
@@ -42,11 +43,115 @@
 #include <pybind11/numpy.h>
 #include <sstream>
 
-/*
- * Image 2D indexing
- */
 template<typename FilterType>
-void define_getGradXY(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImageFilter>> &pyClass)
+void define_getGaussianKernels(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImageFilter>> &pyClass)
+{
+#ifdef ENABLE_VISP_NAMESPACE
+  using namespace VISP_NAMESPACE_NAME;
+#endif
+  pyClass.def_static("getGaussianKernel", [](py::array_t<FilterType> &filter, unsigned int size, FilterType sigma, bool normalize) -> void {
+    filter.resize({ static_cast<py::ssize_t>(1), static_cast<py::ssize_t>((size+1)/2) });
+    py::buffer_info buf_filter = filter.request();
+    FilterType *filter_ptr = static_cast<FilterType *>(buf_filter.ptr);
+    vpImageFilter::getGaussianKernel(filter_ptr, size, sigma, normalize);
+  }, R"doc(
+Return the coefficients G_i of a Gaussian filter.
+
+:param filter: Array that will have a dimension rows = 1, cols = (size+1)/2.The first value refers to the central coefficient, the next one to the right coefficients. Left coefficients could be deduced by symmetry.
+:param size: Filter size. This value should be odd and positive.
+:param sigma: Gaussian standard deviation. If it is equal to zero or negative, it is computed from filter size as sigma = (size-1)/6.
+:param normalize: normalize Flag indicating whether to normalize the filter coefficients or not. In that case, the sum of the coefficients equal one.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core ImageFilter
+  import numpy as np
+  size = 7
+  normalize = True
+  filter = np.zeros((1,1))
+  ImageFilter.getGaussianKernel(filter, size, sigma, normalize)
+  assert filter.shape[0] == 1 and filter.shape[1] == ((size + 1)/2)
+    )doc", py::arg("filter"), py::arg("size"), py::arg("sigma") = 0., py::arg("normalize") = true);
+
+  pyClass.def_static("getGaussianKernel", [](vpArray2D<FilterType> &filter, unsigned int size, FilterType sigma, bool normalize) -> void {
+    filter.resize(1, (size+1)/2, true);
+    vpImageFilter::getGaussianKernel(filter.data, size, sigma, normalize);
+  }, R"doc(
+Return the coefficients G_i of a Gaussian filter.
+
+:param filter: Array that will have a dimension rows = 1, cols = (size+1)/2.The first value refers to the central coefficient, the next one to the right coefficients. Left coefficients could be deduced by symmetry.
+:param size: Filter size. This value should be odd and positive.
+:param sigma: Gaussian standard deviation. If it is equal to zero or negative, it is computed from filter size as sigma = (size-1)/6.
+:param normalize: normalize Flag indicating whether to normalize the filter coefficients or not. In that case, the sum of the coefficients equal one.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core ImageFilter, ArrayDouble2D
+  import numpy as np
+  size = 7
+  normalize = True
+  filter = ArrayDouble2D(1,1)
+  ImageFilter.getGaussianKernel(filter, size, sigma, normalize)
+  assert filter.getRows() == 1 and filter.getCols() == ((size + 1)/2)
+    )doc", py::arg("filter"), py::arg("size"), py::arg("sigma") = 0., py::arg("normalize") = true);
+
+  pyClass.def_static("getGaussianDerivativeKernel", [](py::array_t<FilterType> &filter, unsigned int size, FilterType sigma, bool normalize) -> void {
+    filter.resize({ static_cast<py::ssize_t>(1), static_cast<py::ssize_t>((size+1)/2) });
+    py::buffer_info buf_filter = filter.request();
+    FilterType *filter_ptr = static_cast<FilterType *>(buf_filter.ptr);
+    vpImageFilter::getGaussianDerivativeKernel(filter_ptr, size, sigma, normalize);
+  }, R"doc(
+Return the coefficients of a Gaussian derivative filter that may be used to compute spatial image derivatives after applying a Gaussian blur.
+
+:param filter: Array that will have a dimension rows = 1, cols = (size+1)/2.The first value refers to the central coefficient, the next one to the right coefficients. Left coefficients could be deduced by symmetry.
+:param size: Filter size. This value should be odd and positive.
+:param sigma: Gaussian standard deviation. If it is equal to zero or negative, it is computed from filter size as sigma = (size-1)/6.
+:param normalize: normalize Flag indicating whether to normalize the filter coefficients or not. In that case, the sum of the coefficients equal one.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core ImageFilter
+  import numpy as np
+  size = 7
+  normalize = True
+  filter = np.zeros((1,1))
+  ImageFilter.getGaussianDerivativeKernel(filter, size, sigma, normalize)
+  assert filter.shape[0] == 1 and filter.shape[1] == ((size + 1)/2)
+    )doc", py::arg("filter"), py::arg("size"), py::arg("sigma") = 0., py::arg("normalize") = true);
+
+  pyClass.def_static("getGaussianDerivativeKernel", [](vpArray2D<FilterType> &filter, unsigned int size, FilterType sigma, bool normalize) -> void {
+    filter.resize(1, (size+1)/2, true);
+    vpImageFilter::getGaussianDerivativeKernel(filter.data, size, sigma, normalize);
+  }, R"doc(
+Return the coefficients of a Gaussian derivative filter that may be used to compute spatial image derivatives after applying a Gaussian blur.
+
+:param filter: Array that will have a dimension rows = 1, cols = (size+1)/2.The first value refers to the central coefficient, the next one to the right coefficients. Left coefficients could be deduced by symmetry.
+:param size: Filter size. This value should be odd and positive.
+:param sigma: Gaussian standard deviation. If it is equal to zero or negative, it is computed from filter size as sigma = (size-1)/6.
+:param normalize: normalize Flag indicating whether to normalize the filter coefficients or not. In that case, the sum of the coefficients equal one.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core ImageFilter, ArrayDouble2D
+  import numpy as np
+  size = 7
+  normalize = True
+  filter = ArrayDouble2D(1,1)
+  ImageFilter.getGaussianDerivativeKernel(filter, size, sigma, normalize)
+  assert filter.getRows() == 1 and filter.getCols() == ((size + 1)/2)
+    )doc", py::arg("filter"), py::arg("size"), py::arg("sigma") = 0., py::arg("normalize") = true);
+}
+
+template<typename FilterType>
+void define_simple_getGradXY(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImageFilter>> &pyClass)
 {
 #ifdef ENABLE_VISP_NAMESPACE
   using namespace VISP_NAMESPACE_NAME;
@@ -74,15 +179,15 @@ Example usage:
 
   from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter
   Iin = ImageGray(100,100,0)
-  Iin[25:75][25:75] = 50
+  Iin[25:75,25:75] = 50
   Iout = ImageDouble()
-  Iout = ImageFilter.getGradX(Iin, Iout, None)
+  ImageFilter.getGradX(Iin, Iout, None)
   assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
   Iout = ImageDouble()
   mask = ImageBool(100,100,True)
-  Iout = ImageFilter.getGradX(Iin, Iout, mask)
+  ImageFilter.getGradX(Iin, Iout, mask)
   assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
-    )doc", py::arg("input"), py::arg("output"), py::arg("mask").none(true));
+    )doc", py::arg("input"), py::arg("output"), py::arg("mask").none(true) = static_cast<std::optional<vpImage<bool>>>(std::nullopt));
 
   pyClass.def_static("getGradY", [](const vpImage<unsigned char> &input, vpImage<FilterType> &output, const std::optional<vpImage<bool>> &mask) -> void {
     if (!mask) {
@@ -106,15 +211,207 @@ Example usage:
 
   from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter
   Iin = ImageGray(100,100,0)
-  Iin[25:75][25:75] = 50
+  Iin[25:75,25:75] = 50
   Iout = ImageDouble()
-  Iout = ImageFilter.getGradY(Iin, Iout, None)
+  ImageFilter.getGradY(Iin, Iout, None)
   assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
   Iout = ImageDouble()
   mask = ImageBool(100,100,True)
-  Iout = ImageFilter.getGradY(Iin, Iout, mask)
+  ImageFilter.getGradY(Iin, Iout, mask)
   assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
-)doc", py::arg("input"), py::arg("output"), py::arg("mask").none(true));
+)doc", py::arg("input"), py::arg("output"), py::arg("mask").none(true) = static_cast<std::optional<vpImage<bool>>>(std::nullopt));
+}
+
+template<typename ImageType, typename FilterType>
+void define_complex_getGradXY(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImageFilter>> &pyClass)
+{
+#ifdef ENABLE_VISP_NAMESPACE
+  using namespace VISP_NAMESPACE_NAME;
+#endif
+
+  pyClass.def_static("getGradX", [](const vpImage<ImageType> &input, vpImage<FilterType> &output, const py::array_t<FilterType> &filter, unsigned int size, const std::optional<vpImage<bool>> &mask) -> void {
+    py::buffer_info buf_filter = filter.request();
+    const unsigned int expected_dim = ((size+1)/2);
+    if ((buf_filter.shape[1] != expected_dim) || (buf_filter.shape[0] != 1)) {
+      std::stringstream ss;
+      ss << "The filter must be of size (" << 1 << " , " << expected_dim << "), but got filter = (" << shape_to_string(buf_filter.shape);
+      throw std::runtime_error(ss.str());
+    }
+
+    const FilterType *filter_ptr = static_cast<const FilterType *>(buf_filter.ptr);
+    if (!mask) {
+      vpImageFilter::getGradX(input, output, filter_ptr, size, nullptr);
+    }
+    else {
+      vpImageFilter::getGradX(input, output, filter_ptr, size, &(mask.value()));
+    }
+  }, R"doc(
+Compute the gradient along the X-axis.
+
+:param input: The image that must be filtered.
+:param output: The resulting image that contains the gradient along the X-axis.
+:param filter: The filter to apply to compute the gradient.
+:param size: The size of the filter.
+:param mask: mask where True means that the gradient must be computed for the pixel and False means that the computation must be skipped.
+
+:return: An image that contains the gradient along the X-axis.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter
+  import numpy as np
+  Iin = ImageGray(100,100,0)
+  Iin[25:75,25:75] = 50
+  size = 7
+  filter = np.zeros((1,int((size + 1) / 2)))
+  ImageFilter.getGaussianDerivativeKernel(filter, size)
+  Iout = ImageDouble()
+  ImageFilter.getGradX(Iin, Iout, filter, size, None)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+  Iout = ImageDouble()
+  mask = ImageBool(100,100,True)
+  ImageFilter.getGradX(Iin, Iout, filter, size, mask)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+    )doc", py::arg("input"), py::arg("output"), py::arg("filter"), py::arg("size"), py::arg("mask").none(true) = static_cast<std::optional<vpImage<bool>>>(std::nullopt));
+
+  pyClass.def_static("getGradX", [](const vpImage<ImageType> &input, vpImage<FilterType> &output, const vpArray2D<FilterType> &filter, unsigned int size, const std::optional<vpImage<bool>> &mask) -> void {
+    const unsigned int expected_dim = ((size+1)/2);
+    if ((filter.getCols() != expected_dim) || (filter.getRows() != 1)) {
+      std::stringstream ss;
+      ss << "The filter must be of size (" << 1 << " , " << expected_dim << "), but got filter = (" << filter.getRows() << " , " << filter.getCols();
+      throw std::runtime_error(ss.str());
+    }
+
+    const FilterType *filter_ptr = filter.data;
+    if (!mask) {
+      vpImageFilter::getGradX(input, output, filter_ptr, size, nullptr);
+    }
+    else {
+      vpImageFilter::getGradX(input, output, filter_ptr, size, &(mask.value()));
+    }
+    }, R"doc(
+Compute the gradient along the X-axis.
+
+:param input: The image that must be filtered.
+:param output: The resulting image that contains the gradient along the X-axis.
+:param filter: The filter to apply to compute the gradient.
+:param size: The size of the filter.
+:param mask: mask where True means that the gradient must be computed for the pixel and False means that the computation must be skipped.
+
+:return: An image that contains the gradient along the Y-axis.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter, ArrayDouble2D
+  Iin = ImageGray(100,100,0)
+  Iin[25:75,25:75] = 50
+  size = 7
+  filter = ArrayDouble2D()
+  ImageFilter.getGaussianDerivativeKernel(filter, size)
+  Iout = ImageDouble()
+  ImageFilter.getGradX(Iin, Iout, filter, size, None)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+  Iout = ImageDouble()
+  mask = ImageBool(100,100,True)
+  ImageFilter.getGradX(Iin, Iout, filter, size, mask)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+)doc", py::arg("input"), py::arg("output"), py::arg("filter"), py::arg("size"), py::arg("mask").none(true) = static_cast<std::optional<vpImage<bool>>>(std::nullopt));
+
+  pyClass.def_static("getGradY", [](const vpImage<ImageType> &input, vpImage<FilterType> &output, const py::array_t<FilterType> &filter, unsigned int size, const std::optional<vpImage<bool>> &mask) -> void {
+    py::buffer_info buf_filter = filter.request();
+    const unsigned int expected_dim = ((size+1)/2);
+    if ((buf_filter.shape[1] != expected_dim) || (buf_filter.shape[0] != 1)) {
+      std::stringstream ss;
+      ss << "The filter must be of size (" << 1 << " , " << expected_dim << "), but got filter = (" << shape_to_string(buf_filter.shape);
+      throw std::runtime_error(ss.str());
+    }
+
+    const FilterType *filter_ptr = static_cast<const FilterType *>(buf_filter.ptr);
+    if (!mask) {
+      vpImageFilter::getGradY(input, output, filter_ptr, size, nullptr);
+    }
+    else {
+      vpImageFilter::getGradY(input, output, filter_ptr, size, &(mask.value()));
+    }
+  }, R"doc(
+Compute the gradient along the Y-axis.
+
+:param input: The image that must be filtered.
+:param output: The resulting image that contains the gradient along the Y-axis.
+:param filter: The filter to apply to compute the gradient.
+:param size: The size of the filter.
+:param mask: mask where True means that the gradient must be computed for the pixel and False means that the computation must be skipped.
+
+:return: An image that contains the gradient along the Y-axis.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter
+  import numpy as np
+  Iin = ImageGray(100,100,0)
+  Iin[25:75,25:75] = 50
+  size = 7
+  filter = np.zeros((1,int((size + 1) / 2)))
+  ImageFilter.getGaussianDerivativeKernel(filter, size)
+  Iout = ImageDouble()
+  ImageFilter.getGradY(Iin, Iout, filter, size, None)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+  Iout = ImageDouble()
+  mask = ImageBool(100,100,True)
+  ImageFilter.getGradY(Iin, Iout, filter, size, mask)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+)doc", py::arg("input"), py::arg("output"), py::arg("filter"), py::arg("size"), py::arg("mask").none(true) = static_cast<std::optional<vpImage<bool>>>(std::nullopt));
+
+  pyClass.def_static("getGradY", [](const vpImage<ImageType> &input, vpImage<FilterType> &output, const vpArray2D<FilterType> &filter, unsigned int size, const std::optional<vpImage<bool>> &mask) -> void {
+    const unsigned int expected_dim = ((size+1)/2);
+    if ((filter.getCols() != expected_dim) || (filter.getRows() != 1)) {
+      std::stringstream ss;
+      ss << "The filter must be of size (" << 1 << " , " << expected_dim << "), but got filter = (" << filter.getRows() << " , " << filter.getCols();
+      throw std::runtime_error(ss.str());
+    }
+
+    const FilterType *filter_ptr = filter.data;
+    if (!mask) {
+      vpImageFilter::getGradY(input, output, filter_ptr, size, nullptr);
+    }
+    else {
+      vpImageFilter::getGradY(input, output, filter_ptr, size, &(mask.value()));
+    }
+    }, R"doc(
+Compute the gradient along the Y-axis.
+
+:param input: The image that must be filtered.
+:param output: The resulting image that contains the gradient along the Y-axis.
+:param filter: The filter to apply to compute the gradient.
+:param size: The size of the filter.
+:param mask: mask where True means that the gradient must be computed for the pixel and False means that the computation must be skipped.
+
+:return: An image that contains the gradient along the Y-axis.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter, ArrayDouble2D
+  Iin = ImageGray(100,100,0)
+  Iin[25:75,25:75] = 50
+  size = 7
+  filter = ArrayDouble2D()
+  ImageFilter.getGaussianDerivativeKernel(filter, size)
+  Iout = ImageDouble()
+  ImageFilter.getGradY(Iin, Iout, filter, size, None)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+  Iout = ImageDouble()
+  mask = ImageBool(100,100,True)
+  ImageFilter.getGradY(Iin, Iout, filter, size, mask)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+)doc", py::arg("input"), py::arg("output"), py::arg("filter"), py::arg("size"), py::arg("mask").none(true) = static_cast<std::optional<vpImage<bool>>>(std::nullopt));
 }
 
   /*
@@ -126,107 +423,13 @@ bindings_vpImageFilter(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::
 #ifdef ENABLE_VISP_NAMESPACE
   using namespace VISP_NAMESPACE_NAME;
 #endif
-  define_getGradXY<float>(pyImageFilter);
-  define_getGradXY<double>(pyImageFilter);
+  define_getGaussianKernels<float>(pyImageFilter);
+  define_getGaussianKernels<double>(pyImageFilter);
+  define_simple_getGradXY<float>(pyImageFilter);
+  define_simple_getGradXY<double>(pyImageFilter);
+  define_complex_getGradXY<unsigned char, float>(pyImageFilter);
+  define_complex_getGradXY<unsigned char, double>(pyImageFilter);
+  define_complex_getGradXY<float, float>(pyImageFilter);
+  define_complex_getGradXY<double, double>(pyImageFilter);
 }
-
-// template<typename T>
-// typename std::enable_if<std::is_same<VISP_NAMESPACE_ADDRESSING vpRGBa, T>::value, void>::type
-// bindings_vpImage(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImage<T>>> &pyImage)
-// {
-// #ifdef ENABLE_VISP_NAMESPACE
-//   using namespace VISP_NAMESPACE_NAME;
-// #endif
-//   using NpRep = unsigned char;
-//   static_assert(sizeof(T) == 4 * sizeof(NpRep));
-//   pyImage.def_buffer([](vpImage<T> &image) -> py::buffer_info {
-//     return make_array_buffer<NpRep, 3>(reinterpret_cast<NpRep *>(image.bitmap), { image.getHeight(), image.getWidth(), 4 }, false);
-//   });
-//   pyImage.def("numpy", [](vpImage<T> &self) -> np_array_cf<NpRep> {
-//     return py::cast(self).template cast<np_array_cf<NpRep>>();
-//   }, numpy_fn_doc_image, py::keep_alive<0, 1>());
-
-//   pyImage.def(py::init([](np_array_cf<NpRep> &np_array) {
-//     verify_array_shape_and_dims(np_array, 3, "ViSP RGBa image");
-//     const std::vector<py::ssize_t> shape = np_array.request().shape;
-//     if (shape[2] != 4) {
-//       throw std::runtime_error("Tried to copy a 3D numpy array that does not have 4 elements per pixel into a ViSP RGBA image");
-//     }
-//     vpImage<T> result(static_cast<unsigned int>(shape[0]), static_cast<unsigned int>(shape[1]));
-//     copy_data_from_np(np_array, (NpRep *)result.bitmap);
-//     return result;
-//                        }), R"doc(
-// Construct an image by **copying** a 3D numpy array. this numpy array should be of the form :math:`H \times W \times 4`
-// where the 4 denotes the red, green, blue and alpha components of the image.
-
-// :param np_array: The numpy array to copy.
-
-// )doc", py::arg("np_array"));
-//   define_get_item_2d_image<T, NpRep>(pyImage);
-//   define_set_item_2d_image<T, NpRep>(pyImage, sizeof(T) / sizeof(NpRep));
-
-
-//   pyImage.def("__repr__", [](const vpImage<T> &self) -> std::string {
-//     std::stringstream ss;
-//     ss << "<RGBa Image (" << self.getHeight() << ", " << self.getWidth() << ")>";
-//     return ss.str();
-//   });
-
-//   pyImage.def("_visp_repr", [](const vpImage<T> &self) -> std::string {
-//     std::stringstream ss;
-//     ss << self;
-//     return ss.str();
-//   }, R"doc(Get the full ViSP image string representation.)doc");
-
-// }
-// template<typename T>
-// typename std::enable_if<std::is_same<VISP_NAMESPACE_ADDRESSING vpRGBf, T>::value, void>::type
-// bindings_vpImage(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImage<T>>> &pyImage)
-// {
-// #ifdef ENABLE_VISP_NAMESPACE
-//   using namespace VISP_NAMESPACE_NAME;
-// #endif
-//   using NpRep = float;
-//   static_assert(sizeof(T) == 3 * sizeof(NpRep));
-//   pyImage.def_buffer([](vpImage<T> &image) -> py::buffer_info {
-//     return make_array_buffer<NpRep, 3>(reinterpret_cast<NpRep *>(image.bitmap), { image.getHeight(), image.getWidth(), 3 }, false);
-//   });
-
-//   pyImage.def("numpy", [](vpImage<T> &self) -> np_array_cf<NpRep> {
-//     return py::cast(self).template cast<np_array_cf<NpRep>>();
-//   }, numpy_fn_doc_image, py::keep_alive<0, 1>());
-
-//   pyImage.def(py::init([](np_array_cf<NpRep> &np_array) {
-//     verify_array_shape_and_dims(np_array, 3, "ViSP RGBa image");
-//     const std::vector<py::ssize_t> shape = np_array.request().shape;
-//     if (shape[2] != 3) {
-//       throw std::runtime_error("Tried to copy a 3D numpy array that does not have 3 elements per pixel into a ViSP RGBf image");
-//     }
-//     vpImage<T> result(static_cast<unsigned int>(shape[0]), static_cast<unsigned int>(shape[1]));
-//     copy_data_from_np(np_array, (NpRep *)result.bitmap);
-//     return result;
-//                        }), R"doc(
-// Construct an image by **copying** a 3D numpy array. this numpy array should be of the form :math:`H \times W \times 3`
-// where the 3 denotes the red, green and blue components of the image.
-
-// :param np_array: The numpy array to copy.
-
-// )doc", py::arg("np_array"));
-
-//   define_get_item_2d_image<T, NpRep>(pyImage);
-//   define_set_item_2d_image<T, NpRep>(pyImage, sizeof(T) / sizeof(NpRep));
-
-//   pyImage.def("__repr__", [](const vpImage<T> &self) -> std::string {
-//     std::stringstream ss;
-//     ss << "<RGBf Image (" << self.getHeight() << ", " << self.getWidth() << ")>";
-//     return ss.str();
-//   });
-
-//   pyImage.def("_visp_repr", [](const vpImage<T> &self) -> std::string {
-//     std::stringstream ss;
-//     ss << self;
-//     return ss.str();
-//   }, R"doc(Get the full ViSP image string representation.)doc");
-// }
-
 #endif

--- a/modules/python/bindings/include/core/image_filter.hpp
+++ b/modules/python/bindings/include/core/image_filter.hpp
@@ -1,0 +1,232 @@
+/*
+ * ViSP, open source Visual Servoing Platform software.
+ * Copyright (C) 2005 - 2025 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See https://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Python bindings.
+ */
+
+#ifndef VISP_PYTHON_CORE_IMAGE_FILTER_HPP
+#define VISP_PYTHON_CORE_IMAGE_FILTER_HPP
+#include <visp3/core/vpConfig.h>
+#include <visp3/core/vpImage.h>
+#include <visp3/core/vpImageFilter.h>
+#include <visp3/core/vpRGBa.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <sstream>
+
+/*
+ * Image 2D indexing
+ */
+template<typename FilterType>
+void define_getGradXY(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImageFilter>> &pyClass)
+{
+#ifdef ENABLE_VISP_NAMESPACE
+  using namespace VISP_NAMESPACE_NAME;
+#endif
+
+  pyClass.def_static("getGradX", [](const vpImage<unsigned char> &input, vpImage<FilterType> &output, const std::optional<vpImage<bool>> &mask) -> void {
+    if (!mask) {
+      vpImageFilter::getGradX(input, output, nullptr);
+    }
+    else {
+      vpImageFilter::getGradX(input, output, &(mask.value()));
+    }
+  }, R"doc(
+Compute the gradient along the X-axis.
+
+:param input: The image that must be filtered.
+:param output: The resulting image that contains the gradient along the X-axis.
+:param mask: mask where True means that the gradient must be computed for the pixel and False means that the computation must be skipped.
+
+:return: An image that contains the gradient along the X-axis.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter
+  Iin = ImageGray(100,100,0)
+  Iin[25:75][25:75] = 50
+  Iout = ImageDouble()
+  Iout = ImageFilter.getGradX(Iin, Iout, None)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+  Iout = ImageDouble()
+  mask = ImageBool(100,100,True)
+  Iout = ImageFilter.getGradX(Iin, Iout, mask)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+    )doc", py::arg("input"), py::arg("output"), py::arg("mask").none(true));
+
+  pyClass.def_static("getGradY", [](const vpImage<unsigned char> &input, vpImage<FilterType> &output, const std::optional<vpImage<bool>> &mask) -> void {
+    if (!mask) {
+      vpImageFilter::getGradY(input, output, nullptr);
+    }
+    else {
+      vpImageFilter::getGradY(input, output, &(mask.value()));
+    }
+}, R"doc(
+Compute the gradient along the Y-axis.
+
+:param input: The image that must be filtered.
+:param output: The resulting image that contains the gradient along the Y-axis.
+:param mask: mask where True means that the gradient must be computed for the pixel and False means that the computation must be skipped.
+
+:return: An image that contains the gradient along the Y-axis.
+
+Example usage:
+
+.. testcode::
+
+  from visp.core import ImageGray, ImageDouble, ImageBool, ImageFilter
+  Iin = ImageGray(100,100,0)
+  Iin[25:75][25:75] = 50
+  Iout = ImageDouble()
+  Iout = ImageFilter.getGradY(Iin, Iout, None)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+  Iout = ImageDouble()
+  mask = ImageBool(100,100,True)
+  Iout = ImageFilter.getGradY(Iin, Iout, mask)
+  assert Iout.getRows() == Iin.getRows() and Iout.getCols() == Iin.getCols()
+)doc", py::arg("input"), py::arg("output"), py::arg("mask").none(true));
+}
+
+  /*
+   * vpImageFilter
+   */
+void
+bindings_vpImageFilter(py::class_<VISP_NAMESPACE_ADDRESSING vpImageFilter, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImageFilter>> &pyImageFilter)
+{
+#ifdef ENABLE_VISP_NAMESPACE
+  using namespace VISP_NAMESPACE_NAME;
+#endif
+  define_getGradXY<float>(pyImageFilter);
+  define_getGradXY<double>(pyImageFilter);
+}
+
+// template<typename T>
+// typename std::enable_if<std::is_same<VISP_NAMESPACE_ADDRESSING vpRGBa, T>::value, void>::type
+// bindings_vpImage(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImage<T>>> &pyImage)
+// {
+// #ifdef ENABLE_VISP_NAMESPACE
+//   using namespace VISP_NAMESPACE_NAME;
+// #endif
+//   using NpRep = unsigned char;
+//   static_assert(sizeof(T) == 4 * sizeof(NpRep));
+//   pyImage.def_buffer([](vpImage<T> &image) -> py::buffer_info {
+//     return make_array_buffer<NpRep, 3>(reinterpret_cast<NpRep *>(image.bitmap), { image.getHeight(), image.getWidth(), 4 }, false);
+//   });
+//   pyImage.def("numpy", [](vpImage<T> &self) -> np_array_cf<NpRep> {
+//     return py::cast(self).template cast<np_array_cf<NpRep>>();
+//   }, numpy_fn_doc_image, py::keep_alive<0, 1>());
+
+//   pyImage.def(py::init([](np_array_cf<NpRep> &np_array) {
+//     verify_array_shape_and_dims(np_array, 3, "ViSP RGBa image");
+//     const std::vector<py::ssize_t> shape = np_array.request().shape;
+//     if (shape[2] != 4) {
+//       throw std::runtime_error("Tried to copy a 3D numpy array that does not have 4 elements per pixel into a ViSP RGBA image");
+//     }
+//     vpImage<T> result(static_cast<unsigned int>(shape[0]), static_cast<unsigned int>(shape[1]));
+//     copy_data_from_np(np_array, (NpRep *)result.bitmap);
+//     return result;
+//                        }), R"doc(
+// Construct an image by **copying** a 3D numpy array. this numpy array should be of the form :math:`H \times W \times 4`
+// where the 4 denotes the red, green, blue and alpha components of the image.
+
+// :param np_array: The numpy array to copy.
+
+// )doc", py::arg("np_array"));
+//   define_get_item_2d_image<T, NpRep>(pyImage);
+//   define_set_item_2d_image<T, NpRep>(pyImage, sizeof(T) / sizeof(NpRep));
+
+
+//   pyImage.def("__repr__", [](const vpImage<T> &self) -> std::string {
+//     std::stringstream ss;
+//     ss << "<RGBa Image (" << self.getHeight() << ", " << self.getWidth() << ")>";
+//     return ss.str();
+//   });
+
+//   pyImage.def("_visp_repr", [](const vpImage<T> &self) -> std::string {
+//     std::stringstream ss;
+//     ss << self;
+//     return ss.str();
+//   }, R"doc(Get the full ViSP image string representation.)doc");
+
+// }
+// template<typename T>
+// typename std::enable_if<std::is_same<VISP_NAMESPACE_ADDRESSING vpRGBf, T>::value, void>::type
+// bindings_vpImage(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, std::shared_ptr<VISP_NAMESPACE_ADDRESSING vpImage<T>>> &pyImage)
+// {
+// #ifdef ENABLE_VISP_NAMESPACE
+//   using namespace VISP_NAMESPACE_NAME;
+// #endif
+//   using NpRep = float;
+//   static_assert(sizeof(T) == 3 * sizeof(NpRep));
+//   pyImage.def_buffer([](vpImage<T> &image) -> py::buffer_info {
+//     return make_array_buffer<NpRep, 3>(reinterpret_cast<NpRep *>(image.bitmap), { image.getHeight(), image.getWidth(), 3 }, false);
+//   });
+
+//   pyImage.def("numpy", [](vpImage<T> &self) -> np_array_cf<NpRep> {
+//     return py::cast(self).template cast<np_array_cf<NpRep>>();
+//   }, numpy_fn_doc_image, py::keep_alive<0, 1>());
+
+//   pyImage.def(py::init([](np_array_cf<NpRep> &np_array) {
+//     verify_array_shape_and_dims(np_array, 3, "ViSP RGBa image");
+//     const std::vector<py::ssize_t> shape = np_array.request().shape;
+//     if (shape[2] != 3) {
+//       throw std::runtime_error("Tried to copy a 3D numpy array that does not have 3 elements per pixel into a ViSP RGBf image");
+//     }
+//     vpImage<T> result(static_cast<unsigned int>(shape[0]), static_cast<unsigned int>(shape[1]));
+//     copy_data_from_np(np_array, (NpRep *)result.bitmap);
+//     return result;
+//                        }), R"doc(
+// Construct an image by **copying** a 3D numpy array. this numpy array should be of the form :math:`H \times W \times 3`
+// where the 3 denotes the red, green and blue components of the image.
+
+// :param np_array: The numpy array to copy.
+
+// )doc", py::arg("np_array"));
+
+//   define_get_item_2d_image<T, NpRep>(pyImage);
+//   define_set_item_2d_image<T, NpRep>(pyImage, sizeof(T) / sizeof(NpRep));
+
+//   pyImage.def("__repr__", [](const vpImage<T> &self) -> std::string {
+//     std::stringstream ss;
+//     ss << "<RGBf Image (" << self.getHeight() << ", " << self.getWidth() << ")>";
+//     return ss.str();
+//   });
+
+//   pyImage.def("_visp_repr", [](const vpImage<T> &self) -> std::string {
+//     std::stringstream ss;
+//     ss << self;
+//     return ss.str();
+//   }, R"doc(Get the full ViSP image string representation.)doc");
+// }
+
+#endif

--- a/modules/python/bindings/include/core/images.hpp
+++ b/modules/python/bindings/include/core/images.hpp
@@ -59,42 +59,37 @@ void define_get_item_2d_image(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, s
   using namespace VISP_NAMESPACE_NAME;
 #endif
 
-  pyClass.def("__getitem__", [](const vpImage<T> &self, std::pair<int, int> pair) -> T {
-    int i = pair.first, j = pair.second;
-    const int rows = (int)self.getRows(), cols = (int)self.getCols();
-    if (i >= rows || j >= cols || i < -rows || j < -cols) {
-      std::stringstream ss;
-      ss << "Invalid indexing into a 2D image: got indices " << shape_to_string({ i, j })
-        << " but image has dimensions " << shape_to_string({ rows, cols });
-      throw std::runtime_error(ss.str());
-    }
-    if (i < 0) {
-      i = rows + i;
-    }
-    if (j < 0) {
-      j = cols + j;
-    }
-    return self[i][j];
-  });
-  pyClass.def("__getitem__", [](const vpImage<T> &self, int i) -> np_array_cf<NpRep> {
-    const int rows = (int)self.getRows();
-    if (i >= rows || i < -rows) {
-      std::stringstream ss;
-      ss << "Invalid indexing into a 2D image: got row index " << shape_to_string({ i })
-        << " but array has " << rows << " rows";
-      throw std::runtime_error(ss.str());
-    }
-    if (i < 0) {
-      i = rows + i;
-    }
-    return (py::cast(self).template cast<np_array_cf<NpRep> >())[py::cast(i)].template cast<np_array_cf<NpRep>>();
-  });
-  pyClass.def("__getitem__", [](const vpImage<T> &self, py::slice slice) -> py::array_t<NpRep> {
-    return (py::cast(self).template cast<np_array_cf<NpRep> >())[slice].template cast<py::array_t<NpRep>>();
-  }, py::keep_alive<0, 1>());
-  pyClass.def("__getitem__", [](const vpImage<T> &self, py::tuple tuple) {
-    return (py::cast(self).template cast<np_array_cf<NpRep> >())[tuple].template cast<py::array_t<NpRep>>();
-  }, py::keep_alive<0, 1>());
+  pyClass.def("__getitem__",
+    [](const vpImage<T> &self, py::object index) -> py::object {
+      if (py::isinstance<py::slice>(index)) {
+        // slice handling
+        py::slice slice = index.cast<py::slice>();
+        return (py::cast(self).template cast<np_array_cf<NpRep> >())[slice].template cast<np_array_cf<NpRep>>();
+      }
+
+      if (py::isinstance<py::int_>(index)) {
+          // row handling
+        int i = index.cast<int>();
+        const int rows = (int)self.getRows();
+        if (i >= rows || i < -rows) {
+          std::stringstream ss;
+          ss << "Invalid indexing into a 2D array: got row index " << shape_to_string({ i })
+            << " but array has " << rows << " rows";
+          throw std::runtime_error(ss.str());
+        }
+        if (i < 0) {
+          i = rows + i;
+        }
+        return (py::cast(self).template cast<np_array_cf<NpRep> >())[py::cast(i)].template cast<np_array_cf<NpRep>>();
+      }
+
+      if (py::isinstance<py::tuple>(index)) {
+        py::tuple tuple = index.cast<py::tuple>();
+        return (py::cast(self).template cast<np_array_cf<NpRep> >())[tuple].template cast<py::array_t<NpRep>>();
+      }
+
+      throw py::type_error("Invalid index");
+    }, py::keep_alive<0, 1>());
 }
 
 /*

--- a/modules/python/bindings/include/core/images.hpp
+++ b/modules/python/bindings/include/core/images.hpp
@@ -61,13 +61,13 @@ void define_get_item_2d_image(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, s
 
   pyClass.def("__getitem__",
     [](const vpImage<T> &self, py::object index) -> py::object {
+      py::object result;
       if (py::isinstance<py::slice>(index)) {
         // slice handling
         py::slice slice = index.cast<py::slice>();
-        return (py::cast(self).template cast<np_array_cf<NpRep> >())[slice].template cast<np_array_cf<NpRep>>();
+        result = (py::cast(self).template cast<np_array_cf<NpRep> >())[slice];
       }
-
-      if (py::isinstance<py::int_>(index)) {
+      else if (py::isinstance<py::int_>(index)) {
           // row handling
         int i = index.cast<int>();
         const int rows = (int)self.getRows();
@@ -80,16 +80,50 @@ void define_get_item_2d_image(py::class_<VISP_NAMESPACE_ADDRESSING vpImage<T>, s
         if (i < 0) {
           i = rows + i;
         }
-        return (py::cast(self).template cast<np_array_cf<NpRep> >())[py::cast(i)].template cast<np_array_cf<NpRep>>();
+        result = (py::cast(self).template cast<np_array_cf<NpRep> >())[py::cast(i)];
       }
-
-      if (py::isinstance<py::tuple>(index)) {
+      else if (py::isinstance<py::tuple>(index)) {
         py::tuple tuple = index.cast<py::tuple>();
-        return (py::cast(self).template cast<np_array_cf<NpRep> >())[tuple].template cast<py::array_t<NpRep>>();
+        size_t it = 0, nb_of_items = tuple.size();
+        bool is_pair_of_int = (nb_of_items == 2);
+        while (is_pair_of_int && (it < nb_of_items)) {
+          is_pair_of_int = !(py::isinstance<py::slice>(tuple[it]));
+          ++it;
+        }
+        if (is_pair_of_int) {
+          int i = tuple[0].cast<int>();
+          int j = tuple[1].cast<int>();
+          int rows = static_cast<int>(self.getRows()), cols = static_cast<int>(self.getCols());
+          if (i >= rows || i < -rows) {
+            std::stringstream ss;
+            ss << "Invalid indexing into a 2D image: got row index " << shape_to_string({ i })
+              << " but array has " << rows << " rows";
+            throw std::runtime_error(ss.str());
+          }
+          else if (j >= cols || j < -cols) {
+            std::stringstream ss;
+            ss << "Invalid indexing into a 2D image: got cil index " << j
+              << " but array has " << cols << " cols";
+            throw std::runtime_error(ss.str());
+          }
+          if (i < 0) {
+            i = rows + i;
+          }
+          if (j < 0) {
+            j = cols + j;
+          }
+          return py::cast(self[i][j]);;
+        }
+        result = (py::cast(self).template cast<np_array_cf<NpRep> >())[tuple];
       }
-
-      throw py::type_error("Invalid index");
-    }, py::keep_alive<0, 1>());
+      else {
+        throw py::type_error("Invalid index");
+      }
+      if (py::isinstance<py::array>(result)) {
+        py::detail::keep_alive_impl(result, py::cast(self));
+      }
+      return result;
+    });
 }
 
 /*

--- a/modules/python/config/core.json
+++ b/modules/python/config/core.json
@@ -1073,6 +1073,7 @@
       ]
     },
     "vpImageFilter": {
+      "additional_bindings": "bindings_vpImageFilter",
       "methods": [
         {
           "static": true,

--- a/modules/python/config/core_image.json
+++ b/modules/python/config/core_image.json
@@ -29,6 +29,12 @@
           ]
         },
         {
+          "python_name": "ImageBool",
+          "arguments": [
+            "bool"
+          ]
+        },
+        {
           "python_name": "ImageUInt16",
           "arguments": [
             "uint16_t"


### PR DESCRIPTION
Added manual bindings for:
- ` getGradX` and `getGradY`
- `getGaussianKernel` and `getGaussianDerivativeKernel`
Added a fix for the binding of the `vpImage` access through slices