### PR TITLE
[DOC][FIX] Fixed typo in package name

### DIFF
--- a/doc/tutorial/package/tutorial-install-ubuntu-package.dox
+++ b/doc/tutorial/package/tutorial-install-ubuntu-package.dox
@@ -26,7 +26,7 @@ $ sudo apt-get install visp-images-data
 
 To install ViSP html documentation you can run:
 \verbatim
-$ sudo apt-get install visp-doc
+$ sudo apt-get install libvisp-doc
 \endverbatim
 
 \section install_ubuntu_package_next Next tutorial


### PR DESCRIPTION
In the Ubuntu documentation, it was mentionned `visp-doc` instead of `libvisp-doc`