### PR TITLE
Attempt to fix non converging photometricMappingVisualServoing example

### DIFF
--- a/example/direct-visual-servoing/photometricMappingVisualServoing.cpp
+++ b/example/direct-visual-servoing/photometricMappingVisualServoing.cpp
@@ -116,7 +116,7 @@ OPTIONS:                                               Default\n\
      Number of visual servoing iterations.\n\
 \n\
   -l %%f                                               %f\n\
-     Number of visual servoing iterations.\n\
+     Gain parameter for the Gauss-Newton method.\n\
 \n\
   -h\n\
      Print the help.\n",
@@ -211,10 +211,11 @@ int main(int argc, const char **argv)
     std::string opt_method = "dct";
     unsigned opt_numDbImages = 2000;
     unsigned opt_numComponents = 32;
-    double opt_lambda = 5.0;
-    double lambdaGN;
-
+    double lambda_levenberg_marquardt = 5.0; // Gain used during Levenberg-Marquardt optimization
+    double opt_lambda_gauss_newton = lambda_levenberg_marquardt;
+    double lambda = lambda_levenberg_marquardt;
     double mu = 0.01; // mu = 0 : Gauss Newton ; mu != 0  : LM
+
 
     const double Z = 0.8;
     const unsigned int ih = 240;
@@ -232,11 +233,9 @@ int main(int argc, const char **argv)
 
     // Read the command line options
     if (getOptions(argc, argv, opt_ipath, opt_click_allowed, opt_display, opt_niter, opt_method,
-                   opt_numDbImages, opt_numComponents, opt_lambda) == false) {
+                   opt_numDbImages, opt_numComponents, opt_lambda_gauss_newton) == false) {
       return EXIT_FAILURE;
     }
-
-    lambdaGN = opt_lambda;
 
     // Get the option values
     if (!opt_ipath.empty())
@@ -255,7 +254,7 @@ int main(int argc, const char **argv)
 
     // Test if an input path is set
     if (opt_ipath.empty() && env_ipath.empty()) {
-      usage(argv[0], nullptr, ipath, opt_niter, opt_method, opt_numDbImages, opt_numComponents, opt_lambda);
+      usage(argv[0], nullptr, ipath, opt_niter, opt_method, opt_numDbImages, opt_numComponents, opt_lambda_gauss_newton);
       std::cerr << std::endl << "ERROR:" << std::endl;
       std::cerr << "  Use -i <visp image path> option or set VISP_INPUT_IMAGE_PATH " << std::endl
         << "  environment variable to specify the location of the " << std::endl
@@ -499,8 +498,10 @@ int main(int argc, const char **argv)
       sI.buildFrom(I);
       sI.getMapping()->inverse(sI.get_s(), Irec);
 
+      // Specific parameters for Gauss-Newton
       if (iter > iterGN) {
         mu = 0.0001;
+        lambda = opt_lambda_gauss_newton;
       }
       sI.interaction(L);
       sI.error(sId, error);
@@ -511,7 +512,7 @@ int main(int argc, const char **argv)
       }
       H = ((mu * diagHs) + Hs).inverseByLU();
       // Compute the control law
-      v = -opt_lambda * H * L.t() * error;
+      v = -lambda * H * L.t() * error;
       normError = error.sumSquare();
 
       std::cout << " |e| = " << normError << std::endl;

--- a/example/direct-visual-servoing/photometricMappingVisualServoing.cpp
+++ b/example/direct-visual-servoing/photometricMappingVisualServoing.cpp
@@ -1,6 +1,6 @@
 /*
  * ViSP, open source Visual Servoing Platform software.
- * Copyright (C) 2005 - 2024 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2026 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -212,11 +212,9 @@ int main(int argc, const char **argv)
     unsigned opt_numDbImages = 2000;
     unsigned opt_numComponents = 32;
     double opt_lambda = 5.0;
+    double lambdaGN;
 
     double mu = 0.01; // mu = 0 : Gauss Newton ; mu != 0  : LM
-    double lambdaGN = opt_lambda;
-
-
 
     const double Z = 0.8;
     const unsigned int ih = 240;
@@ -237,6 +235,8 @@ int main(int argc, const char **argv)
                    opt_numDbImages, opt_numComponents, opt_lambda) == false) {
       return EXIT_FAILURE;
     }
+
+    lambdaGN = opt_lambda;
 
     // Get the option values
     if (!opt_ipath.empty())
@@ -269,8 +269,9 @@ int main(int argc, const char **argv)
     vpImageIo::read(Itexture, filename);
 
     vpColVector X[4];
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; ++i) {
       X[i].resize(3);
+    }
     // Top left corner
     X[0][0] = -(scenew / 2.0);
     X[0][1] = -(sceneh / 2.0);
@@ -306,7 +307,6 @@ int main(int argc, const char **argv)
     vpHomogeneousMatrix cdMo;
     cdMo[2][3] = Z;
 
-
     vpCameraParameters cam(870, 870, 160, 120);
     std::shared_ptr<vpLuminanceMapping> sMapping = nullptr;
     std::shared_ptr<vpLuminanceMapping> sdMapping = nullptr;
@@ -328,15 +328,18 @@ int main(int argc, const char **argv)
       std::vector<vpImage<unsigned char>> images(opt_numDbImages);
       for (unsigned i = 0; i < opt_numDbImages; ++i) {
         vpColVector to(3, 0.0), positionNoise(3, 0.0);
-        const double noiseDiv = 16.0;
+        const double noiseDiv = 4.0;
         positionNoise[0] = random.uniform(-scenew / noiseDiv, scenew / noiseDiv);
         positionNoise[1] = random.uniform(-sceneh / noiseDiv, sceneh / noiseDiv);
-        positionNoise[2] = random.uniform(0.0, Z / noiseDiv);
-        const double noiseDivTo = 16.0;
+        positionNoise[2] = random.uniform(0.0, 0.3);
+        const double noiseDivTo = 8.0;
         to[0] = random.uniform(-scenew / noiseDivTo, scenew / noiseDivTo);
         to[1] = random.uniform(-sceneh / noiseDivTo, sceneh / noiseDivTo);
         const vpColVector from = vpColVector(cdMo.getTranslationVector()) + positionNoise;
-        vpRotationMatrix Rrot(0.0, 0.0, vpMath::rad(random.uniform(-10, 10)));
+
+        vpRotationMatrix Rrot(vpMath::rad(random.uniform(-20, 20)),
+                               vpMath::rad(random.uniform(-20, 20)),
+                               vpMath::rad(random.uniform(-15, 15)));
         vpHomogeneousMatrix dbMo = vpMath::lookAt(from, to, Rrot * vpColVector({ 0.0, 1.0, 0.0 }));
         sim.setCameraPosition(dbMo);
         sim.getImage(I, cam);
@@ -498,7 +501,6 @@ int main(int argc, const char **argv)
 
       if (iter > iterGN) {
         mu = 0.0001;
-        opt_lambda = lambdaGN;
       }
       sI.interaction(L);
       sI.error(sId, error);


### PR DESCRIPTION
It can occur that `build-ubuntu-dep-apt` CI can fail when running `photometricMappingVisualServoing` that doesn't converge after 200 iterations. This is for example the case of `build-ubuntu-dep-apt (ubuntu-22.04, /usr/bin/gcc, /usr/bin/g++, 11, ogre-1.9)`.

```
250/312 Test #184: photometricMappingPCAVisualServoing ...............................***Failed   39.68 sec
Building image database for PCA computation with 100 images
Computing PCA, this may take some time!
Explained variance: 74.3856%
Starting VS loop
--------------------------------------------1
 |e| = 1.57361e+08
 |v| = 3.25674
Excess velocity 2.17587 axis nr. 2
Excess velocity 2.4053 axis nr. 5
--------------------------------------------2
 |e| = 7.49332e+07
 |v| = 1.72772
Excess velocity 1.579 axis nr. 2
--------------------------------------------3
 |e| = 4.14245e+07
 |v| = 0.527725
--------------------------------------------4
 |e| = 3.07835e+07
 |v| = 0.824815
--------------------------------------------5
 |e| = 4.38993e+07
 |v| = 1.0325
 ...
 
--------------------------------------------198
 |e| = 2.30497e+07
 |v| = 0.0115982
--------------------------------------------199
 |e| = 2.30136e+07
 |v| = 0.0114959
Time to convergence: 37465.8 ms
```

Changes done to:
- Fix lambdaGN capturing the wrong value: it was initialized from
  opt_lambda before getOptions() parsed the -l command line argument,
  so any user-specified gain was silently discarded once the loop
  switched from LM (mu=0.01) to Gauss-Newton (mu=0.0001) after
  iterGN iterations. lambdaGN is now assigned after option parsing.
- Drop the opt_lambda = lambdaGN reset in the LM->GN switch so the
  gain requested via -l is kept for the whole servoing loop instead
  of reverting to the default value.
- Widen the pose sampling used to build the PCA training database:
  reduce noiseDiv from 16 to 4 and extend the Z noise range to
  [0, 0.3] (instead of [0, Z/16]) so the training images better cover
  the actual initial offset used in the test (Z+0.2). Also sample
  rotation noise on all three axes (roll/pitch/yaw) instead of yaw
  only, matching the non-zero roll/pitch of the initial camera pose.
  This addresses the plateau observed in
  photometricMappingPCAVisualServoing, where the compressed
  luminance error stalled well above the convergence threshold due
  to insufficient explained variance in the learned PCA subspace.
- Minor cleanup: brace style for the X[] loop, drop stray blank
  lines, bump copyright year to 2026.